### PR TITLE
Ignoring all local files when deploying the images.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/AppEngineClient.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/AppEngineClient.cs
@@ -27,11 +27,15 @@ namespace GoogleCloudExtension.GCloud
             "ADD ./ /app\n" +
             "RUN chmod +x /app/gae_start\n";
 
-        // The app.yaml to use for all apps.
+        // The app.yaml to use for all apps. The skip_files entry makes it so no local files are sent
+        // to the server, no files need to be sent because we're deploying a Docker image but gcloud
+        // will send the entire app to the server, which can take a long while.
         private const string AppYamlContent =
             "vm: true\n" +
             "threadsafe: true\n" +
-            "api_version: 1\n";
+            "api_version: 1\n" +
+            "skip_files: \n" +
+            "- ^.*$";
 
         private const string AppYamlFileName = "app.yaml";
         private const string DockerfileFilename = "Dockerfile";


### PR DESCRIPTION
When deploying an image to the server `gcloud` will also send all of the files that compose the image so the server can determine if any of them are going to be served using an `static_handler` even if there are no such handlers defined in the `app.yaml`. This process might take a bit of time since a published ASP.NET app will contain many files. To avoid wasting time this way the default `app.yaml` that is generated will have an `skip_files` which will prevent these files from being sent.

In windows this is particularly slow because the to send the files `gcloud` uses the `rsync` command which needs to hash the files and in Windows this is done in Python instead of using a native library.
