### PR TITLE
Reorganizing the commands structure.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.vsct
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.vsct
@@ -33,11 +33,11 @@
 
     <Menus>
       <!-- The Google Cloud menu. -->
-      <Menu guid="guidDeployToGaePackageCmdSet" id="GcpMenu" type="Menu" priority="0x700">
-        <Parent guid="guidSHLMainMenu" id="IDG_VS_MM_TOOLSADDINS" />
+      <Menu guid="guidDeployToGaePackageCmdSet" id="GcpMenu" type="Menu" priority="0x0000">
+        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroupMenu" />
         <Strings>
-          <ButtonText>Google Cloud</ButtonText>
-          <CommandName>Google Cloud</CommandName>
+          <ButtonText>Google Cloud Tools</ButtonText>
+          <CommandName>Google Cloud Tools</CommandName>
         </Strings>
       </Menu>
     </Menus>
@@ -48,9 +48,19 @@
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE" />
       </Group>
 
-      <!-- This group contains all of the Gcp commands in the top level menu. -->
+      <!-- This group represents the GCP tools group under the Tools menu. -->
+      <Group guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroupMenu" priority="0x9000">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS" />
+      </Group>
+
+      <!-- This group contains all of the commands that go under the GCP tools submenu. -->
       <Group guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroup" priority="0x0000">
         <Parent guid="guidDeployToGaePackageCmdSet" id="GcpMenu" />
+      </Group>
+
+      <!-- This group contains all of the tool window commands. -->
+      <Group guid="guidDeployToGaePackageCmdSet" id="GcpWindowsGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_WINDOWS" />
       </Group>
     </Groups>
 
@@ -75,13 +85,21 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>TextChanges</CommandFlag>
         <Strings>
-          <ButtonText>Deploy Project to Google AppEngine...</ButtonText>
+          <ButtonText>Deploy Project to AppEngine...</ButtonText>
         </Strings>
       </Button>
 
+      <!-- This command opens the browser to add a new account to the credentials store. -->
+      <Button guid="guidDeployToGaePackageCmdSet" id="cmdidAddNewAccountCommand" priority="0x500" type="Button">
+        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroup" />
+        <Strings>
+          <ButtonText>Add Account...</ButtonText>
+        </Strings>
+      </Button>
+    
       <!-- This command shows the tool window that managed AppEngine apps. -->
       <Button guid="guidDeployToGaePackageCmdSet" id="cmdidAppEngineAppsToolWindowCommand" priority="0x0200" type="Button">
-        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroup" />
+        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpWindowsGroup" />
         <Strings>
           <ButtonText>Google AppEngine Apps</ButtonText>
         </Strings>
@@ -89,17 +107,9 @@
 
       <!-- This command shows the tool window that manages the current account and project, could be a toolbar. -->
       <Button guid="guidGoogleCloudExtensionPackageCmdSet" id="cmdidUserAndProjectListWindowCommand" priority="0x0400" type="Button">
-        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroup" />
+        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpWindowsGroup" />
         <Strings>
           <ButtonText>Google Cloud Projects and Users</ButtonText>
-        </Strings>
-      </Button>
-      
-      <!-- This command opens the browser to add a new account to the credentials store. -->
-      <Button guid="guidDeployToGaePackageCmdSet" id="cmdidAddNewAccountCommand" priority="0x500" type="Button">
-        <Parent guid="guidDeployToGaePackageCmdSet" id="GcpToolsGroup" />
-        <Strings>
-          <ButtonText>Add Account...</ButtonText>
         </Strings>
       </Button>
     </Buttons>
@@ -129,8 +139,10 @@
       <IDSymbol value="4129" name="cmdidAppEngineAppsToolWindowCommand" />
       <IDSymbol value="0x1060" name="GcpMenu" />
       <IDSymbol value="0x1070" name="GcpToolsGroup" />
+      <IDSymbol value="0x1080" name="GcpToolsGroupMenu" />
       <IDSymbol value="4179" name="cmdidDeployToGaeContextMenuCommand" />
       <IDSymbol value="4180" name="cmdidAddNewAccountCommand" />
+      <IDSymbol value="5000" name="GcpWindowsGroup"/>
     </GuidSymbol>
 
     <GuidSymbol name="guidImages" value="{7f45e823-c417-46b7-bcf7-eb027a474180}">


### PR DESCRIPTION
This change removes the top level "Google Cloud Menu" and instead
moves the commands that were in that menu into more appropiate
locations:
- There's a submenu added to the Tools toplevel menu which will
  contain:
  - The "Deploy To AppEngine..." command, to deploy the currenttly
    selected project to AppEngine.
  - The "Add account..." command, to log in a new user.
- The two commands that open tool windows are moved to the "Other
  Windows" submenu under the View menu.
  - Google AppEngine Apps, which shows the apps currently deployed in
    AppEngine.
  - Google Cloud Projects and Users, which shows the current projects
    and credentials available in gcloud.
    - This command will probably be deleted I think, the quality of
      the window is not where I want it.
