### PR TITLE
Support only the .NET Core CLR.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/DnxEnvironment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/DnxEnvironment.cs
@@ -25,7 +25,6 @@ namespace GoogleCloudExtension.GCloud.Dnx
         // Names for the runtime to use depending on the runtime.
         //   {0} is the bitness of the os, x86 or x64.
         //   {1} is the version of the runtime.
-        private const string Dnx451RuntimeNameFormat = "dnx-clr-win-{0}.{1}";
         private const string DnxCore50RuntimeNameFormat = "dnx-coreclr-win-{0}.{1}";
 
         private static readonly List<string> s_VSKeysToCheck = new List<string>
@@ -47,25 +46,12 @@ namespace GoogleCloudExtension.GCloud.Dnx
         /// </summary>
         /// <param name="runtime"></param>
         /// <returns></returns>
-        public static string GetDnxPathForRuntime(DnxRuntime runtime)
+        public static string GetDnxPath()
         {
             var userDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string bitness = Environment.Is64BitProcess ? "x64" : "x86";
 
-            string runtimeNameFormat = null;
-            switch (runtime)
-            {
-                case DnxRuntime.Dnx451:
-                    runtimeNameFormat = Dnx451RuntimeNameFormat;
-                    break;
-                case DnxRuntime.DnxCore50:
-                    runtimeNameFormat = DnxCore50RuntimeNameFormat;
-                    break;
-                default:
-                    throw new InvalidOperationException();
-            }
-
-            var runtimeName = String.Format(runtimeNameFormat, bitness, DnxVersion);
+            var runtimeName = String.Format(DnxCore50RuntimeNameFormat, bitness, DnxVersion);
             var runtimeRelativePath = String.Format(DnxRuntimesBinPathFormat, runtimeName);
             Debug.WriteLine($"Using runtime path: {runtimeRelativePath}");
 
@@ -77,15 +63,15 @@ namespace GoogleCloudExtension.GCloud.Dnx
             return Path.Combine(s_VSInstallPath.Value, WebToolsRelativePath);
         }
 
-        public static bool ValidateDnxInstallationForRuntime(DnxRuntime runtime)
+        public static bool ValidateDnxInstallation()
         {
             bool result = false;
             Debug.WriteLine("Validating DNX installation.");
-            var dnxDirectory = GetDnxPathForRuntime(runtime);
+            var dnxDirectory = GetDnxPath();
             var dnuPath = Path.Combine(dnxDirectory, "dnu.cmd");
 
             result = File.Exists(dnuPath);
-            Debug.WriteLineIf(!result, $"DNX runtime {runtime} not installed, cannot find {dnuPath}");
+            Debug.WriteLineIf(!result, $"DNX runtime not installed, cannot find {dnuPath}");
             return result;
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/DnxRuntimeInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/DnxRuntimeInfo.cs
@@ -11,10 +11,6 @@ namespace GoogleCloudExtension.GCloud.Dnx
     /// </summary>
     public class DnxRuntimeInfo
     {
-        // Docker images names for the runtime.
-        public const string Dnx451ImageName = "mono";
-        public const string DnxCore50ImageName = "coreclr";
-
         // The names of the supported runtimes.
         // Clr will be substituted by Mono in the container.
         // CoreClr will be itself.
@@ -34,13 +30,11 @@ namespace GoogleCloudExtension.GCloud.Dnx
             new DnxRuntimeInfo(
                 runtime: DnxRuntime.Dnx451,
                 displayName: Dnx451DisplayString,
-                frameworkName: Dnx451FrameworkName,
-                imageName: Dnx451ImageName),
+                frameworkName: Dnx451FrameworkName),
             new DnxRuntimeInfo(
                 runtime: DnxRuntime.DnxCore50,
                 displayName: DnxCore50DisplayString,
-                frameworkName: DnxCore50FrameworkName,
-                imageName: DnxCore50ImageName),
+                frameworkName: DnxCore50FrameworkName),
         };
 
         /// <summary>
@@ -49,8 +43,7 @@ namespace GoogleCloudExtension.GCloud.Dnx
         private static readonly DnxRuntimeInfo s_UnknownRuntimeInfo = new DnxRuntimeInfo(
             runtime: DnxRuntime.None,
             displayName: "",
-            frameworkName: "",
-            imageName: "");
+            frameworkName: "");
 
         public DnxRuntime Runtime { get; }
 
@@ -58,14 +51,11 @@ namespace GoogleCloudExtension.GCloud.Dnx
 
         public string FrameworkName { get; }
 
-        public string ImageName { get; }
-
-        private DnxRuntimeInfo(DnxRuntime runtime, string displayName, string frameworkName, string imageName)
+        private DnxRuntimeInfo(DnxRuntime runtime, string displayName, string frameworkName)
         {
             Runtime = runtime;
             DisplayName = displayName;
             FrameworkName = frameworkName;
-            ImageName = imageName;
         }
 
         public static DnxRuntimeInfo GetRuntimeInfo(DnxRuntime runtime)

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/Project.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/Project.cs
@@ -34,7 +34,7 @@ namespace GoogleCloudExtension.GCloud.Dnx
 
         public IEnumerable<DnxRuntime> SupportedRuntimes => _supportedRuntimes.Value;
 
-        public bool HasWebServer => _parsedProject.Value.Dependencies.ContainsKey(KestrelFullName);
+        public bool IsEntryPoint => _parsedProject.Value.Dependencies.ContainsKey(KestrelFullName);
 
         public Project(string root)
         {
@@ -74,8 +74,7 @@ namespace GoogleCloudExtension.GCloud.Dnx
         };
 
         private DnxRuntime GetProjectRuntime() => s_PreferredRuntimes
-            .Where(x => _parsedProject.Value.Frameworks.ContainsKey(x.FrameworkName)
-                && DnxEnvironment.ValidateDnxInstallationForRuntime(x.Runtime))
+            .Where(x => _parsedProject.Value.Frameworks.ContainsKey(x.FrameworkName))
             .Select(x => x.Runtime)
             .FirstOrDefault();
 
@@ -87,7 +86,6 @@ namespace GoogleCloudExtension.GCloud.Dnx
 
         private IEnumerable<DnxRuntime> GetSupportedRuntimes() => _parsedProject.Value.Frameworks
             .Select(x => DnxRuntimeInfo.GetRuntimeInfo(x.Key).Runtime)
-            .Where(x => x != DnxRuntime.None)
-            .Where(x => DnxEnvironment.ValidateDnxInstallationForRuntime(x));
+            .Where(x => x != DnxRuntime.None);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolWindowCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolWindowCommand.cs
@@ -88,7 +88,7 @@ namespace GoogleCloudExtension.AppEngineApps
             }
 
             // Validate the environment, possibly show an error if not valid.
-            if (!CommandUtils.ValidateEnvironment(this.ServiceProvider))
+            if (!CommandUtils.ValidateEnvironment())
             {
                 return;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngine/DeployToAppEngineCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngine/DeployToAppEngineCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-using GoogleCloudExtension.DeploymentDialog;
 using GoogleCloudExtension.GCloud.Dnx;
 using GoogleCloudExtension.Projects;
 using GoogleCloudExtension.Utils;
@@ -82,19 +81,7 @@ namespace GoogleCloudExtension.DeployToAppEngine
             {
                 return;
             }
-
-            // Validate the environment, possibly show an error if not valid.
-            if (!CommandUtils.ValidateEnvironment(this.ServiceProvider))
-            {
-                return;
-            }
-
-            var window = new DeploymentDialogWindow(new DeploymentDialogWindowOptions
-            {
-                Project = startupProject,
-                ProjectsToRestore = SolutionHelper.CurrentSolution.Projects,
-            });
-            window.ShowModal();
+            DeploymentUtils.StartProjectDeployment(startupProject, ServiceProvider);
         }
 
         private void QueryStatusHandler(object sender, EventArgs e)
@@ -111,7 +98,7 @@ namespace GoogleCloudExtension.DeployToAppEngine
 
             if (startupProject != null)
             {
-                isDnxProject = startupProject.Runtime != DnxRuntime.None && startupProject.HasWebServer;
+                isDnxProject = startupProject.Runtime != DnxRuntime.None && startupProject.IsEntryPoint;
             }
 
             bool isComandEnabled = !GoogleCloudExtensionPackage.IsDeploying && isDnxProject;

--- a/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngineContextMenu/DeployToAppEngineContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngineContextMenu/DeployToAppEngineContextMenuCommand.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
-using GoogleCloudExtension.DeploymentDialog;
 using GoogleCloudExtension.GCloud.Dnx;
-using GoogleCloudExtension.Projects;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -126,20 +124,9 @@ namespace GoogleCloudExtension.DeployToAppEngineContextMenu
 
         private void DeployToGaeHandler(object sender, EventArgs e)
         {
-            var startupProjectPath = GetSelectedProjectPath();
-
-            // Validate the environment, possibly show an error if not valid.
-            if (!CommandUtils.ValidateEnvironment(this.ServiceProvider))
-            {
-                return;
-            }
-
-            var window = new DeploymentDialogWindow(new DeploymentDialogWindowOptions
-            {
-                Project = new Project(startupProjectPath),
-                ProjectsToRestore = SolutionHelper.CurrentSolution.Projects,
-            });
-            window.ShowModal();
+            DeploymentUtils.StartProjectDeployment(
+                new Project(GetSelectedProjectPath()),
+                ServiceProvider);
         }
 
         private void QueryStatusHandler(object sender, EventArgs e)
@@ -157,7 +144,7 @@ namespace GoogleCloudExtension.DeployToAppEngineContextMenu
             if (isDnxProject)
             {
                 project = new Project(selectedProjectPath);
-                isDnxProject = project.Runtime != DnxRuntime.None && project.HasWebServer;
+                isDnxProject = project.Runtime != DnxRuntime.None && project.IsEntryPoint;
             }
 
             bool isCommandEnabled = !GoogleCloudExtensionPackage.IsDeploying && isDnxProject;

--- a/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogContent.xaml
@@ -17,20 +17,17 @@
     </UserControl.Resources>
 
     <Grid Margin="0" Height="369" VerticalAlignment="Top">
-        <Button Content="Deploy" HorizontalAlignment="Left" Margin="10,287,0,0" VerticalAlignment="Top" Width="181" Height="35" Command="{Binding DeployCommand}" IsDefault="True" IsEnabled="{Binding Loaded}"/>
+        <Button Content="Deploy" HorizontalAlignment="Left" Margin="10,245,0,0" VerticalAlignment="Top" Width="181" Height="35" Command="{Binding DeployCommand}" IsDefault="True" IsEnabled="{Binding Loaded}"/>
         <ComboBox HorizontalAlignment="Left" Margin="209,99,0,0" VerticalAlignment="Top" Width="181" ItemsSource="{Binding CloudProjects}" SelectedItem="{Binding SelectedCloudProject, Mode=TwoWay}" IsEnabled="{Binding Loaded}"/>
         <TextBlock HorizontalAlignment="Left" Margin="10,99,0,0" TextWrapping="Wrap" Text="Cloud Project:" VerticalAlignment="Top"/>
-        <Button Content="Cancel" HorizontalAlignment="Left" Margin="209,287,0,0" VerticalAlignment="Top" Width="181" Height="35" Command="{Binding CancelCommand}" IsCancel="True"/>
-        <CheckBox Content="Make Default Version" HorizontalAlignment="Left" Margin="209,224,0,0" VerticalAlignment="Top" Width="178" IsChecked="{Binding MakeDefault, Mode=TwoWay}" IsEnabled="{Binding Loaded}"/>
+        <Button Content="Cancel" HorizontalAlignment="Left" Margin="209,245,0,0" VerticalAlignment="Top" Width="181" Height="35" Command="{Binding CancelCommand}" IsCancel="True"/>
+        <CheckBox Content="Make Default Version" HorizontalAlignment="Left" Margin="209,182,0,0" VerticalAlignment="Top" Width="178" IsChecked="{Binding MakeDefault, Mode=TwoWay}" IsEnabled="{Binding Loaded}"/>
         <TextBlock HorizontalAlignment="Left" Margin="10,23,0,0" TextWrapping="Wrap" Text="Deploying project:" VerticalAlignment="Top"/>
         <TextBlock HorizontalAlignment="Left" Margin="209,23,0,0" TextWrapping="Wrap" Text="{Binding Project}" VerticalAlignment="Top" Width="181"/>
-        <TextBox HorizontalAlignment="Left" Height="23" Margin="209,175,0,0" TextWrapping="Wrap" Text="{Binding VersionName}" VerticalAlignment="Top" Width="181" IsEnabled="{Binding Loaded}"/>
-        <TextBlock HorizontalAlignment="Left" Margin="10,175,0,0" TextWrapping="Wrap" Text="Version Name:" VerticalAlignment="Top" Width="170"/>
+        <TextBox HorizontalAlignment="Left" Height="23" Margin="209,140,0,0" TextWrapping="Wrap" Text="{Binding VersionName}" VerticalAlignment="Top" Width="181" IsEnabled="{Binding Loaded}"/>
+        <TextBlock HorizontalAlignment="Left" Margin="10,140,0,0" TextWrapping="Wrap" Text="Version Name:" VerticalAlignment="Top" Width="170"/>
         <TextBlock HorizontalAlignment="Left" Margin="10,61,0,0" TextWrapping="Wrap" Text="Cloud Account:" VerticalAlignment="Top" Width="120"/>
         <ComboBox HorizontalAlignment="Left" Margin="209,61,0,0" VerticalAlignment="Top" Width="181" ItemsSource="{Binding Accounts}" SelectedItem="{Binding SelectedAccount}" IsEnabled="{Binding Loaded}"/>
-        <TextBlock x:Name="textBlock" HorizontalAlignment="Left" Margin="10,138,0,0" TextWrapping="Wrap" Text="Runtime:" VerticalAlignment="Top" Width="150"/>
-        <ComboBox x:Name="comboBox" HorizontalAlignment="Left" Margin="209,138,0,0" VerticalAlignment="Top" Width="181" IsEnabled="{Binding Loaded}" ItemsSource="{Binding SupportedRuntimes}" SelectedItem="{Binding SelectedRuntime, Mode=TwoWay}" ItemTemplate="{DynamicResource RuntimeTemplate}"/>
-        <CheckBox x:Name="checkBox" Content="Preserve Publish Output" HorizontalAlignment="Left" Margin="209,255,0,0" VerticalAlignment="Top" Width="178" IsChecked="{Binding PreserveOutput, Mode=TwoWay}" IsEnabled="{Binding Loaded}"/>
-
+        <CheckBox x:Name="checkBox" Content="Preserve Publish Output" HorizontalAlignment="Left" Margin="209,213,0,0" VerticalAlignment="Top" Width="178" IsChecked="{Binding PreserveOutput, Mode=TwoWay}" IsEnabled="{Binding Loaded}"/>
     </Grid>
 </UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0.
 
 using GoogleCloudExtension.GCloud;
-using GoogleCloudExtension.GCloud.Dnx;
 using GoogleCloudExtension.GCloud.Models;
 using GoogleCloudExtension.Utils;
 using System.Collections.Generic;
@@ -28,7 +27,6 @@ namespace GoogleCloudExtension.DeploymentDialog
         private CloudProject _selectedCloudProject;
         private IEnumerable<string> _accounts;
         private string _selectedAccount;
-        private DnxRuntime _selectedRuntime;
         private bool _loaded;
         private bool _makeDefault;
         private bool _preserveOutput;
@@ -38,11 +36,6 @@ namespace GoogleCloudExtension.DeploymentDialog
         /// The project that will be deployed.
         /// </summary>
         public string Project { get; }
-
-        /// <summary>
-        /// The list of supported runtimes by the project being deployed.
-        /// </summary>
-        public IList<DnxRuntime> SupportedRuntimes { get; }
 
         /// <summary>
         /// The list of cloud projects available to deploy the code.
@@ -82,15 +75,6 @@ namespace GoogleCloudExtension.DeploymentDialog
                 SetValueAndRaise(ref _selectedAccount, value);
                 InvalidateSelectedAccount();
             }
-        }
-
-        /// <summary>
-        /// The selected runtime to use for the deployment.
-        /// </summary>
-        public DnxRuntime SelectedRuntime
-        {
-            get { return _selectedRuntime; }
-            set { SetValueAndRaise(ref _selectedRuntime, value); }
         }
 
         /// <summary>
@@ -144,8 +128,6 @@ namespace GoogleCloudExtension.DeploymentDialog
             this.DeployCommand = new WeakCommand(this.OnDeployHandler);
             this.CancelCommand = new WeakCommand(this.OnCancelHandler);
             this.Project = window.Options.Project.Name;
-            this.SupportedRuntimes = window.Options.Project.SupportedRuntimes.ToList();
-            this.SelectedRuntime = window.Options.Project.Runtime;
             _window = window;
         }
 
@@ -192,7 +174,6 @@ namespace GoogleCloudExtension.DeploymentDialog
             DeploymentUtils.DeployProjectAsync(
                 startupProject: _window.Options.Project,
                 projects: _window.Options.ProjectsToRestore,
-                selectedRuntime: SelectedRuntime,
                 versionName: VersionName,
                 makeDefault: MakeDefault,
                 preserveOutput: PreserveOutput,

--- a/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogWindow.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension.DeploymentDialog
         {
             this.ResizeMode = System.Windows.ResizeMode.NoResize;
             this.Width = 420;
-            this.Height = 400;
+            this.Height = 350;
             this.Title = "Deploy to AppEngine";
 
             this.Options = options;

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/CommandUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/CommandUtils.cs
@@ -3,31 +3,16 @@
 
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.GCloud.Dnx;
-using Microsoft.VisualStudio.Shell;
-using System;
-using System.Diagnostics;
 
 namespace GoogleCloudExtension.Utils
 {
     internal static class CommandUtils
     {
-        public static bool ValidateEnvironment(IServiceProvider serviceProvider)
+        public static bool ValidateEnvironment()
         {
-            var validDNXInstallation = DnxEnvironment.ValidateDnxInstallationForRuntime(DnxRuntime.DnxCore50) ||
-                DnxEnvironment.ValidateDnxInstallationForRuntime(DnxRuntime.Dnx451);
+            var validDNXInstallation = DnxEnvironment.ValidateDnxInstallation();
             var validGCloudInstallation = GCloudWrapper.Instance.ValidateGCloudInstallation();
             var validEnvironment = validDNXInstallation && validGCloudInstallation;
-            if (!validEnvironment)
-            {
-                Debug.WriteLine("Invoked when the environment is not valid.");
-                VsShellUtilities.ShowMessageBox(
-                    serviceProvider,
-                    "Please ensure that GCloud is installed.",
-                    "Error",
-                    Microsoft.VisualStudio.Shell.Interop.OLEMSGICON.OLEMSGICON_CRITICAL,
-                    Microsoft.VisualStudio.Shell.Interop.OLEMSGBUTTON.OLEMSGBUTTON_OK,
-                    Microsoft.VisualStudio.Shell.Interop.OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
-            }
             return validEnvironment;
         }
     }


### PR DESCRIPTION
This change removes the automatic support for the Mono runtime from
the extension, if the project can't run on Core CLR then it will show
an error message to the user to that respect. In that error message we
can include a link to instructions on how to either change the project
to support Core CLR or how to use the Mono image manually to deploy to
AppEngine.
This change also uses the new `dotnet` image as the base for the
generated `Dockerfile` for the deployment.
