### PR TITLE
Adding Google Analytics for the extension.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License Version 2.0.
 
 using GoogleCloudExtension.GCloud.Models;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -238,9 +239,29 @@ namespace GoogleCloudExtension.GCloud
             return GetJsonOutputAsync<IList<CloudProject>>("alpha projects list");
         }
 
+        /// <summary>
+        /// Fetches the list of projects for the given credentials from the
+        /// gcloud store.
+        /// </summary>
+        /// <param name="credentials">The credentials to use.</param>
+        /// <returns>The task with the list of projects.</returns>
         public async Task<IList<CloudProject>> GetProjectsAsync(Credentials credentials)
         {
             return await GetJsonOutputAsync<IList<CloudProject>>("alpha projects list", credentials);
+        }
+
+        /// <summary>
+        /// Fetches the value of the property given its full name.
+        /// </summary>
+        /// <param name="group">The group that contains the property.</param>
+        /// <param name="property">The name of the property to fetch.</param>
+        /// <returns>The task with the result from reading the property.</returns>
+        public async Task<string> GetPropertyAsync(string group, string property)
+        {
+            Debug.WriteLine($"Reading property gcloud {group}/{property}");
+            var config = await GetJsonOutputAsync<JObject>($"config list {group}/{property}");
+            var groupObject = config?[group];
+            return (string)groupObject?[property];
         }
 
         public bool ValidateGCloudInstallation()

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleAnalyticsReporter.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleAnalyticsReporter.cs
@@ -1,0 +1,198 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+
+namespace GoogleCloudExtension.Utils
+{
+    /// <summary>
+    /// <para>
+    /// Client for the the Google Analytics Measurement Protocol service, which makes
+    /// HTTP requests to publish data to a Google Analytics account
+    /// </para>
+    /// 
+    /// <para>
+    /// For more information, see:
+    /// https://developers.google.com/analytics/devguides/collection/protocol/v1/
+    /// </para>
+    ///
+    /// <para>
+    /// This class is thread hostile. You have been warned. The recommeneded way to use this class is
+    /// as a shared instance so the entire app uses the same reporter. This reporter should only be used
+    /// from one thread, typically the easiest is the UI thread, which is OK since the reporting
+    /// is done in an asynchronous manner.
+    /// </para>
+    /// </summary>
+    public class GoogleAnalyticsReporter
+    {
+        private const string ProductionServerUrl = "https://ssl.google-analytics.com/collect";
+        private const string DebugServerUrl = "https://ssl.google-analytics.com/debug/collect";
+
+        private const string HitTypeParam = "t";
+        private const string VersionParam = "v";
+        private const string EventCategoryParam = "ec";
+        private const string EventActionParam = "ea";
+        private const string EventLabelParam = "el";
+        private const string EventValueParam = "ev";
+        private const string SessionControlParam = "sc";
+        private const string PropertyIdParam = "tid";
+        private const string ClientIdParam = "cid";
+        private const string AppNameParam = "an";
+        private const string AppVersionParam = "av";
+
+        private const string VersionValue = "1";
+        private const string EventTypeValue = "event";
+        private const string SessionStartValue = "start";
+        private const string SessionEndValue = "end";
+
+        private readonly bool _debug;
+        private readonly string _serverUrl;
+        private readonly string _appName;
+        private readonly string _appVersion;
+        private readonly Dictionary<string, string> _baseHitData;
+
+        /// <summary>
+        /// The property ID being used by this reporter.
+        /// </summary>
+        public string PropertyId { get; }
+
+        /// <summary>
+        /// The client ID being used by this reporter.
+        /// Note: This ID is generated with every instance, which is why is important
+        /// to share the instance.
+        /// TODO: Perhaps accept the ID from the caller.
+        /// </summary>
+        public string ClientId { get; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Initializes the instance.
+        /// </summary>
+        /// <param name="propertyId">The property ID to use, string with the format US-XXXX. Must not be null.</param>
+        /// <param name="appName">The name of the app for which this reporter is reporting. Must not be null.</param>
+        /// <param name="appVersion">Optional, the app version. Defaults to null.</param>
+        /// <param name="debug">Optional, whether this reporter is in debug mode. Defaults to false.</param>
+        public GoogleAnalyticsReporter(
+            string propertyId,
+            string appName,
+            string appVersion = null,
+            bool debug = false)
+        {
+            PropertyId = propertyId;
+            _serverUrl = debug ? DebugServerUrl : ProductionServerUrl;
+            _appName = appName;
+            _appVersion = appVersion;
+            _debug = debug;
+            _baseHitData = MakeBaseHitData();
+        }
+
+        /// <summary>
+        /// Convenience method to report a singe event to Google Analytics.
+        /// </summary>
+        /// <param name="category">The category for the even.</param>
+        /// <param name="action">The action that took place.</param>
+        /// <param name="label">The label affected by the event.</param>
+        /// <param name="value">The new value.</param>
+        public void ReportEvent(string category, string action, string label, int? value = null)
+        {
+            // Data we will send along with the web request. Later baked into the HTTP
+            // request's payload.
+            var hitData = new Dictionary<string, string>(_baseHitData) {
+                { HitTypeParam, EventTypeValue },
+                { EventCategoryParam, category },
+                { EventActionParam, action },
+            };
+            if (label != null)
+            {
+                hitData[EventLabelParam] = label;
+            }
+            if (value != null)
+            {
+                hitData[EventValueParam] = value.ToString();
+            }
+            SendHitData(hitData);
+        }
+
+        /// <summary>
+        /// Reports that the session is starting.
+        /// </summary>
+        public void ReportStartSession()
+        {
+            var hitData = new Dictionary<string, string>(_baseHitData)
+            {
+                { HitTypeParam,EventTypeValue },
+                { SessionControlParam, SessionStartValue }
+            };
+            SendHitData(hitData);
+        }
+
+        /// <summary>
+        /// Reports that the session is ending.
+        /// </summary>
+        public void ReportEndSession()
+        {
+            var hitData = new Dictionary<string, string>(_baseHitData)
+            {
+                { HitTypeParam, EventTypeValue },
+                { SessionControlParam, SessionEndValue }
+            };
+            SendHitData(hitData);
+        }
+
+        private Dictionary<string, string> MakeBaseHitData()
+        {
+            var result = new Dictionary<string, string>
+            {
+                { VersionParam, VersionValue },
+                { PropertyIdParam, PropertyId },
+                { ClientIdParam, ClientId },
+                { AppNameParam, _appName },
+            };
+            if (_appVersion != null)
+            {
+                result.Add(AppVersionParam, _appVersion);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Sens the hit data to the server.
+        /// Note: This method behaves differently in debug mode vs. normal mode. In debug mode
+        /// it will block to read the output of the debug reporting server and log that out
+        /// for verification. On normal mode (typically used in Release builds) this reporting
+        /// is done using a non-blocking method.
+        /// </summary>
+        /// <param name="hitData">The hit data to be sent.</param>
+        private void SendHitData(Dictionary<string, string> hitData)
+        {
+            var values = new NameValueCollection();
+            foreach (var entry in hitData)
+            {
+                values.Add(entry.Key, entry.Value);
+            }
+
+            try
+            {
+                var client = new WebClient();
+                if (_debug)
+                {
+                    var result = client.UploadValues(_serverUrl, values);
+                    var decoded = Encoding.UTF8.GetString(result);
+                    Debug.WriteLine($"Output of analytics: {decoded}");
+                }
+                else
+                {
+                    client.UploadValuesAsync(new Uri(_serverUrl), values);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to report analytics. {ex.Message}");
+            }
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleCloudExtension.Utils.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleCloudExtension.Utils.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BooleanConverter.cs" />
+    <Compile Include="GoogleAnalyticsReporter.cs" />
     <Compile Include="Model.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VisibilityConverter.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/AddNewAccount/AddNewAccountCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AddNewAccount/AddNewAccountCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Shell;
@@ -14,6 +15,8 @@ namespace GoogleCloudExtension.AddNewAccount
     /// </summary>
     internal sealed class AddNewAccountCommand
     {
+        private const string AddAccountCommand = nameof(AddAccountCommand);
+
         /// <summary>
         /// Command ID.
         /// </summary>
@@ -78,6 +81,8 @@ namespace GoogleCloudExtension.AddNewAccount
         /// <param name="e">Event args.</param>
         private async void AddNewAccountHandler(object sender, EventArgs e)
         {
+            ExtensionAnalytics.ReportStartCommand(AddAccountCommand, CommandInvocationSource.ToolsMenu);
+
             AppEngineOutputWindow.Clear();
             AppEngineOutputWindow.Activate();
             try
@@ -85,9 +90,12 @@ namespace GoogleCloudExtension.AddNewAccount
                 AppEngineOutputWindow.OutputLine("Activating browser.");
                 await GCloudWrapper.Instance.AddCredentialsAsync(AppEngineOutputWindow.OutputLine);
                 AppEngineOutputWindow.OutputLine("Done adding account.");
+
+                ExtensionAnalytics.ReportEndCommand(AddAccountCommand, succeeded: true);
             }
             catch (Exception ex)
             {
+                ExtensionAnalytics.ReportEndCommand(AddAccountCommand, succeeded: false);
                 AppEngineOutputWindow.OutputLine(ex.Message);
             }
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/ExtensionAnalytics.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/ExtensionAnalytics.cs
@@ -1,0 +1,207 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using GoogleCloudExtension.GCloud;
+using GoogleCloudExtension.Utils;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.Analytics
+{
+    public enum CommandInvocationSource
+    {
+        None,
+        ToolsMenu,
+        ContextMenu,
+        Button,
+    }
+
+    internal static class ExtensionAnalytics
+    {
+        private const string PropertyId = "UA-71653866-1";
+        private const string ApplicationName = "Visual Studio Extension";
+
+        private const string CommandCategory = "Command";
+        private const string WindowCategory = "Window";
+        private const string EventCategory = "Event";
+
+        private const string OpenWindowAction = "OpenWindow";
+        private const string EndCommandAction = "EndCommand";
+
+        private const string SucceededLabel = "Success";
+        private const string FailedLabel = "Failed";
+        private const string FalseValue = "false";
+
+        private static readonly Lazy<GoogleAnalyticsReporter> s_reporter = new Lazy<GoogleAnalyticsReporter>(CreateReporter);
+        private static readonly Lazy<Task<bool>> s_isReportingEnabled = new Lazy<Task<bool>>(IsReportingEnabled);
+
+        #region Report convenience methods.
+
+        /// <summary>
+        /// Reports that the given command is starting its execution, typically to be called right at the
+        /// begining of the command's handler method.
+        /// </summary>
+        /// <param name="command">The name of the command. Must not be null.</param>
+        /// <param name="invocationSource">From where the command was invoked.</param>
+        public static async void ReportStartCommand(string command, CommandInvocationSource invocationSource)
+        {
+            Debug.WriteLine($"Reporting: Starting command {command} from source {invocationSource}");
+            var reporter = await GetReporter();
+            string action;
+            switch (invocationSource)
+            {
+                case CommandInvocationSource.ToolsMenu:
+                    action = "StartCommandFromToolsMenu";
+                    break;
+                case CommandInvocationSource.ContextMenu:
+                    action = "StartCommandFromContextMenu";
+                    break;
+                case CommandInvocationSource.Button:
+                    action = "StartCommandFromButton";
+                    break;
+                default:
+                    action = "StartCommand";
+                    break;
+            }
+            reporter?.ReportEvent(
+                category: CommandCategory,
+                action: action,
+                label: invocationSource.ToString());
+        }
+
+        /// <summary>
+        /// Reports a command has finished.
+        /// </summary>
+        /// <param name="command">The command completed. Must not be null.</param>
+        /// <param name="succeeded">Did it succeed or not.</param>
+        public static async void ReportEndCommand(string command, bool succeeded)
+        {
+            Debug.WriteLine($"Reporting: Command {command} success: {succeeded}");
+            var reporter = await GetReporter();
+            reporter?.ReportEvent(
+                category: CommandCategory,
+                action: EndCommandAction,
+                label: succeeded ? SucceededLabel : FailedLabel);
+        }
+
+        /// <summary>
+        /// Convenience wrapper to report a command when the command action is self contained.
+        /// </summary>
+        /// <param name="command">The name of the command. Must not be null.</param>
+        /// <param name="source">From where the command was invoked.</param>
+        /// <param name="action">The action to execute for the command.</param>
+        public static void ReportCommand(string command, CommandInvocationSource source, Action action)
+        {
+            ReportStartCommand(command, source);
+            bool succeeded = false;
+            try
+            {
+                action();
+                succeeded = true;
+            }
+            finally
+            {
+                ReportEndCommand(command, succeeded);
+            }
+        }
+
+        /// <summary>
+        /// Reports what tool window from the extension has been opened.
+        /// </summary>
+        /// <param name="name">The name of the window, typically <c>nameof(class)</c>. Must not be null.</param>
+        public static async void ReportWindowOpened(string name)
+        {
+            Debug.WriteLine($"Reporting: Window {name} is opened");
+            var reporter = await GetReporter();
+            reporter?.ReportEvent(
+                category: WindowCategory,
+                action: OpenWindowAction,
+                label: name);
+        }
+
+        /// <summary>
+        /// Reports that an event happened.
+        /// </summary>
+        /// <param name="name">The name of the event. Must not be null.</param>
+        /// <param name="value">Optional, the value associated with the event.</param>
+        public static async void ReportEvent(string name, string value = null)
+        {
+            Debug.WriteLine($"Reporting: Event {name} with param {value}");
+            var reporter = await GetReporter();
+            reporter?.ReportEvent(
+                category: EventCategory,
+                action: name,
+                label: value);
+        }
+
+        /// <summary>
+        /// Reports the begining of the session, to be called when the extension is loaded.
+        /// </summary>
+        public static async void ReportStartSession()
+        {
+            Debug.WriteLine($"Reporting: Starting session.");
+            var reporter = await GetReporter();
+            reporter?.ReportStartSession();
+        }
+
+        /// <summary>
+        /// Reports the end of the session, to be called when the extension is unloaded.
+        /// </summary>
+        public static async void ReportEndSession()
+        {
+            Debug.WriteLine($"Reporting: Ending session.");
+            var reporter = await GetReporter();
+            reporter?.ReportEndSession();
+        }
+
+        #endregion
+
+        private static GoogleAnalyticsReporter CreateReporter()
+        {
+            bool debug = false;
+#if DEBUG
+            debug = true;
+#endif
+            return new GoogleAnalyticsReporter(PropertyId, appName: ApplicationName, debug: debug);
+        }
+
+        /// <summary>
+        /// Returns the reporter to use for reporting data, or null if no reporting is to be done.
+        /// Note: The check for whether reporting data is enabled is done once per session, if the user
+        /// changes the setting then Visual Studio will have to be restarted.
+        /// </summary>
+        /// <returns>The task with the reporter to use.</returns>
+        private static async Task<GoogleAnalyticsReporter> GetReporter()
+        {
+            return await s_isReportingEnabled.Value ? s_reporter.Value : null;
+        }
+
+        /// <summary>
+        /// Checks with gcloud to see if usage reporting is enabled or not. Only checks once per session.
+        /// </summary>
+        /// <returns>The task with the result of the check.</returns>
+        private static async Task<bool> IsReportingEnabled()
+        {
+            // If gcloud is not present then we have to assume that we can't report usage.
+            if (!GCloudWrapper.Instance.ValidateGCloudInstallation())
+            {
+                return false;
+            }
+
+            // The disable reporting state in gcloud is stored by:
+            // * If there's no property stored this means that the user never disabled reporting, so it is enabled.
+            // * If there's a property stored, use the value.
+            // Because of this the default value is true, in case there's no property stored.
+            bool result = true;
+            var value = await GCloudWrapper.Instance.GetPropertyAsync("core", "disable_usage_reporting");
+            if (value != null)
+            {
+                result = value.Equals(FalseValue, StringComparison.OrdinalIgnoreCase);
+            }
+
+            Debug.WriteLine($"Reporting enabled: {result}");
+            return result;
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolWindow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
@@ -33,6 +34,8 @@ namespace GoogleCloudExtension.AppEngineApps
 
             // Load the list of apps for the current user and project.
             model.LoadAppEngineAppListAsync();
+
+            ExtensionAnalytics.ReportWindowOpened(nameof(AppEngineAppsToolWindow));
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolWindowCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolWindowCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -14,6 +15,8 @@ namespace GoogleCloudExtension.AppEngineApps
     /// </summary>
     internal sealed class AppEngineAppsToolWindowCommand
     {
+        private const string ShowAppEngineAppsToolWindowCommand = nameof(ShowAppEngineAppsToolWindowCommand);
+
         /// <summary>
         /// Command ID.
         /// </summary>
@@ -78,23 +81,29 @@ namespace GoogleCloudExtension.AppEngineApps
         /// <param name="e">The event args.</param>
         private void ShowToolWindow(object sender, EventArgs e)
         {
-            // Get the instance number 0 of this tool window. This window is single instance so this instance
-            // is actually the only one.
-            // The last flag is set to true so that if the tool window does not exists it will be created.
-            ToolWindowPane window = _package.FindToolWindow(typeof(AppEngineAppsToolWindow), 0, true);
-            if (window?.Frame == null)
-            {
-                throw new NotSupportedException("Cannot create tool window");
-            }
+            ExtensionAnalytics.ReportCommand(
+                ShowAppEngineAppsToolWindowCommand,
+                CommandInvocationSource.ToolsMenu,
+                () =>
+                {
+                    // Get the instance number 0 of this tool window. This window is single instance so this instance
+                    // is actually the only one.
+                    // The last flag is set to true so that if the tool window does not exists it will be created.
+                    ToolWindowPane window = _package.FindToolWindow(typeof(AppEngineAppsToolWindow), 0, true);
+                    if (window?.Frame == null)
+                    {
+                        throw new NotSupportedException("Cannot create tool window");
+                    }
 
-            // Validate the environment, possibly show an error if not valid.
-            if (!CommandUtils.ValidateEnvironment())
-            {
-                return;
-            }
+                    // Validate the environment, possibly show an error if not valid.
+                    if (!CommandUtils.ValidateEnvironment())
+                    {
+                        return;
+                    }
 
-            IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
-            Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                    IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
+                    Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                });
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngine/DeployToAppEngineCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngine/DeployToAppEngineCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.GCloud.Dnx;
 using GoogleCloudExtension.Projects;
 using GoogleCloudExtension.Utils;
@@ -15,6 +16,8 @@ namespace GoogleCloudExtension.DeployToAppEngine
     /// </summary>
     internal sealed class DeployToAppEngineCommand
     {
+        public const string StartDeployToAppEngineCommand = nameof(StartDeployToAppEngineCommand);
+
         /// <summary>
         /// Command ID.
         /// </summary>
@@ -81,7 +84,10 @@ namespace GoogleCloudExtension.DeployToAppEngine
             {
                 return;
             }
-            DeploymentUtils.StartProjectDeployment(startupProject, ServiceProvider);
+            ExtensionAnalytics.ReportCommand(
+                StartDeployToAppEngineCommand,
+                CommandInvocationSource.ToolsMenu,
+                () => DeploymentUtils.StartProjectDeployment(startupProject, ServiceProvider));
         }
 
         private void QueryStatusHandler(object sender, EventArgs e)

--- a/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngineContextMenu/DeployToAppEngineContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeployToAppEngineContextMenu/DeployToAppEngineContextMenuCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.GCloud.Dnx;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio;
@@ -124,9 +125,12 @@ namespace GoogleCloudExtension.DeployToAppEngineContextMenu
 
         private void DeployToGaeHandler(object sender, EventArgs e)
         {
-            DeploymentUtils.StartProjectDeployment(
-                new Project(GetSelectedProjectPath()),
-                ServiceProvider);
+            ExtensionAnalytics.ReportCommand(
+                DeployToAppEngine.DeployToAppEngineCommand.StartDeployToAppEngineCommand,
+                CommandInvocationSource.ContextMenu,
+                () => DeploymentUtils.StartProjectDeployment(
+                        new Project(GetSelectedProjectPath()),
+                        ServiceProvider));
         }
 
         private void QueryStatusHandler(object sender, EventArgs e)

--- a/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.GCloud.Models;
 using GoogleCloudExtension.Utils;
@@ -16,6 +17,9 @@ namespace GoogleCloudExtension.DeploymentDialog
     /// </summary>
     public class DeploymentDialogViewModel : ViewModelBase
     {
+        private const string DeployAppEngineAppCommand = nameof(DeployAppEngineAppCommand);
+        private const string CancelDeploymentAppEngineAppCommand = nameof(CancelDeploymentAppEngineAppCommand);
+
         private readonly DeploymentDialogWindow _window;
 
         // Default values to show while loading data.
@@ -169,21 +173,26 @@ namespace GoogleCloudExtension.DeploymentDialog
 
         #region Command handlers
 
-        private void OnDeployHandler()
+        private async void OnDeployHandler()
         {
-            DeploymentUtils.DeployProjectAsync(
+            _window.Close();
+            ExtensionAnalytics.ReportStartCommand(DeployAppEngineAppCommand, CommandInvocationSource.Button);
+            var success = await DeploymentUtils.DeployProjectAsync(
                 startupProject: _window.Options.Project,
                 projects: _window.Options.ProjectsToRestore,
                 versionName: VersionName,
                 makeDefault: MakeDefault,
                 preserveOutput: PreserveOutput,
                 accountAndProject: new Credentials(account: this.SelectedAccount, projectId: this.SelectedCloudProject.Id));
-            _window.Close();
+            ExtensionAnalytics.ReportEndCommand(DeployAppEngineAppCommand, succeeded: success);
         }
 
         private void OnCancelHandler()
         {
-            _window.Close();
+            ExtensionAnalytics.ReportCommand(
+                CancelDeploymentAppEngineAppCommand,
+                CommandInvocationSource.Button,
+                () => _window.Close());
         }
 
         #endregion

--- a/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/DeploymentDialog/DeploymentDialogWindow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.GCloud.Dnx;
 using Microsoft.VisualStudio.PlatformUI;
 using System.Collections.Generic;
@@ -28,6 +29,8 @@ namespace GoogleCloudExtension.DeploymentDialog
             this.Content = new DeploymentDialogContent { DataContext = model };
 
             model.StartLoadingProjectsAsync();
+
+            ExtensionAnalytics.ReportWindowOpened(nameof(DeploymentDialogWindow));
         }
 
         public DeploymentDialogWindowOptions Options { get; private set; }

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -38,7 +38,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -52,6 +52,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddNewAccount\AddNewAccountCommand.cs" />
+    <Compile Include="Analytics\ExtensionAnalytics.cs" />
     <Compile Include="AppEngineApps\AppEngineAppsToolViewModel.cs" />
     <Compile Include="AppEngineApps\AppEngineAppsToolWindow.cs" />
     <Compile Include="AppEngineApps\AppEngineAppsToolWindowCommand.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using EnvDTE;
 using GoogleCloudExtension.AddNewAccount;
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.AppEngineApps;
 using GoogleCloudExtension.DeployToAppEngine;
 using GoogleCloudExtension.DeployToAppEngineContextMenu;
@@ -73,6 +75,16 @@ namespace GoogleCloudExtension
             UserAndProjectListWindowCommand.Initialize(this);
             DeployToAppEngineContextMenuCommand.Initialize(this);
             AddNewAccountCommand.Initialize(this);
+
+            ExtensionAnalytics.ReportStartSession();
+
+            var dte = (DTE)Package.GetGlobalService(typeof(DTE));
+            dte.Events.DTEEvents.OnBeginShutdown += DTEEvents_OnBeginShutdown;
+        }
+
+        private void DTEEvents_OnBeginShutdown()
+        {
+            ExtensionAnalytics.ReportEndSession();
         }
 
         #endregion

--- a/GoogleCloudExtension/GoogleCloudExtension/UserAndProjectList/UserAndProjectListViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/UserAndProjectList/UserAndProjectListViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.GCloud.Models;
 using GoogleCloudExtension.Utils;
@@ -16,22 +17,15 @@ namespace GoogleCloudExtension.UserAndProjectList
     /// </summary>
     public class UserAndProjectListViewModel : ViewModelBase
     {
+        private const string UpdateCurrentProjectCommand = nameof(UpdateCurrentProjectCommand);
+        private const string UpdateCurrentAccountCommand = nameof(UpdateCurrentAccountCommand);
+
         private IList<CloudProject> _projects;
         private CloudProject _currentProject;
         private IEnumerable<string> _accounts;
         private string _currentAccount;
         private bool _loadingProjects;
         private bool _loadingAccounts;
-
-        /// <summary>
-        /// Helper property that determines if GCloud is installed.
-        /// </summary>
-        public bool IsGCloudInstalled => GCloudWrapper.Instance.ValidateGCloudInstallation();
-
-        /// <summary>
-        /// Helper property that negates the previous one, needed to simplify UI bindings.
-        /// </summary>
-        public bool IsGCloudNotInstalled => !IsGCloudInstalled;
 
         /// <summary>
         /// The list of cloud projects available to the selected user.
@@ -159,6 +153,8 @@ namespace GoogleCloudExtension.UserAndProjectList
         /// <param name="newProject"></param>
         private async void UpdateCurrentProject(CloudProject newProject)
         {
+            ExtensionAnalytics.ReportStartCommand(UpdateCurrentProjectCommand, CommandInvocationSource.None);
+
             try
             {
                 if (newProject == null)
@@ -174,12 +170,16 @@ namespace GoogleCloudExtension.UserAndProjectList
                     account: currentAccountAndProject.Account,
                     projectId: newProject.Id);
                 GCloudWrapper.Instance.UpdateCredentials(newCurrentAccountAndProject);
+
+                ExtensionAnalytics.ReportEndCommand(UpdateCurrentProjectCommand, succeeded: true);
             }
             catch (GCloudException ex)
             {
                 AppEngineOutputWindow.OutputLine($"Failed to update project to {newProject.Name}");
                 AppEngineOutputWindow.OutputLine(ex.Message);
                 AppEngineOutputWindow.Activate();
+
+                ExtensionAnalytics.ReportEndCommand(UpdateCurrentProjectCommand, succeeded: false);
             }
         }
 
@@ -193,6 +193,8 @@ namespace GoogleCloudExtension.UserAndProjectList
             {
                 return;
             }
+
+            ExtensionAnalytics.ReportStartCommand(UpdateCurrentAccountCommand, CommandInvocationSource.None);
 
             try
             {
@@ -227,12 +229,16 @@ namespace GoogleCloudExtension.UserAndProjectList
                         this.LoadingProjects = false;
                     }
                 }
+
+                ExtensionAnalytics.ReportEndCommand(UpdateCurrentAccountCommand, succeeded: true);
             }
             catch (GCloudException ex)
             {
                 AppEngineOutputWindow.OutputLine($"Failed to update current account to {value}");
                 AppEngineOutputWindow.OutputLine(ex.Message);
                 AppEngineOutputWindow.Activate();
+
+                ExtensionAnalytics.ReportEndCommand(UpdateCurrentAccountCommand, succeeded: false);
             }
         }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension/UserAndProjectList/UserAndProjectListWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/UserAndProjectList/UserAndProjectListWindow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
@@ -32,6 +33,8 @@ namespace GoogleCloudExtension.UserAndProjectList
             this.Content = new UserAndProjectListWindowControl { DataContext = model };
 
             model.LoadAccountsAsync();
+
+            ExtensionAnalytics.ReportWindowOpened(nameof(UserAndProjectListWindow));
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/UserAndProjectList/UserAndProjectListWindowCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/UserAndProjectList/UserAndProjectListWindowCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
@@ -13,6 +14,8 @@ namespace GoogleCloudExtension.UserAndProjectList
     /// </summary>
     internal sealed class UserAndProjectListWindowCommand
     {
+        private const string ShowUserAndProjectListCommand = nameof(ShowUserAndProjectListCommand);
+
         /// <summary>
         /// Command ID.
         /// </summary>
@@ -87,17 +90,23 @@ namespace GoogleCloudExtension.UserAndProjectList
         /// <param name="e">The event args.</param>
         private void ShowToolWindow(object sender, EventArgs e)
         {
-            // Get the instance number 0 of this tool window. This window is single instance so this instance
-            // is actually the only one.
-            // The last flag is set to true so that if the tool window does not exists it will be created.
-            ToolWindowPane window = _package.FindToolWindow(typeof(UserAndProjectListWindow), 0, true);
-            if ((null == window) || (null == window.Frame))
-            {
-                throw new NotSupportedException("Cannot create tool window");
-            }
+            ExtensionAnalytics.ReportCommand(
+                ShowUserAndProjectListCommand,
+                CommandInvocationSource.ToolsMenu,
+                () =>
+                {
+                    // Get the instance number 0 of this tool window. This window is single instance so this instance
+                    // is actually the only one.
+                    // The last flag is set to true so that if the tool window does not exists it will be created.
+                    ToolWindowPane window = _package.FindToolWindow(typeof(UserAndProjectListWindow), 0, true);
+                    if ((null == window) || (null == window.Frame))
+                    {
+                        throw new NotSupportedException("Cannot create tool window");
+                    }
 
-            IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
-            Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                    IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
+                    Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                });
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/DeploymentUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/DeploymentUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2015 Google Inc. All Rights Reserved.
 // Licensed under the Apache License Version 2.0.
 
+using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.DeploymentDialog;
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.GCloud.Dnx;
@@ -11,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.Utils
 {
@@ -53,6 +55,7 @@ namespace GoogleCloudExtension.Utils
             else
             {
                 var runtime = DnxRuntimeInfo.GetRuntimeInfo(startupProject.Runtime);
+                ExtensionAnalytics.ReportEvent("RuntimeNotSupportedError", startupProject.Runtime.ToString());
                 AppEngineOutputWindow.OutputLine($"Runtime {runtime.DisplayName} is not supported for project {startupProject.Name}");
                 VsShellUtilities.ShowMessageBox(
                     serviceProvider,
@@ -64,7 +67,7 @@ namespace GoogleCloudExtension.Utils
             }
         }
 
-        public static async void DeployProjectAsync(
+        public static async Task<bool> DeployProjectAsync(
             Project startupProject,
             IList<Project> projects,
             string versionName,
@@ -72,6 +75,8 @@ namespace GoogleCloudExtension.Utils
             bool preserveOutput,
             Credentials accountAndProject)
         {
+            bool result = false;
+
             try
             {
                 StatusbarHelper.SetText("Deployment to AppEngine started...");
@@ -96,6 +101,8 @@ namespace GoogleCloudExtension.Utils
 
                 StatusbarHelper.SetText("Deployment Succeeded");
                 AppEngineOutputWindow.OutputLine("Deployment Succeeded.");
+
+                result = true;
             }
             catch (GCloudException ex)
             {
@@ -113,6 +120,8 @@ namespace GoogleCloudExtension.Utils
                 StatusbarHelper.HideDeployAnimation();
                 GoogleCloudExtensionPackage.IsDeploying = false;
             }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
This change adds the necessary infrastructure for Google analytics
reporting to the extension as well as adding reporting points to
report interesting usage points:
- Report each command being executed and where they are executed from,
  tools menu, context menu or button.
  - Also report success/failure for each command.
- Report windows being opened.
- Report unsupported runtimes being targetted by projects.

Many thanks to @chrsmith for the work he did on the analytics on PowerShell as I got the reporter class from there, with some adaptation so I can use it on the extension. As he did there I am using a private property ID until it is the right time to hookup with the GCloud ID if we want to go that route.

The check for whether the reporting is enabled or not is only done once per session, so if the user ever changes this setting Visual Studio will have to be restarted in order for the change to be picked up. I did this way to avoid having to call `gcloud` every time we send data, and also it because it is a setting that will not change that often anyway.

The user id is generated randomly, `new Guid()` in every session, perhaps it would make sense to create it once the very first time the extension is loaded and keep it that way, it seems that otherwise the number of active sessions is going to be wrong.
