### PR TITLE
Adding generation of ClientId.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleAnalyticsReporter.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleAnalyticsReporter.cs
@@ -65,20 +65,21 @@ namespace GoogleCloudExtension.Utils
         /// The client ID being used by this reporter.
         /// Note: This ID is generated with every instance, which is why is important
         /// to share the instance.
-        /// TODO: Perhaps accept the ID from the caller.
         /// </summary>
-        public string ClientId { get; } = Guid.NewGuid().ToString();
+        public string ClientId { get; }
 
         /// <summary>
         /// Initializes the instance.
         /// </summary>
         /// <param name="propertyId">The property ID to use, string with the format US-XXXX. Must not be null.</param>
         /// <param name="appName">The name of the app for which this reporter is reporting. Must not be null.</param>
+        /// <param name="clientId">The client id to use when reporting, if null a new random Guid will be generated.</param>
         /// <param name="appVersion">Optional, the app version. Defaults to null.</param>
         /// <param name="debug">Optional, whether this reporter is in debug mode. Defaults to false.</param>
         public GoogleAnalyticsReporter(
             string propertyId,
             string appName,
+            string clientId = null,
             string appVersion = null,
             bool debug = false)
         {
@@ -87,6 +88,7 @@ namespace GoogleCloudExtension.Utils
             _appName = appName;
             _appVersion = appVersion;
             _debug = debug;
+            ClientId = clientId ?? Guid.NewGuid().ToString();
             _baseHitData = MakeBaseHitData();
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
@@ -49,6 +49,8 @@ namespace GoogleCloudExtension
         /// </summary>
         public const string PackageGuidString = "3784fd98-7fcc-40fc-be3b-b68334735af2";
 
+        private DTE _dteInstance;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DeployToAppEngine"/> class.
         /// </summary>
@@ -75,11 +77,12 @@ namespace GoogleCloudExtension
             UserAndProjectListWindowCommand.Initialize(this);
             DeployToAppEngineContextMenuCommand.Initialize(this);
             AddNewAccountCommand.Initialize(this);
+            ExtensionAnalytics.Initialize(this);
 
             ExtensionAnalytics.ReportStartSession();
 
-            var dte = (DTE)Package.GetGlobalService(typeof(DTE));
-            dte.Events.DTEEvents.OnBeginShutdown += DTEEvents_OnBeginShutdown;
+            _dteInstance = (DTE)Package.GetGlobalService(typeof(DTE));
+            _dteInstance.Events.DTEEvents.OnBeginShutdown += DTEEvents_OnBeginShutdown;
         }
 
         private void DTEEvents_OnBeginShutdown()


### PR DESCRIPTION
With this change we can generate a persistent client identifier, which is just a Guid with no PII, to track unique sessions of the extension.
This Guid is stored in the user settings area of the registry.
