### PR TITLE
Need to add vm: true, to ensure gcloud parses app.yaml.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/AppEngineClient.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/AppEngineClient.cs
@@ -33,6 +33,7 @@ namespace GoogleCloudExtension.GCloud
         // will send the entire app to the server, which can take a long while.
         private const string AppYamlContent =
             "runtime: custom\n" +
+            "vm: true\n" +
             "api_version: 1\n" +
             "skip_files: \n" +
             "- ^.*$";


### PR DESCRIPTION
With the latest build of `glcoud` the `vm: true` setting needs to be there or the deployment will fail because no `URLMap` entries are defined.
