### PR TITLE
Fixing crash while parsing output on startup.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -258,10 +258,17 @@ namespace GoogleCloudExtension.GCloud
         /// <returns>The task with the result from reading the property.</returns>
         public async Task<string> GetPropertyAsync(string group, string property)
         {
-            Debug.WriteLine($"Reading property gcloud {group}/{property}");
-            var config = await GetJsonOutputAsync<JObject>($"config list {group}/{property}");
-            var groupObject = config?[group];
-            return (string)groupObject?[property];
+            try
+            {
+                Debug.WriteLine($"Reading property gcloud {group}/{property}");
+                var config = await GetJsonOutputAsync<JObject>($"config list {group}/{property}");
+                var groupObject = config?[group];
+                return (string)groupObject?[property];
+            }
+            catch (GCloudException)
+            {
+                return null;
+            }
         }
 
         public bool ValidateGCloudInstallation()

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/ProcessUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/ProcessUtils.cs
@@ -112,8 +112,15 @@ namespace GoogleCloudExtension.GCloud
             {
                 throw new JsonOutputException($"Failed to execute command: {file} {args}\n{output.Error}");
             }
-            var parsed = JsonConvert.DeserializeObject<T>(output.Output);
-            return ValueOrDefault(parsed);
+            try
+            {
+                var parsed = JsonConvert.DeserializeObject<T>(output.Output);
+                return ValueOrDefault(parsed);
+            }
+            catch (JsonSerializationException)
+            {
+                throw new JsonOutputException($"Failed to parse output of command: {file} {args}\n{output.Output}");
+            }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
+++ b/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="0.4.20160105.1" Language="en-US" Publisher="Google Inc." />
+    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="0.4.20160106" Language="en-US" Publisher="Google Inc." />
     <DisplayName>Google Cloud Platform Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">Tools to develop applications for Google Cloud Platform.</Description>
     <MoreInfo>https://github.com/GoogleCloudPlatform/gcloud-visualstudio</MoreInfo>


### PR DESCRIPTION
Because `gcloud` can output invalid json (such as an error message) while querying for property values if `gcloud init` was never used, we need to harden that code or the extension will crash on startup as it tries to determine if analytics reporting is enabled or not.
This change just ensures that the `JsonSerializationException` is handled if an invalid Json string is emitted by a `gcloud` command.
