### PR TITLE
Using Mono temporatily as the main runtime.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/AppEngineClient.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/AppEngineClient.cs
@@ -24,7 +24,7 @@ namespace GoogleCloudExtension.GCloud
         // The Dockefile to use for the specified runtime.
         // {0}, the version of the runtime.
         private const string DockerfileTemplate =
-            "FROM b.gcr.io/aspnet-docker/dotnet:{0}\n" +
+            "FROM b.gcr.io/aspnet-docker/aspnet-mono:{0}\n" +
             "ADD ./ /app\n" +
             "RUN chmod +x /app/app_engine_start\n";
 
@@ -234,7 +234,7 @@ namespace GoogleCloudExtension.GCloud
 
             // This is a dependency on the fact that DNU is a batch file, but it has to be launched this way.
             callback($"Preparing app bundle in {appTempPath}.");
-            var frameworkName = DnxRuntimeInfo.DnxCore50FrameworkName;
+            var frameworkName = DnxRuntimeInfo.Dnx451FrameworkName;
             string command = $"/c dnu publish \"{projectPath}\" --out \"{appTempPath}\" --framework {frameworkName} --configuration release";
             callback($"Executing command: {command}");
             var result = await ProcessUtils.RunCommandAsync("cmd.exe", command, (s, e) => callback(e.Line), environment);

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/DnxEnvironment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/DnxEnvironment.cs
@@ -25,7 +25,7 @@ namespace GoogleCloudExtension.GCloud.Dnx
         // Names for the runtime to use depending on the runtime.
         //   {0} is the bitness of the os, x86 or x64.
         //   {1} is the version of the runtime.
-        private const string DnxCore50RuntimeNameFormat = "dnx-coreclr-win-{0}.{1}";
+        private const string Dnx451RuntimeNameFormat = "dnx-clr-win-{0}.{1}";
 
         private static readonly List<string> s_VSKeysToCheck = new List<string>
         {
@@ -51,7 +51,7 @@ namespace GoogleCloudExtension.GCloud.Dnx
             var userDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             string bitness = Environment.Is64BitProcess ? "x64" : "x86";
 
-            var runtimeName = String.Format(DnxCore50RuntimeNameFormat, bitness, DnxVersion);
+            var runtimeName = String.Format(Dnx451RuntimeNameFormat, bitness, DnxVersion);
             var runtimeRelativePath = String.Format(DnxRuntimesBinPathFormat, runtimeName);
             Debug.WriteLine($"Using runtime path: {runtimeRelativePath}");
 

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/Project.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Dnx/Project.cs
@@ -69,8 +69,8 @@ namespace GoogleCloudExtension.GCloud.Dnx
         /// </summary>
         private static readonly IList<DnxRuntimeInfo> s_PreferredRuntimes = new List<DnxRuntimeInfo>
         {
+            DnxRuntimeInfo.GetRuntimeInfo(DnxRuntime.Dnx451),
             DnxRuntimeInfo.GetRuntimeInfo(DnxRuntime.DnxCore50),
-            DnxRuntimeInfo.GetRuntimeInfo(DnxRuntime.Dnx451)
         };
 
         private DnxRuntime GetProjectRuntime() => s_PreferredRuntimes

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -258,10 +258,17 @@ namespace GoogleCloudExtension.GCloud
         /// <returns>The task with the result from reading the property.</returns>
         public async Task<string> GetPropertyAsync(string group, string property)
         {
-            Debug.WriteLine($"Reading property gcloud {group}/{property}");
-            var config = await GetJsonOutputAsync<JObject>($"config list {group}/{property}");
-            var groupObject = config?[group];
-            return (string)groupObject?[property];
+            try
+            {
+                Debug.WriteLine($"Reading property gcloud {group}/{property}");
+                var config = await GetJsonOutputAsync<JObject>($"config list {group}/{property}");
+                var groupObject = config?[group];
+                return (string)groupObject?[property];
+            }
+            catch (GCloudException)
+            {
+                return null;
+            }
         }
 
         public bool ValidateGCloudInstallation()

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/ProcessUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/ProcessUtils.cs
@@ -112,8 +112,15 @@ namespace GoogleCloudExtension.GCloud
             {
                 throw new JsonOutputException($"Failed to execute command: {file} {args}\n{output.Error}");
             }
-            var parsed = JsonConvert.DeserializeObject<T>(output.Output);
-            return ValueOrDefault(parsed);
+            try
+            {
+                var parsed = JsonConvert.DeserializeObject<T>(output.Output);
+                return ValueOrDefault(parsed);
+            }
+            catch (JsonSerializationException)
+            {
+                throw new JsonOutputException($"Failed to parse output of command: {file} {args}\n{output.Output}");
+            }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/DeploymentUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/DeploymentUtils.cs
@@ -43,7 +43,7 @@ namespace GoogleCloudExtension.Utils
             }
 
             // We only support the CoreCLR runtime.
-            if (startupProject.Runtime == DnxRuntime.DnxCore50)
+            if (startupProject.Runtime == DnxRuntime.Dnx451)
             {
                 var window = new DeploymentDialogWindow(new DeploymentDialogWindowOptions
                 {
@@ -59,7 +59,7 @@ namespace GoogleCloudExtension.Utils
                 AppEngineOutputWindow.OutputLine($"Runtime {runtime.DisplayName} is not supported for project {startupProject.Name}");
                 VsShellUtilities.ShowMessageBox(
                     serviceProvider,
-                    $"Runtime {runtime.DisplayName} is not supported. Project {startupProject.Name} needs to target {DnxRuntimeInfo.DnxCore50DisplayString}.",
+                    $"Runtime {runtime.DisplayName} is not supported. Project {startupProject.Name} needs to target {DnxRuntimeInfo.Dnx451DisplayString}.",
                     "Runtime not supported",
                     OLEMSGICON.OLEMSGICON_INFO,
                     OLEMSGBUTTON.OLEMSGBUTTON_OK,

--- a/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
+++ b/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="0.4.20160105.1" Language="en-US" Publisher="Google Inc." />
+    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="0.5.20160106" Language="en-US" Publisher="Google Inc." />
     <DisplayName>Google Cloud Platform Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">Tools to develop applications for Google Cloud Platform.</Description>
     <MoreInfo>https://github.com/GoogleCloudPlatform/gcloud-visualstudio</MoreInfo>


### PR DESCRIPTION
This change makes the Mono runtime the main runtime for executing apps
in Managed VMs in AppEngine. With this change more libraries will be
compatible.
