### PR TITLE
Fixing disabled commands.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/WeakCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/WeakCommand.cs
@@ -33,7 +33,7 @@ namespace GoogleCloudExtension.Utils
 
         public bool CanExecute(object parameter)
         {
-            return parameter != null && (parameter is T) && CanExecuteCommand;
+            return CanExecuteCommand;
         }
 
         public void Execute(object parameter)

--- a/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AppEngineApps/AppEngineAppsToolViewModel.cs
@@ -162,6 +162,11 @@ namespace GoogleCloudExtension.AppEngineApps
 
         private async void OnOpenApp(ModuleAndVersion app)
         {
+            if (app == null)
+            {
+                return;
+            }
+
             ExtensionAnalytics.ReportStartCommand(OpenAppEngineVersionCommand, CommandInvocationSource.Button);
 
             try
@@ -189,6 +194,11 @@ namespace GoogleCloudExtension.AppEngineApps
 
         private async void OnDeleteVersion(ModuleAndVersion app)
         {
+            if (app == null)
+            {
+                return;
+            }
+
             ExtensionAnalytics.ReportStartCommand(DeleteAppEngineVersionCommand, CommandInvocationSource.Button);
 
             try
@@ -214,6 +224,11 @@ namespace GoogleCloudExtension.AppEngineApps
 
         private async void OnSetDefaultVersion(ModuleAndVersion app)
         {
+            if (app == null)
+            {
+                return;
+            }
+
             ExtensionAnalytics.ReportStartCommand(SetAppEngineVersionDefaultCommand, CommandInvocationSource.Button);
 
             try


### PR DESCRIPTION
Because of an unfortunate bug, the buttons in the AppEngine tool window are always disabled which makes the window pretty much useless. This fix solve that.
The idea behind the fix is that WPF only checks once if the command is enable/disabled, because when this happens there's no selected app the commands end up being disabled. The implementation of the commands is not complete. I have another change in flight for the master branch with the full fix, this is a smaller fix for the alpha.
