### PR TITLE
Submit updated utils

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleCloudExtension.Utils.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleCloudExtension.Utils.csproj
@@ -36,6 +36,10 @@
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -50,7 +54,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BooleanConverter.cs" />
+    <Compile Include="JsonOutputException.cs" />
     <Compile Include="Model.cs" />
+    <Compile Include="ProcessUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VisibilityConverter.cs" />
     <Compile Include="WeakAction.cs" />
@@ -59,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/JsonOutputException.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/JsonOutputException.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace GoogleCloudExtension.Utils
+{
+    /// <summary>
+    /// Exception thrown when there's a problem parsing json output from a process.
+    /// </summary>
+    [Serializable]
+    public class JsonOutputException : Exception
+    {
+        public JsonOutputException()
+        {
+        }
+
+        public JsonOutputException(string message) : base(message)
+        {
+        }
+
+        public JsonOutputException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected JsonOutputException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/ProcessUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/ProcessUtils.cs
@@ -1,0 +1,218 @@
+﻿// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License Version 2.0.
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.Utils
+{
+    /// <summary>
+    /// This class contains the output of a running process.
+    /// </summary>
+    public sealed class ProcessOutput
+    {
+        /// <summary>
+        /// Whether the process succeeded or not.
+        /// </summary>
+        public bool Succeeded { get; }
+
+        /// <summary>
+        /// The complete contents of the stderr stream.
+        /// </summary>
+        public string StandardError { get; }
+
+        /// <summary>
+        /// The complete contents of the stdout stream.
+        /// </summary>
+        public string StandardOutput { get; }
+
+        public ProcessOutput(bool succeeded, string standardOutput, string standardError)
+        {
+            Succeeded = succeeded;
+            StandardOutput = standardOutput;
+            StandardError = standardError;
+        }
+    }
+
+    /// <summary>
+    /// The output streams from a process.
+    /// </summary>
+    public enum OutputStream
+    {
+        None,
+        StandardError,
+        StandardOutput
+    }
+
+    /// <summary>
+    /// Evemt args passed to the output handler of a process.
+    /// </summary>
+    public class OutputHandlerEventArgs : EventArgs
+    {
+        public string Line { get; }
+        public OutputStream OutputStream { get; }
+
+        public OutputHandlerEventArgs(string line, OutputStream stream)
+        {
+            Line = line;
+            OutputStream = stream;
+        }
+    }
+
+    /// <summary>
+    /// This class defines helper methods for starting sub-processes and getting the output from
+    /// the processes, including a helper to parse the output as json.
+    /// </summary>
+    public static class ProcessUtils
+    {
+        /// <summary>
+        /// Runs the given binary given by <paramref name="file"/> with the passed in <paramref name="args"/> and
+        /// reads the output of the new process as it happens, calling <paramref name="handler"/> with each line being output
+        /// by the process.
+        /// Uses <paramref name="environment"/> if provided to customize the environment of the child process.
+        /// </summary>
+        /// <param name="file">The path to the binary to execute, it should not be null.</param>
+        /// <param name="args">The arguments to pass to the binary to execute, it can be null.</param>
+        /// <param name="handler">The callback to call with wach line being oput by the process, it can be called outside
+        /// of the UI thread. Must not be null.</param>
+        /// <param name="environment">Optional parameter with values for environment variables to pass on to the child process.</param>
+        /// <returns></returns>
+        public static Task<bool> RunCommandAsync(
+            string file,
+            string args,
+            EventHandler<OutputHandlerEventArgs> handler,
+            IDictionary<string, string> environment)
+        {
+            var startInfo = GetStartInfoForInteractiveProcess(file, args, environment);
+
+            return Task.Run(async () =>
+            {
+                var process = Process.Start(startInfo);
+                var readErrorsTask = ReadLinesFromOutput(OutputStream.StandardError, process.StandardError, handler);
+                var readOutputTask = ReadLinesFromOutput(OutputStream.StandardOutput, process.StandardOutput, handler);
+                await readErrorsTask;
+                await readOutputTask;
+                process.WaitForExit();
+                return process.ExitCode == 0;
+            });
+        }
+
+        /// <summary>
+        /// Runs a process until it exists, returns it's complete output.
+        /// </summary>
+        /// <param name="file">The path to the exectuable.</param>
+        /// <param name="args">The arguments to pass to the executable.</param>
+        /// <param name="environment">The environment variables to use for the executable.</param>
+        /// <returns></returns>
+        public static Task<ProcessOutput> GetCommandOutputAsync(string file, string args, IDictionary<string, string> environment)
+        {
+            var startInfo = GetStartInfoForInteractiveProcess(file, args, environment);
+
+            return Task.Run(async () =>
+            {
+                var process = Process.Start(startInfo);
+                var readErrorsTask = process.StandardError.ReadToEndAsync();
+                var readOutputTask = process.StandardOutput.ReadToEndAsync();
+                process.WaitForExit();
+                var succeeded = process.ExitCode == 0;
+                return new ProcessOutput(
+                    succeeded: succeeded,
+                    standardOutput: await readOutputTask,
+                    standardError: await readErrorsTask);
+            });
+        }
+
+        /// <summary>
+        /// Launches a process with the given parameters and environment, does not parse the output.
+        /// </summary>
+        /// <param name="file">The file with the process to execute.</param>
+        /// <param name="args">The arguments for the process.</param>
+        /// <param name="environment">The environment to use for executing the proces.</param>
+        /// <returns>A task that will resolve to the exit code of the process.</returns>
+        public static Task<int> LaunchCommandAsync(string file, string args, IDictionary<string, string> environment)
+        {
+            var startInfo = GetBaseStartInfo(file, args, environment);
+            return Task.Run(() =>
+            {
+                var process = Process.Start(startInfo);
+                process.WaitForExit();
+                return process.ExitCode;
+            });
+        }
+
+        /// <summary>
+        /// Launches a process and parses its stdout stream as a json value to an instance of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to use to deserialize the stdout stream.</typeparam>
+        /// <param name="file">The path to the exectuable.</param>
+        /// <param name="args">The arguments to pass to the executable.</param>
+        /// <param name="environment">The environment to use for the executable.</param>
+        /// <returns></returns>
+        public static async Task<T> GetJsonOutputAsync<T>(string file, string args, IDictionary<string, string> environment)
+        {
+            var output = await ProcessUtils.GetCommandOutputAsync(file, args, environment);
+            if (!output.Succeeded)
+            {
+                throw new JsonOutputException($"Failed to execute command: {file} {args}\n{output.StandardError}");
+            }
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(output.StandardOutput);
+            }
+            catch (JsonSerializationException)
+            {
+                throw new JsonOutputException($"Failed to parse output of command: {file} {args}\n{output.StandardOutput}");
+            }
+        }
+
+        private static ProcessStartInfo GetBaseStartInfo(string file, string args, IDictionary<string, string> environment)
+        {
+            // Always start the tool in the user's home directory, avoid random directories
+            // coming from Visual Studio.
+            ProcessStartInfo result = new ProcessStartInfo
+            {
+                FileName = file,
+                Arguments = args,
+                WorkingDirectory = Environment.GetEnvironmentVariable("USERPROFILE"),
+            };
+
+            // Customize the environment for the incoming process.
+            if (environment != null)
+            {
+                foreach (var entry in environment)
+                {
+                    result.EnvironmentVariables[entry.Key] = entry.Value;
+                }
+            }
+
+            return result;
+        }
+
+        private static ProcessStartInfo GetStartInfoForInteractiveProcess(string file, string args, IDictionary<string, string> environment)
+        {
+            ProcessStartInfo startInfo = GetBaseStartInfo(file, args, environment);
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardInput = true;
+            return startInfo;
+        }
+
+        private static Task ReadLinesFromOutput(OutputStream outputStream, StreamReader stream, EventHandler<OutputHandlerEventArgs> handler)
+        {
+            return Task.Run(() =>
+            {
+                while (!stream.EndOfStream)
+                {
+                    var line = stream.ReadLine();
+                    handler(null, new OutputHandlerEventArgs(line, outputStream));
+                }
+            });
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/README.md
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/README.md
@@ -1,0 +1,40 @@
+# Design for the utils library used by the VS extension.
+
+This library contains various utilities used by the VS extension that
+are of general use.
+
+## Converters for WPF development.
+
+### BooleanConverter
+The `BooleanConverter` class implements a value converter incoming boolean values to either the value of the `TrueValue` or `FalseValue` properties.
+
+### VisiblityConverter
+The `VisiblityConverter` class implements a value converter that converts a boolean value to either `Visiblity.Visible` if the incoming value is `true` or `Visiblity.Collapsed` if the incoming value is `false`. As such is a specialized version of the `BooleanConverter` for visiblity.
+
+The common way of using this converter is to use it in a binding to a boolean property on the view model for the view, this boolean property controlling whether a UI item is visible or not.
+
+## Weak action handlers.
+This weak action handlers help to ensure that there will not be any leaks when binding UI elements to view models and models, ensuring that the models will not keep the UI elements unnecessary alive.
+
+### WeakDelegate.
+The `WeakDelegate` class implements the same interface as a delegate but keeping a weak reference back to the delegate target.
+
+### WeakAction.
+The `WeakAction` class implements a class similar to `Action` but using `WeakDelegate` instead of a regular delegate.
+
+Simple overloads of the generic are available with, 1, 2 ad no parameters.
+
+### WeakCommand.
+The `WeakCommand` class implements the `ICommand` interface using `WeakActions` to point back to the actual handler of the commands.
+
+There is a variang of `WeakCommand` that accept a parameter and another one that doesn't . The `WeakCommand` variant that accept commands ensures that the argument is not `null` before invoking the command, as it is expected that the command will only support non-null arguments.
+
+## ProcessUtils
+The `ProcessUtils` class provices helpers to run processes and read the `stdout` and `stderr` streams from the process.
+
+The class can run a sub-process in various modes:
+* Run the process and provide the lines of output via a callback, using the `ProcessUtils.RunCommandAsync` method. This method will return once the process exits. The resulting boolean will be `true` if the process suceeded (the exit code is 0) or false otherwise.
+* Run the process and collect all of the output from the process, using the `ProcessUtils.GetCommandOutputAsync` method. This method will run the process and collect all of the `stdout` and `stderr` output and return them, together with whether the process suceeded or not.
+* Run the process and only know if the process failed or not, using the `ProcessUtils.LaunchCommandAsync` method. This method will run the process and return whether the process failed or not but nothing else.
+
+On top of these ther eis a helper that will run the process using `ProcessUtils.GetCommandOutputAsync` and parse the `stdout` output, if the process suceeded, parse it as json output and return that, very very useful for parsing the output of running gcloud commands.

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Cleaning up the code in the extension as part of the Cloud Explorer work, now the GoogleCloudExtension.Utils library will contain all of the code of general use, such as the `ProcessUtils` class, and the GoogleCloudExtension.GCloud library will only deal with wrapping gcloud.

This commit PR also includes documentation on the library.
