### PR TITLE
Support for Windows views, some documentation

### DIFF
--- a/GoogleCloudExtension/GoogleAnalyticsUtils/GoogleAnalyticsReporter.cs
+++ b/GoogleCloudExtension/GoogleAnalyticsUtils/GoogleAnalyticsReporter.cs
@@ -47,11 +47,13 @@ namespace GoogleAnalyticsUtils
         private const string ClientIdParam = "cid";
         private const string AppNameParam = "an";
         private const string AppVersionParam = "av";
+        private const string ScreenNameParam = "cd";
 
         private const string VersionValue = "1";
         private const string EventTypeValue = "event";
         private const string SessionStartValue = "start";
         private const string SessionEndValue = "end";
+        private const string ScreenViewValue = "screenview";
 
         private readonly bool _debug;
         private readonly string _serverUrl;
@@ -109,11 +111,15 @@ namespace GoogleAnalyticsUtils
         /// <param name="action">The action that took place.</param>
         /// <param name="label">The label affected by the event.</param>
         /// <param name="value">The new value.</param>
-        public void ReportEvent(string category, string action, string label, int? value = null)
+        public void ReportEvent(string category, string action, string label = null, int? value = null)
         {
+            Preconditions.CheckNotNull(category, nameof(category));
+            Preconditions.CheckNotNull(action, nameof(action));
+
             // Data we will send along with the web request. Later baked into the HTTP
             // request's payload.
-            var hitData = new Dictionary<string, string>(_baseHitData) {
+            var hitData = new Dictionary<string, string>(_baseHitData)
+            {
                 { HitTypeParam, EventTypeValue },
                 { EventCategoryParam, category },
                 { EventActionParam, action },
@@ -126,6 +132,22 @@ namespace GoogleAnalyticsUtils
             {
                 hitData[EventValueParam] = value.ToString();
             }
+            SendHitData(hitData);
+        }
+
+        /// <summary>
+        /// Reports a window view.
+        /// </summary>
+        /// <param name="name">The name of the window. Must not be null.</param>
+        public void ReportScreen(string name)
+        {
+            Preconditions.CheckNotNull(name, nameof(name));
+
+            var hitData = new Dictionary<string, string>(_baseHitData)
+            {
+                { HitTypeParam, ScreenViewValue },
+                { ScreenNameParam, name },
+            };
             SendHitData(hitData);
         }
 

--- a/GoogleCloudExtension/GoogleAnalyticsUtils/README.md
+++ b/GoogleCloudExtension/GoogleAnalyticsUtils/README.md
@@ -1,0 +1,31 @@
+# GoogleAnalyticsUtils
+The GoogleAnalyticsUtils library implements the [Google Analytics Measurement protocol][1] to report events and screen views to Google Analytics.
+
+The class `AnalyticsReporter` implements the measurement protocol to report events and screen views.
+
+## Instantiation of the class
+In order to instantiate the class the following parameters are needed:
+* The `propertyId`, which should be obtained from Google Analytics. It is particular to the application being tracked.
+* The `appName`, which is the application name being tracked.
+* The `clientId`, which is a unique identifier that identifies the current _user_. This identifer should not be tied in any way to the actual identity of the user. A GUID is the ideal one. If no identifier is provided a temporary one, a GUID, is created for the session.
+  + If tracking of the same user accross sessions is desired, the GUID should be persisted.
+  + The user should explicitly opt-in to be tracked.
+* The `appVersion`, which is the version string for the app being tracked. This is optional.
+* Whether the tracker is in `debug` mode, which will output extra information to the output window while debugging.
+
+## Reporting events
+To report events you use the `ReportEvent()` method. An event is defined by at least two values, the `category` and the `action`, see the [Event Tracking](https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#event) section in the Measure Protocol for a description of the parameters.
+
+When designing how the events are reported, think about how they should be reported in the Analytics page, and what statistics you want to track.
+
+## Reporting screens
+To report a screen, or Windows being opened, use the `ReportScreen()` method. This method just accepts a string with the `name` of the screen. The best name would be the name of the class implementing the window being tracked. Like:
+```C#
+analytics.ReportScreen(nameof(MyWindow));
+```
+
+## Session reporting
+The analytics class also have functionality to report the start and end of a new session. This is reported using the `ReportStartSession()` and `ReportEndSession()` methods. These methods don't accept any parameters.
+
+
+[1]: https://developers.google.com/analytics/devguides/collection/protocol/v1/#getting-started


### PR DESCRIPTION
This PR adds support for reporting windows views, screens in the analytics documentation. There's also a new README.md file for the module.
