### PR TITLE
Hide empty zones

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -234,6 +234,12 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             IEnumerable<TreeNode> viewModels;
             if (_showZones)
             {
+                // This query creates the zone view model with the following steps:
+                //   * Create an object that represents the zone and the instances that must be shown (after filtering)
+                //     for that zone. The instances in the zone are sorted by their name.
+                //   * Filter out the zones that (after filtering instances) are empty.
+                //   * Sort the resulting zones by the zone name.
+                //   * Create the view model for each zone, containing the instances for that zone.
                 viewModels = _instancesPerZone
                     .Select(x => new
                     {
@@ -248,6 +254,11 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             }
             else
             {
+                // This query gets the list of view models for the instnaces with the following steps:
+                //   * Select all of the instances in all of the zones in a source list.
+                //   * Filters the instances according to the _showOnlyWindowsInstances setting.
+                //   * Sorts the resulting instances by name.
+                //   * Creates the view model for each instance.
                 viewModels = _instancesPerZone
                     .SelectMany(x => x.Instances)
                     .Where(x => _showOnlyWindowsInstances ? x.IsWindowsInstance() : true)

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -235,7 +235,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             if (_showZones)
             {
                 viewModels = _instancesPerZone
-                    .Select(x => new { Zone = x.Zone.Name, Instances = x.Instances.Where(i => _showOnlyWindowsInstances ? i.IsWindowsInstance() : true) })
+                    .Select(x => new
+                    {
+                        Zone = x.Zone.Name,
+                        Instances = x.Instances
+                            .Where(i => _showOnlyWindowsInstances ? i.IsWindowsInstance() : true)
+                            .OrderBy(i => i.Name)
+                    })
                     .Where(x => x.Instances.Count() > 0)
                     .OrderBy(x => x.Zone)
                     .Select(x => new ZoneViewModel(this, x.Zone, x.Instances.Select(i => new GceInstanceViewModel(this, i))));

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
@@ -47,20 +47,16 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         public object Item => new ZoneItem(_instancesPerZone.Zone);
 
-        public ZoneViewModel(GceSourceRootViewModel owner, InstancesPerZone instancesPerZone, bool onlyWindowsInstances)
+        internal ZoneViewModel(GceSourceRootViewModel owner, string name, IEnumerable<GceInstanceViewModel> instances)
         {
             _owner = owner;
-            _instancesPerZone = instancesPerZone;
 
-            var instancesToShow = instancesPerZone.Instances.Where(x => !onlyWindowsInstances || x.IsWindowsInstance()).ToList();
-
-            Caption = $"{instancesPerZone.Zone.Name} ({instancesToShow.Count})";
+            Caption = $"{name} ({instances.Count()})";
             Icon = s_zoneIcon.Value;
 
-            var viewModels = instancesToShow.Select(x => new GceInstanceViewModel(owner, x));
-            foreach (var viewModel in viewModels)
+            foreach (var instance in instances)
             {
-                Children.Add(viewModel);
+                Children.Add(instance);
             }
 
             var menuItems = new List<MenuItem>
@@ -69,18 +65,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 new MenuItem { Header = Resources.UiPropertiesMenuHeader, Command = new WeakCommand(OnPropertiesCommand) },
             };
             ContextMenu = new ContextMenu { ItemsSource = menuItems };
-
-            if (Children.Count == 0)
-            {
-                if (onlyWindowsInstances)
-                {
-                    Children.Add(s_noWindowsInstancesPlaceholder);
-                }
-                else
-                {
-                    Children.Add(s_noInstancesPlaceholder);
-                }
-            }
         }
 
         private void OnPropertiesCommand()


### PR DESCRIPTION
This PR hides the empty zones from the GCE listings, including those zones that become empty when the user filters out the non-Windows machines.

The PR accomplishes this but doing a bit of refactoring on how the zone view models are created, and how the queries that process the data to refresh the UI.

There's also a small cosmetic change, in which the GCE instances, or the zones, are sorted alphabetically.