### PR TITLE
Using the versioned app name when creating data sources.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
@@ -113,7 +113,7 @@ namespace GoogleCloudExtension.Accounts
                 ClientId = s_extensionCredentials.ClientId,
                 ClientSecret = s_extensionCredentials.ClientSecret
             };
-            var plusDataSource = new GPlusDataSource(result.GetGoogleCredential(), GoogleCloudExtensionPackage.ApplicationName);
+            var plusDataSource = new GPlusDataSource(result.GetGoogleCredential(), GoogleCloudExtensionPackage.VersionedApplicationName);
             var person = await plusDataSource.GetProfileAsync();
             result.AccountName = person.Emails.FirstOrDefault()?.Value;
             return result;

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/ExtensionAnalytics.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/ExtensionAnalytics.cs
@@ -127,7 +127,7 @@ namespace GoogleCloudExtension.Analytics
                     appName: GoogleCloudExtensionPackage.ApplicationName,
                     appVersion: GoogleCloudExtensionPackage.ApplicationVersion,
                     debug: debug,
-                    userAgent: GoogleCloudExtensionPackage.ApplicationName);
+                    userAgent: GoogleCloudExtensionPackage.VersionedApplicationName);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
@@ -231,13 +231,13 @@ namespace GoogleCloudExtension.CloudExplorer
         private static GPlusDataSource CreatePlusDataSource()
         {
             var currentCredential = CredentialsStore.Default.CurrentGoogleCredential;
-            return currentCredential != null ? new GPlusDataSource(currentCredential, GoogleCloudExtensionPackage.ApplicationName) : null;
+            return currentCredential != null ? new GPlusDataSource(currentCredential, GoogleCloudExtensionPackage.VersionedApplicationName) : null;
         }
 
         private static ResourceManagerDataSource CreateResourceManagerDataSource()
         {
             var currentCredential = CredentialsStore.Default.CurrentGoogleCredential;
-            return currentCredential != null ? new ResourceManagerDataSource(currentCredential, GoogleCloudExtensionPackage.ApplicationName) : null;
+            return currentCredential != null ? new ResourceManagerDataSource(currentCredential, GoogleCloudExtensionPackage.VersionedApplicationName) : null;
         }
 
         private void UpdateUserProfile()

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
@@ -87,7 +87,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
                 return new CloudSqlDataSource(
                     CredentialsStore.Default.CurrentProjectId,
                     CredentialsStore.Default.CurrentGoogleCredential,
-                    GoogleCloudExtensionPackage.ApplicationName);
+                    GoogleCloudExtensionPackage.VersionedApplicationName);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -194,7 +194,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 return new GceDataSource(
                     CredentialsStore.Default.CurrentProjectId,
                     CredentialsStore.Default.CurrentGoogleCredential,
-                    GoogleCloudExtensionPackage.ApplicationName);
+                    GoogleCloudExtensionPackage.VersionedApplicationName);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -124,7 +124,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
                 return new GcsDataSource(
                     CredentialsStore.Default.CurrentProjectId,
                     CredentialsStore.Default.CurrentGoogleCredential,
-                    GoogleCloudExtensionPackage.ApplicationName);
+                    GoogleCloudExtensionPackage.VersionedApplicationName);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
@@ -92,6 +92,11 @@ namespace GoogleCloudExtension
         /// </summary>
         public static string ApplicationVersion => s_appVersion.Value;
 
+        /// <summary>
+        /// Returns the versioned application name in the right format for analytics, etc...
+        /// </summary>
+        public static string VersionedApplicationName => $"{ApplicationName}/{ApplicationVersion}";
+
         public GoogleCloudExtensionPackage()
         {
             // Register all of the properties.

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
@@ -36,7 +36,7 @@ namespace GoogleCloudExtension.ManageAccounts
 
             AccountName = userAccount.AccountName;
 
-            var dataSource = new GPlusDataSource(userAccount.GetGoogleCredential(), GoogleCloudExtensionPackage.ApplicationName);
+            var dataSource = new GPlusDataSource(userAccount.GetGoogleCredential(), GoogleCloudExtensionPackage.VersionedApplicationName);
             var personTask = dataSource.GetProfileAsync();
 
             // TODO: Show the default image while it is being loaded.


### PR DESCRIPTION
This PR fixed #187 by adding a new variant of the app name, `VersionedAppName` which contains a string suitable to be added to the `User-Agent` when performing API calls.