### PR TITLE
Publishing dialog link manage accounts

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
@@ -25,7 +25,7 @@
                   SelectedItem="{Binding SelectedCredentials, Mode=TwoWay}" />
         <TextBlock Margin="0,5,0,0">
             <Hyperlink Command="{Binding ManageCredentialsCommand}">
-                <TextBlock Text="Manage Credentials" />
+                <TextBlock Text="{x:Static ext:Resources.GcePublishStepManageCredentialsCaption}" />
             </Hyperlink>
         </TextBlock>
         

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
@@ -17,30 +17,18 @@
                   IsSynchronizedWithCurrentItem="True"
                   SelectedItem="{Binding SelectedInstance, Mode=TwoWay}" />
 
-        <Grid Margin="0,5,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="25" />
-            </Grid.ColumnDefinitions>
-
-            <TextBlock Grid.ColumnSpan="2" Text="{x:Static ext:Resources.PublishDialogGceStepSelectCredentialsMessage}" />
-            <ComboBox ItemsSource="{Binding Credentials}"
-                      IsEnabled="{Binding Instances.IsCompleted}"
-                      IsSynchronizedWithCurrentItem="True"
-                      DisplayMemberPath="User"
-                      Grid.Row="1"
-                      SelectedItem="{Binding SelectedCredentials, Mode=TwoWay}" Margin="0,0,5,0" />
-            <Button Content="..."
-                    ToolTip="{x:Static ext:Resources.WindowsCredentialsChooserButtonToolTip}"
-                    Grid.Row="1"
-                    Grid.Column="1"
-                    Command="{Binding ManageCredentialsCommand}" />
-        </Grid>
+        <TextBlock Margin="0,5,0,0" Text="{x:Static ext:Resources.PublishDialogGceStepSelectCredentialsMessage}" />
+        <ComboBox ItemsSource="{Binding Credentials}"
+                  IsEnabled="{Binding Instances.IsCompleted}"
+                  IsSynchronizedWithCurrentItem="True"
+                  DisplayMemberPath="User"
+                  SelectedItem="{Binding SelectedCredentials, Mode=TwoWay}" />
+        <TextBlock Margin="0,5,0,0">
+            <Hyperlink Command="{Binding ManageCredentialsCommand}">
+                <TextBlock Text="Manage Credentials" />
+            </Hyperlink>
+        </TextBlock>
+        
 
         <CheckBox Margin="0,8,0,0"
                   IsEnabled="{Binding Instances.IsCompleted}"

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1654,6 +1654,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Manage Credentials.
+        /// </summary>
+        public static string GcePublishStepManageCredentialsCaption {
+            get {
+                return ResourceManager.GetString("GcePublishStepManageCredentialsCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Publishing {0} to Compute Engine..
         /// </summary>
         public static string GcePublishStepStartMessage {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1141,5 +1141,8 @@
     <value>Deleting version...</value>
     <comment>Message shown when a version is being deleted.</comment>
   </data>
+  <data name="GcePublishStepManageCredentialsCaption" xml:space="preserve">
+    <value>Manage Credentials</value>
+    <comment>Caption for the link shown in the GCE step of the publishing dialog for managing the credentials of the selected VM.</comment>
+  </data>
 </root>
-


### PR DESCRIPTION
This change updates the UI to use a hyperlink instead of the cryptic "..." button. The dialog step now looks like this:
<img width="502" alt="screen shot 2016-10-06 at 2 18 43 pm" src="https://cloud.githubusercontent.com/assets/9807532/19153788/d35e71e6-8bcf-11e6-8a2d-c79e8db1f540.png">
