### PR TITLE
Ensuring that we don't try to present when there's no data.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -208,6 +208,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
         {
             try
             {
+                _instancesPerZone = null;
                 _instancesPerZone = await _dataSource.Value.GetAllInstancesPerZonesAsync();
                 PresentViewModels();
 
@@ -236,6 +237,12 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         private void PresentViewModels()
         {
+            // If there's no data then there's nothing to do.
+            if (_instancesPerZone == null)
+            {
+                return;
+            }
+
             IEnumerable<TreeNode> viewModels;
             if (_showZones)
             {


### PR DESCRIPTION
This PR fixes issue #174, which occurs when the user clicks on the "Show only Windows instances" button while the data is being loaded. The fix checks if there's data to be presented before attempting to present the data.