### PR TITLE
Adding quotes for paths.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -108,7 +108,7 @@ namespace GoogleCloudExtension.GCloud
         private static string FormatCommand(string command, Context context)
         {
             var projectId = context?.ProjectId != null ? $"--project={context.ProjectId}" : "";
-            var credentialsPath = context?.CredentialsPath != null ? $"--credential-file-override={context.CredentialsPath}" : "";
+            var credentialsPath = context?.CredentialsPath != null ? $"--credential-file-override=\"{context.CredentialsPath}\"" : "";
             return $"gcloud {command} {projectId} {credentialsPath} --format=json";
         }
 


### PR DESCRIPTION
Every path passed down to the command line must be property quoted to avoid issues with spaces in the path.

In this case the `--credential-file-override` parameter is a path to the credentials .json file, and needs to be quoted.

Future arguments will be quoted in the same fashion.

Incidentally, quotes in the middle of the parameter as in:
```
gcloud --credential-file-override="c:\something or else\that.json"
```
Is fully supported.
