### PR TITLE
Updating the MoreInfo link to point to the docs page.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
+++ b/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
     <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="0.9.3.0" Language="en-US" Publisher="Google Inc." />
     <DisplayName>Google Cloud Tools for Visual Studio</DisplayName>
     <Description xml:space="preserve">Tools to develop applications for Google Cloud Platform.</Description>
-    <MoreInfo>https://github.com/GoogleCloudPlatform/gcloud-visualstudio</MoreInfo>
+    <MoreInfo>https://cloud.google.com/visual-studio/</MoreInfo>
     <License>License.txt</License>
     <Icon>logo_cloud_128.png</Icon>
     <PreviewImage>logo_cloud_512.png</PreviewImage>


### PR DESCRIPTION
This PR updates the link to point to the Visual Studio [page](https://cloud.google.com/visual-studio/).

This PR then fixes issue #182.