### PR TITLE
Using the project id instead of the project name.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -75,7 +75,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
 
         private void OnOpenOnCloudConsoleCommand()
         {
-            var url = $"https://console.cloud.google.com/sql/instances/{_instance.Name}/overview?project={_owner.Context.CurrentProject.Name}";
+            var url = $"https://console.cloud.google.com/sql/instances/{_instance.Name}/overview?project={_owner.Context.CurrentProject.ProjectId}";
             Process.Start(url);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -168,13 +168,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         private void OnNewAspNetInstanceCommand()
         {
-            var url = $"https://console.cloud.google.com/launcher/details/click-to-deploy-images/aspnet?project={Context.CurrentProject.Name}";
+            var url = $"https://console.cloud.google.com/launcher/details/click-to-deploy-images/aspnet?project={Context.CurrentProject.ProjectId}";
             Process.Start(url);
         }
 
         private void OnNewInstanceCommand()
         {
-            var url = $"https://console.cloud.google.com/compute/instancesAdd?project={Context.CurrentProject.Name}";
+            var url = $"https://console.cloud.google.com/compute/instancesAdd?project={Context.CurrentProject.ProjectId}";
             Process.Start(url);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
@@ -75,7 +75,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         private void OnNewInstanceCommand()
         {
-            var url = $"https://console.cloud.google.com/compute/instancesAdd?project={_owner.Context.CurrentProject.Name}&zone={_zone.Name}";
+            var url = $"https://console.cloud.google.com/compute/instancesAdd?project={_owner.Context.CurrentProject.ProjectId}&zone={_zone.Name}";
             Process.Start(url);
         }
     }


### PR DESCRIPTION
In all the cases we should be using the `ProjectId` instead of the `Name` property. The `Name` is the human friendly (and therefore not unique) string but all APIs and pages expect the `ProjectId` which is much more restricted and actually unique.