### PR TITLE
Metrics for unhandled errors

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.Analytics.Events
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
@@ -14,22 +14,18 @@ namespace GoogleCloudExtension.Analytics.Events
         private const string UnhandledExceptionEventName = "unhandledException";
         private const string ExceptionProperty = "exception";
 
-        public static AnalyticsEvent Create(Exception ex)
+        public static AnalyticsEvent Create(AggregateException ex)
         {
-            string name;
-            if (ex is AggregateException)
-            {
-                var aggregate = (AggregateException)ex;
-                name = aggregate.InnerException.GetType().Name;
-            }
-            else
-            {
-                name = ex.GetType().Name;
-            }
-
             return new AnalyticsEvent(
                 UnhandledExceptionEventName,
-                ExceptionProperty, name);
+                ExceptionProperty, ex.InnerException.GetType().Name);
+        }
+
+        public static AnalyticsEvent Create(Exception ex)
+        {
+            return new AnalyticsEvent(
+                UnhandledExceptionEventName,
+                ExceptionProperty, ex.GetType().Name);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.Analytics.Events
+{
+    /// <summary>
+    /// This event is sent every time that there's an unhandled exception.
+    /// </summary>
+    internal static class UnhandledExceptionEvent
+    {
+        private const string UnhandledExceptionEventName = "unhandledException";
+        private const string ExceptionProperty = "exception";
+
+        public static AnalyticsEvent Create(Exception ex)
+        {
+            string name;
+            if (ex is AggregateException)
+            {
+                var aggregate = (AggregateException)ex;
+                name = aggregate.InnerException.GetType().Name;
+            }
+            else
+            {
+                name = ex.GetType().Name;
+            }
+
+            return new AnalyticsEvent(
+                UnhandledExceptionEventName,
+                ExceptionProperty, name);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/UnhandledExceptionEvent.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace GoogleCloudExtension.Analytics.Events
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Analytics\Events\GcsBucketsLoadedEvent.cs" />
     <Compile Include="Analytics\Events\NewInstallEvent.cs" />
     <Compile Include="Analytics\Events\NewLoginEvent.cs" />
+    <Compile Include="Analytics\Events\UnhandledExceptionEvent.cs" />
     <Compile Include="Analytics\Events\UpgradeEvent.cs" />
     <Compile Include="AuthorizedNetworkManagement\AuthorizedNetworkModel.cs" />
     <Compile Include="AuthorizedNetworkManagement\AuthorizedNetworksViewModel.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/ErrorHandlerUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/ErrorHandlerUtils.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using GoogleCloudExtension.Analytics;
+using GoogleCloudExtension.Analytics.Events;
 using Microsoft.VisualStudio;
 using System;
 using System.Diagnostics;
@@ -42,6 +44,7 @@ namespace GoogleCloudExtension.Utils
                 {
                     throw;
                 }
+                EventsReporterWrapper.ReportEvent(UnhandledExceptionEvent.Create(ex));
                 UserPromptUtils.ExceptionPrompt(ex);
             }
             catch (Exception ex)
@@ -51,6 +54,7 @@ namespace GoogleCloudExtension.Utils
                 {
                     throw;
                 }
+                EventsReporterWrapper.ReportEvent(UnhandledExceptionEvent.Create(ex));
                 UserPromptUtils.ExceptionPrompt(ex);
             }
         }


### PR DESCRIPTION
Adding an event to reported to the metrics server when we encounter an unhandled exception. The name of the exception type will be reported.