### PR TITLE
Ensuring .resx file and .Designer.cs file are in sync.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -364,7 +364,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             IsLoading = true;
             Children.Clear();
             UpdateContextMenu();
-            Caption = Resources.CloudExplorerGaeUpdateTrafficSplitLoadingMessage;
+            Caption = Resources.CloudExplorerGaeUpdateTrafficSplitMessage;
             GaeDataSource datasource = root.DataSource.Value;
 
             try

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -576,7 +576,7 @@ namespace GoogleCloudExtension {
         /// <summary>
         ///   Looks up a localized string similar to Updating traffic split....
         /// </summary>
-        public static string CloudExplorerGaeUpdateTrafficSplitLoadingMessage {
+        public static string CloudExplorerGaeUpdateTrafficSplitMessage {
             get {
                 return ResourceManager.GetString("CloudExplorerGaeUpdateTrafficSplitMessage", resourceCulture);
             }


### PR DESCRIPTION
The .designer.cs file and the .resx file got out of sync and the name of the string didn't match. Because the designer.cs file still had the old name the extension builds, but it will not get the right string out of the resources.