### PR TITLE
Adding the external tools to the path.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreDeployment.cs
@@ -15,6 +15,7 @@
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.Utils;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -184,9 +185,15 @@ namespace GoogleCloudExtension.Deployment
             var arguments = $"publish \"{projectPath}\" " +
                 $"-o \"{stageDirectory}\" " +
                 "-c Release";
+            var externalTools = GetExternalToolsPath();
+            var env = new Dictionary<string, string>
+            {
+                { "PATH", $"{Environment.GetEnvironmentVariable("PATH")};{externalTools}" },
+            };
 
+            Debug.WriteLine($"Using tools from {externalTools}");
             outputAction($"dotnet {arguments}");
-            return ProcessUtils.RunCommandAsync(s_dotnetPath.Value, arguments, (o, e) => outputAction(e.Line));
+            return ProcessUtils.RunCommandAsync(s_dotnetPath.Value, arguments, (o, e) => outputAction(e.Line), env);
         }
 
         private static void CopyOrCreateAppYaml(string projectPath, string stageDirectory)
@@ -248,6 +255,12 @@ namespace GoogleCloudExtension.Deployment
         {
             var directory = Path.GetDirectoryName(projectPath);
             return Path.GetFileName(directory);
+        }
+
+        private static string GetExternalToolsPath()
+        {
+            var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            return Path.Combine(programFilesPath, @"Microsoft Visual Studio 14.0\Web\External");
         }
     }
 }


### PR DESCRIPTION
This PR adds the external tools (bower, grung, node, etc...) that come pre-installed with the [.NET Core tools](https://go.microsoft.com/fwlink/?LinkID=827546) for Visual Studio. By adding this to the path before the "dotnet publish" invocation we allow the publish process to use these tools instead of requiring the user to download and install node.js and bower separately. These are the same tools that are used from Visual Studio when the user published the app that way.