### PR TITLE
Using the right indexes.

### DIFF
--- a/GoogleCloudExtension/GoogleAnalyticsUtils/EventsReporter.cs
+++ b/GoogleCloudExtension/GoogleAnalyticsUtils/EventsReporter.cs
@@ -30,11 +30,11 @@ namespace GoogleAnalyticsUtils
 
         // The custom dimension index for the various properties sent to Google Analytics.
 
-        // IsUserSignedIn (cd16): true if a user is signed on, false otherwise.
-        private const int IsUserSignedInIndex = 16;
+        // IsInternalUser (cd16): true if the user is internal to Google, false otherwise.
+        private const int IsInternalUserIndex = 16;
 
-        // IsInternalUser (cd17): true if the user is internal to Google, false otherwise.
-        private const int IsInternalUserIndex = 17;
+        // IsUserSignedIn (cd17): true if a user is signed on, false otherwise.
+        private const int IsUserSignedInIndex = 17;
 
         // EventType (cd19): the event type.
         private const int EventTypeIndex = 19;


### PR DESCRIPTION
Flipping the indexes for the custom dimensions. Now the right values should be reported.

// cc @chrsmith, you will need to pick up this change for the next release. Nothing major, the events will still be reported.