### PR TITLE
Adding support for Windows Server 2016 images.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/InstanceExtensions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/InstanceExtensions.cs
@@ -27,12 +27,14 @@ namespace GoogleCloudExtension.DataSources
     {
         private const string WindowsServer2012License = "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2012-r2-dc";
         private const string WindowsServer2008License = "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2008-r2-dc";
+        private const string WindowsServer2016License = "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2016-dc";
         private const string SqlServerSaPasswordKey = "c2d-property-saPassword";
 
         private static readonly Dictionary<string, WindowsInstanceInfo> s_windowsLicenses = new Dictionary<string, WindowsInstanceInfo>
         {
             { WindowsServer2008License, new WindowsInstanceInfo(displayName: "Windows Server 2008 R2 Datacenter Edition", version: "2008", subversion: "RC2") },
             { WindowsServer2012License, new WindowsInstanceInfo(displayName: "Windows Server 2012 R2 Datacenter Edition", version: "2012", subversion: "RC2") },
+            { WindowsServer2016License, new WindowsInstanceInfo(displayName: "Windows Server 2016", version: "2016") }
         };
 
         public const string ProvisioningStatus = "PROVISIONING";

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/WindowsInstanceInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/WindowsInstanceInfo.cs
@@ -31,7 +31,7 @@ namespace GoogleCloudExtension.DataSources
         /// </summary>
         public string Subversion { get; }
 
-        public WindowsInstanceInfo(string displayName, string version, string subversion)
+        public WindowsInstanceInfo(string displayName, string version, string subversion = null)
         {
             DisplayName = displayName;
             Version = version;


### PR DESCRIPTION
This PR fixes issue #248 but adding the licenses for Windows Server 2016 to the list of supported Windows licenses. 