### PR TITLE
Fixing focus issues for dialogs

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddWindowsCredentialWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddWindowsCredentialWindow.cs
@@ -26,7 +26,7 @@ namespace GoogleCloudExtension.AddWindowsCredential
         public AddWindowsCredentialViewModel ViewModel { get; }
 
         private AddWindowsCredentialWindow(Instance instance)
-            : base(String.Format(GoogleCloudExtension.Resources.ResetPasswordWindowTitle, instance.Name))
+            : base(GoogleCloudExtension.Resources.AddWindowsCredentialTitle)
         {
             ViewModel = new AddWindowsCredentialViewModel(this, instance);
             Content = new AddWindowsCredentialWindowContent

--- a/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddwindowsCredentialWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddwindowsCredentialWindowContent.xaml
@@ -41,10 +41,8 @@
                      Margin="0,0,0,24"
                      Style="{StaticResource CommonTextBoxStyle}">
                 <TextBox.ToolTip>
-                    <TextBlock Style="{StaticResource CommonTextStyle}"
-                               MaxWidth="200px"
-                               Text="{x:Static ext:Resources.AddWindowsCredentialToolTip}"
-                               TextWrapping="Wrap" />
+                    <TextBlock Style="{StaticResource CommonToolTipTextStyle}"
+                               Text="{x:Static ext:Resources.AddWindowsCredentialToolTip}" />
                 </TextBox.ToolTip>
             </TextBox>
 

--- a/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddwindowsCredentialWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddwindowsCredentialWindowContent.xaml
@@ -19,6 +19,10 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicSmall}" />
+    </UserControl.Style>
+
     <theming:CommonDialogWindowBaseContent>
         <theming:CommonDialogWindowBaseContent.Buttons>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiSaveButtonCaption}"
@@ -28,14 +32,21 @@
                                       IsCancel="True"/>
         </theming:CommonDialogWindowBaseContent.Buttons>
 
-        <StackPanel MinWidth="315">
+        <StackPanel>
             <Label Content="{x:Static ext:Resources.AddWindowsCredentialUserNameCaption}"
                    Style="{StaticResource CommonLabelStyle}"
                    Target="{Binding ElementName=_userName}"/>
             <TextBox Text="{Binding UserName, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                      x:Name="_userName"
                      Margin="0,0,0,24"
-                     Style="{StaticResource CommonTextBoxStyle}"/>
+                     Style="{StaticResource CommonTextBoxStyle}">
+                <TextBox.ToolTip>
+                    <TextBlock Style="{StaticResource CommonTextStyle}"
+                               MaxWidth="200px"
+                               Text="{x:Static ext:Resources.AddWindowsCredentialToolTip}"
+                               TextWrapping="Wrap" />
+                </TextBox.ToolTip>
+            </TextBox>
 
             <GroupBox Header="{x:Static ext:Resources.AddWindowsCredentialPasswordGroupHeader}">
                 <StackPanel>

--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksViewModel.cs
@@ -36,7 +36,7 @@ namespace GoogleCloudExtension.AuthorizedNetworkManagement
         /// <summary>
         /// True if any changes to the authorized networks occured.
         /// </summary>
-        public bool HasChanges;
+        public bool HasChanges { get; }
 
         public AuthorizedNetworkChange(IList<AuthorizedNetworkModel> authorizedNetworks)
         {
@@ -150,7 +150,7 @@ namespace GoogleCloudExtension.AuthorizedNetworkManagement
                 Name = NetworkName,
                 Value = NetworkValue
             };
-            Networks.Add(new AuthorizedNetworkModel(acl));
+            Networks.Add(new AuthorizedNetworkModel(acl, newNetwork: true));
 
             NetworkValue = "";
             NetworkName = "";

--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindow.cs
@@ -26,7 +26,7 @@ namespace GoogleCloudExtension.AuthorizedNetworkManagement
             (AuthorizedNetworksViewModel)((AuthorizedNetworksWindowContent)Content).DataContext;
 
         private AuthorizedNetworksWindow(DatabaseInstance instance) :
-            base(GoogleCloudExtension.Resources.AuthorizedNetworksWindowCaption, width: 450, height: 550)
+            base(GoogleCloudExtension.Resources.AuthorizedNetworksWindowCaption)
         {
             Content = new AuthorizedNetworksWindowContent
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindowContent.xaml
@@ -7,12 +7,21 @@
              xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
              mc:Ignorable="d" 
-             d:DataContext="{d:DesignInstance {x:Type local:AuthorizedNetworksViewModel}}"
-             d:DesignHeight="500" d:DesignWidth="450">
+             d:DataContext="{d:DesignInstance {x:Type local:AuthorizedNetworksViewModel}}">
 
     <UserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        </ResourceDictionary>
     </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicLarge}" />
+    </UserControl.Style>
 
     <theming:CommonDialogWindowBaseContent>
         <theming:CommonDialogWindowBaseContent.Buttons>
@@ -24,50 +33,50 @@
 
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="20px" />
-                <RowDefinition Height="80px"/>
+                <RowDefinition Height="auto" />
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <TextBlock TextWrapping="Wrap" Margin="3,0,3,5"
-                       Text="{x:Static ext:Resources.AuthorizedNetworksWindowMessage}"/>
+            <!-- Header of the dialog. -->
+            <StackPanel>
+                <Label Content="{x:Static ext:Resources.AuthorizedNetworksWindowMessage}"
+                   Style="{StaticResource CommonLabelStyle}" />
 
-            <Border Grid.Row="1" BorderBrush="Black" BorderThickness="1px">
-                <Grid Background="#FFECECEC">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="50px" />
-                        <RowDefinition Height="25px"/>
-                    </Grid.RowDefinitions>
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                <GroupBox Grid.Row="1"
+                      Header="Network"
+                      Style="{StaticResource CommonGroupBoxStyle}">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
 
-                        <TextBlock Margin="5px, 2px" 
-                                   TextWrapping="Wrap"  VerticalAlignment="Center"  
-                                   Text="{x:Static ext:Resources.AuthorizedNetworksWindowNameTextBoxTitle}"/>
-                        <TextBox Grid.Column="1" Margin="5px, 2px" 
+                            <TextBlock Margin="5px, 2px" 
+                                       TextWrapping="Wrap"  VerticalAlignment="Center"  
+                                       Text="{x:Static ext:Resources.AuthorizedNetworksWindowNameTextBoxTitle}"/>
+                            <TextBox Grid.Column="1" Margin="5px, 2px" 
                                  Text="{Binding NetworkName, Mode=TwoWay}" Height="20px"/>
 
-                        <TextBlock Grid.Row="1" Margin="5px, 2px" 
+                            <TextBlock Grid.Row="1" Margin="5px, 2px" 
                                    TextWrapping="Wrap"  VerticalAlignment="Center"  
                                    Text="{x:Static ext:Resources.AuthorizedNetworksWindowValueTextBoxTitle}"/>
-                        <TextBox Grid.Row="1" Grid.Column="1" Margin="5px, 2px"
+                            <TextBox Grid.Row="1" Grid.Column="1" Margin="5px, 2px"
                                  Text="{Binding NetworkValue, Mode=TwoWay}"  Height="20px" />
-                    </Grid>
+                        </Grid>
 
-                    <Grid Grid.Row="1">
-                        <Button Margin="5px, 2px" Width="Auto" Command="{Binding AddNetwork}"
+                        <Button Command="{Binding AddNetwork}"
                                 Content="{x:Static ext:Resources.AuthorizedNetworksWindowAddNetworkButton}"
-                                HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                    </Grid>
-                </Grid>
-            </Border>
+                                HorizontalAlignment="Right"
+                                Margin="0,18,0,0"
+                                Style="{StaticResource CommonButtonDynamicStyle}"/>
+                    </StackPanel>
+                </GroupBox>
+            </StackPanel>
 
             <Grid Grid.Row="2" Margin="3px, 5px">
                 <ListView ItemsSource="{Binding Networks}">

--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindowContent.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:GoogleCloudExtension.AuthorizedNetworkManagement"
              xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
+             xmlns:utils="clr-namespace:GoogleCloudExtension.Utils;assembly=GoogleCloudExtension.Utils"
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance {x:Type local:AuthorizedNetworksViewModel}}">
 
@@ -14,8 +15,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../Theming/CommonResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
-            <BooleanToVisibilityConverter x:Key="BoolToVis" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -23,7 +22,7 @@
         <Binding Source="{StaticResource CommonDialogStyleDynamicLarge}" />
     </UserControl.Style>
 
-    <theming:CommonDialogWindowBaseContent>
+    <theming:CommonDialogWindowBaseContent HasBanner="True">
         <theming:CommonDialogWindowBaseContent.Buttons>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiSaveButtonCaption}"
                                       IsDefault="True"
@@ -34,39 +33,51 @@
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
             <!-- Header of the dialog. -->
-            <StackPanel>
-                <Label Content="{x:Static ext:Resources.AuthorizedNetworksWindowMessage}"
-                   Style="{StaticResource CommonLabelStyle}" />
-
+            <StackPanel Margin="0,0,0,18">
                 <GroupBox Grid.Row="1"
-                      Header="Network"
-                      Style="{StaticResource CommonGroupBoxStyle}">
+                          Header="Network"
+                          Style="{StaticResource CommonGroupBoxStyle}">
                     <StackPanel>
                         <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*" />
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="0.5*" />
+                                <ColumnDefinition Width="0.5*" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBlock Margin="5px, 2px" 
-                                       TextWrapping="Wrap"  VerticalAlignment="Center"  
-                                       Text="{x:Static ext:Resources.AuthorizedNetworksWindowNameTextBoxTitle}"/>
-                            <TextBox Grid.Column="1" Margin="5px, 2px" 
-                                 Text="{Binding NetworkName, Mode=TwoWay}" Height="20px"/>
+                            <Label Margin="0,0,0,5" 
+                                   VerticalAlignment="Center"
+                                   Content="{x:Static ext:Resources.AuthorizedNetworksWindowNameTextBoxTitle}"
+                                   Target="{Binding ElementName=_networkName}"
+                                   Style="{StaticResource CommonLabelStyle}" />
+                            <TextBox x:Name="_networkName"
+                                     Grid.Column="1"
+                                     Margin="0,0,0,5"
+                                     Text="{Binding NetworkName, Mode=TwoWay}"
+                                     Style="{StaticResource CommonTextBoxStyle}"/>
+                        </Grid>
 
-                            <TextBlock Grid.Row="1" Margin="5px, 2px" 
-                                   TextWrapping="Wrap"  VerticalAlignment="Center"  
-                                   Text="{x:Static ext:Resources.AuthorizedNetworksWindowValueTextBoxTitle}"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Margin="5px, 2px"
-                                 Text="{Binding NetworkValue, Mode=TwoWay}"  Height="20px" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="0.5*" />
+                                <ColumnDefinition Width="0.5*" />
+                            </Grid.ColumnDefinitions>
+
+                            <Label Margin="0,0,0,5" 
+                                   VerticalAlignment="Center"
+                                   Target="{Binding ElementName=_networkValue}"
+                                   Content="{x:Static ext:Resources.AuthorizedNetworksWindowValueTextBoxTitle}"
+                                   Style="{StaticResource CommonLabelStyle}" />
+                            <TextBox x:Name="_networkValue"
+                                     Grid.Column="1"
+                                     Margin="0,0,0,5"
+                                     Text="{Binding NetworkValue, Mode=TwoWay}"
+                                     Style="{StaticResource CommonTextBoxStyle}" />
+
                         </Grid>
 
                         <Button Command="{Binding AddNetwork}"
@@ -78,33 +89,36 @@
                 </GroupBox>
             </StackPanel>
 
-            <Grid Grid.Row="2" Margin="3px, 5px">
-                <ListView ItemsSource="{Binding Networks}">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <Grid Height="25px">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
+            <Label Grid.Row="1"
+                   Content="{x:Static ext:Resources.AuthorizedNetworksWindowMessage}"
+                   Target="{Binding ElementName=_networks}"
+                   Style="{StaticResource CommonLabelStyle}" />
+            <ListBox x:Name="_networks"
+                     Grid.Row="2"
+                     ItemsSource="{Binding Networks}"
+                     Height="200"
+                     Style="{StaticResource CommonMediumListBoxStyle}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding DisplayString}"
+                                       Margin="0,0,5,0"
+                                       VerticalAlignment="Center"
+                                       TextDecorations="{Binding Deleted, Converter={utils:BooleanConverter TrueValue='Strikethrough'}}"
+                                       Style="{StaticResource CommonTextStyle}" />
 
-                                <Button Width="75px" Margin="1px" Command="{Binding DeleteCommand}" 
-                                            Content="{x:Static ext:Resources.UiDeleteButtonCaption}"
-                                            Visibility="{Binding Path=NotDeleted, Converter={StaticResource BoolToVis}}"/>
-                                <Button Width="75px"  Margin="1px" Command="{Binding UndoDeleteCommand}" 
-                                            Content="{x:Static ext:Resources.UiUndoButtonCaption}"
-                                            Visibility="{Binding Path=Deleted, Converter={StaticResource BoolToVis}}"/>
-
-                                <TextBlock Text="{Binding DisplayString}" Grid.Column="1" VerticalAlignment="Center" Margin="1px"
-                                                Visibility="{Binding Path=NotDeleted, Converter={StaticResource BoolToVis}}"/>
-                                <TextBlock Text="{Binding DisplayString}" Grid.Column="1" VerticalAlignment="Center" Margin="1px" 
-                                               TextDecorations="Strikethrough" 
-                                               Visibility="{Binding Path=Deleted, Converter={StaticResource BoolToVis}}"/>
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
-            </Grid>
+                            <Button Command="{Binding DeleteCommand}"
+                                    Content="{x:Static ext:Resources.UiDeleteButtonCaption}"
+                                    Visibility="{Binding Path=NotDeleted, Converter={utils:VisibilityConverter}}"
+                                    Style="{StaticResource CommonButtonDynamicStyle}" />
+                            <Button Command="{Binding UndoDeleteCommand}" 
+                                    Content="{x:Static ext:Resources.UiUndoButtonCaption}"
+                                    Visibility="{Binding Path=Deleted, Converter={utils:VisibilityConverter}}"
+                                    Style="{StaticResource CommonButtonDynamicStyle}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
         </Grid>
     </theming:CommonDialogWindowBaseContent>
 </UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml
@@ -287,6 +287,7 @@
 
             <!-- First the buttons instantiated from the sources -->
             <ItemsControl ItemsSource="{Binding Buttons}"
+                          Focusable="False"
                           Visibility="{Binding IsValidInstallation, Converter={StaticResource visibilityConverter}}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
@@ -242,6 +242,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 {
                     Title = Resources.CloudExplorerGceSavePubSettingsCredentialsTitle,
                     Message = Resources.CloudExplorerGceSavePubSettingsCredentialsMessage,
+                    ActionButtonCaption = Resources.UiSaveButtonCaption
                 });
             if (credentials == null)
             {
@@ -372,7 +373,8 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 new WindowsCredentialsChooserWindow.Options
                 {
                     Title = Resources.TerminalServerManagerWindowTitle,
-                    Message = Resources.TerminalServerManagerWindowMessage
+                    Message = Resources.TerminalServerManagerWindowMessage,
+                    ActionButtonCaption = Resources.UiOpenButtonCaption
                 });
             if (credentials != null)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortInfo.cs
@@ -31,10 +31,16 @@ namespace GoogleCloudExtension.FirewallManagement
         /// </summary>
         public int Port { get; }
 
-        public PortInfo(string name, int port)
+        /// <summary>
+        /// The tooltip to display for this port.
+        /// </summary>
+        public string Description { get; }
+
+        public PortInfo(string name, int port, string description = null)
         {
             Name = name;
             Port = port;
+            Description = description;
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortManagerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortManagerViewModel.cs
@@ -59,10 +59,10 @@ namespace GoogleCloudExtension.FirewallManagement
         /// </summary>
         private static readonly IList<PortInfo> s_supportedPorts = new List<PortInfo>
         {
-            new PortInfo("HTTP", 80),
-            new PortInfo("HTTPS", 443),
-            new PortInfo("RDP", 3389),
-            new PortInfo("WebDeploy", 8172),
+            new PortInfo("HTTP", 80, description: Resources.PortManagerHttpDescription),
+            new PortInfo("HTTPS", 443, description: Resources.PortManagerHttpsDescription),
+            new PortInfo("RDP", 3389, description: Resources.PortManagerRdpDescription),
+            new PortInfo("WebDeploy", 8172, description: Resources.PortManagerWebDeployDescription),
         };
 
         private readonly PortManagerWindow _owner;
@@ -100,7 +100,7 @@ namespace GoogleCloudExtension.FirewallManagement
 
             foreach (var entry in Ports.Where(x => x.Changed))
             {
-                var firewallPort = new FirewallPort(entry.PortInfo.GetTag(_instance), entry.Port);
+                var firewallPort = new FirewallPort(entry.PortInfo.GetTag(_instance), entry.PortInfo.Port);
                 if (entry.IsEnabled)
                 {
                     portsToEnable.Add(firewallPort);

--- a/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortManagerWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortManagerWindow.cs
@@ -24,7 +24,7 @@ namespace GoogleCloudExtension.FirewallManagement
     {
         private PortManagerViewModel ViewModel => (PortManagerViewModel)((PortManagerWindowContent)Content).DataContext;
 
-        private PortManagerWindow(Instance instance) : base(GoogleCloudExtension.Resources.PortManagerWindowCaption, width: 320, height: 300)
+        private PortManagerWindow(Instance instance) : base(GoogleCloudExtension.Resources.PortManagerWindowCaption)
         {
             var viewModel = new PortManagerViewModel(this, instance);
             Content = new PortManagerWindowContent

--- a/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortManagerWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortManagerWindowContent.xaml
@@ -9,38 +9,43 @@
              xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
              mc:Ignorable="d" 
-             d:DataContext="{d:DesignInstance {x:Type local:PortManagerViewModel}}"
-             d:DesignHeight="300" d:DesignWidth="300">
+             d:DataContext="{d:DesignInstance {x:Type local:PortManagerViewModel}}">
 
-    <theming:CommonDialogWindowBaseContent>
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicLarge}" />
+    </UserControl.Style>
+
+    <theming:CommonDialogWindowBaseContent HasBanner="True">
         <theming:CommonDialogWindowBaseContent.Buttons>
-            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiOkButtonCaption}"
+            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiSaveButtonCaption}"
                                       IsDefault="True"
                                       Command="{Binding OkCommand}"/>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCancelButtonCaption}" IsCancel="True" />
         </theming:CommonDialogWindowBaseContent.Buttons>
 
         <StackPanel>
-            <TextBlock TextWrapping="Wrap" Margin="3,0,3,5" Text="{x:Static ext:Resources.PortManagerWindowMessage}"/>
-
-            <StackPanel Margin="3,0">
-                <ItemsControl ItemsSource="{Binding Ports}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <CheckBox IsChecked="{Binding IsEnabled}">
-                                <TextBlock>
-                                    <TextBlock.Text>
-                                        <MultiBinding StringFormat="{}{0} ({1})">
-                                            <Binding Path="Name" />
-                                            <Binding Path="Port" />
-                                        </MultiBinding>
-                                    </TextBlock.Text>
-                                </TextBlock>
-                            </CheckBox>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+            <Label Content="{x:Static ext:Resources.PortManagerWindowMessage}"
+                   Style="{StaticResource CommonLabelStyle}" />
+            
+            <ItemsControl ItemsSource="{Binding Ports}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <CheckBox IsChecked="{Binding IsEnabled}"
+                                  Content="{Binding DisplayString}"
+                                  Margin="0,0,0,5"
+                                  Style="{StaticResource CommonTextStyleBase}">
+                        </CheckBox>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </StackPanel>
 
     </theming:CommonDialogWindowBaseContent>

--- a/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortModel.cs
@@ -31,14 +31,10 @@ namespace GoogleCloudExtension.FirewallManagement
         public PortInfo PortInfo => _port;
 
         /// <summary>
-        /// The name of the port.
+        /// The display string to user.
         /// </summary>
-        public string Name => _port.Name;
-
-        /// <summary>
-        /// The number of the port.
-        /// </summary>
-        public int Port => _port.Port;
+        public string DisplayString =>
+            string.Format(Resources.PortManagerDisplayStringFormat, _port.Description, _port.Name, _port.Port);
 
         /// <summary>
         /// Whether the port is enabled or not.

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsWindow.cs
@@ -18,7 +18,7 @@ namespace GoogleCloudExtension.ManageAccounts
 {
     public class ManageAccountsWindow : CommonDialogWindowBase
     {
-        private ManageAccountsWindow() : base(GoogleCloudExtension.Resources.ManageAccountsWindowTitle, width: 500, height: 400)
+        private ManageAccountsWindow() : base(GoogleCloudExtension.Resources.ManageAccountsWindowTitle)
         {
             Content = new ManageAccountsWindowContent { DataContext = new ManageAccountsViewModel(this) };
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsWindowContent.xaml
@@ -10,9 +10,18 @@
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance {x:Type local:ManageAccountsViewModel}}">
     <UserControl.Resources>
-       
-        <utils:VisibilityConverter x:Key="visibilityConverter" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <utils:VisibilityConverter x:Key="visibilityConverter" />
+        </ResourceDictionary>
     </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleLarge}" />
+    </UserControl.Style>
 
     <theming:CommonDialogWindowBaseContent HasBanner="True">
         <theming:CommonDialogWindowBaseContent.Buttons>
@@ -33,30 +42,27 @@
             </Grid.RowDefinitions>
 
             <!-- Caption row -->
-            <TextBlock Margin="0,0,0,5" Text="{x:Static ext:Resources.ManageAccountsChooseAccountMessage}"/>
+            <Label Content="{x:Static ext:Resources.ManageAccountsChooseAccountMessage}"
+                   Target="{Binding ElementName=_accountsListBox}"
+                   Style="{StaticResource CommonLabelStyle}"/>
 
             <!-- Listbox with the credentials -->
-            <ListBox Grid.Row="1"
-                 x:Name="_accountsListBox"
-                 MouseDoubleClick="ListBox_MouseDoubleClick"
-                 ItemsSource="{Binding UserAccountsList}"
-                 SelectedItem="{Binding CurrentUserAccount, Mode=OneWayToSource}"
-                 SelectedValue="{Binding CurrentAccountName}"
-                 SelectedValuePath="AccountName">
-
-                <ListBox.ItemContainerStyle>
-                    <Style TargetType="{x:Type ListBoxItem}">
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                    </Style>
-                </ListBox.ItemContainerStyle>
+            <ListBox x:Name="_accountsListBox"
+                     Grid.Row="1"
+                     MouseDoubleClick="ListBox_MouseDoubleClick"
+                     ItemsSource="{Binding UserAccountsList}"
+                     SelectedItem="{Binding CurrentUserAccount, Mode=OneWayToSource}"
+                     SelectedValue="{Binding CurrentAccountName}"
+                     SelectedValuePath="AccountName"
+                     Style="{StaticResource CommonLargeListBoxStyle}">
 
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <Grid Height="75" Margin="10,0,0,0" HorizontalAlignment="Stretch">
+                        <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" MinWidth="75" />
-                                <ColumnDefinition />
-                                <ColumnDefinition />
+                                <ColumnDefinition Width="auto" MinWidth="75" />
+                                <ColumnDefinition Width="auto"/>
+                                <ColumnDefinition Width="auto"/>
                             </Grid.ColumnDefinitions>
 
                             <!-- First show the image -->
@@ -75,19 +81,24 @@
                                    VerticalAlignment="Center" />
 
                             <!-- Show the name and the account name -->
-                            <StackPanel Grid.Column="1"
-                                    VerticalAlignment="Center" Height="38">
-                                <TextBlock Text="{Binding NameAsync.Value}" 
-                                       Margin="0,0,0,5"/>
-                                <TextBlock Text="{Binding AccountName, StringFormat='({0})'}" />
-                            </StackPanel>
+                            <TextBlock Grid.Column="1"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,5,0"
+                                       Style="{StaticResource CommonTextStyle}">
+                                <TextBlock.Text>
+                                    <MultiBinding StringFormat="{x:Static ext:Resources.ManageAccountsDisplayStringFormat}">
+                                        <Binding Path="NameAsync.Value" />
+                                        <Binding Path="AccountName" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
 
                             <!-- The label for the current account -->
                             <TextBlock Grid.Column="2"
-                                   Visibility="{Binding IsCurrentAccount, Converter={StaticResource visibilityConverter}}"
-                                   VerticalAlignment="Center"
-                                   Text="{x:Static ext:Resources.ManageAccountsCurrentAccountMessage}" />
-
+                                       Visibility="{Binding IsCurrentAccount, Converter={StaticResource visibilityConverter}}"
+                                       VerticalAlignment="Center"
+                                       Text="{x:Static ext:Resources.ManageAccountsCurrentAccountMessage}"
+                                       Style="{StaticResource CommonTextStyle}"/>
                         </Grid>
                     </DataTemplate>
                 </ListBox.ItemTemplate>

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsWindowContent.xaml
@@ -29,7 +29,7 @@
                                       Command="{Binding AddAccountCommand}" />
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.ManageAccountsSetAsCurrentAccountButtonCaption}"
                                       Command="{Binding SetAsCurrentAccountCommand}" />
-            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.ManageAccountsDeleteAccountButtonCaption}"
+            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiDeleteButtonCaption}"
                                       Command="{Binding DeleteAccountCommand}"/>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCloseButtonCaption}"
                                       IsCancel="True" />

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
@@ -114,6 +114,7 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
             if (!UserPromptUtils.ActionPrompt(
                     String.Format(Resources.ManageWindowsCredentialsDeleteCredentialsPromptMessage, SelectedCredentials.User),
                     Resources.ManageWindowsCredentialsDeleteCredentialsPromptTitle,
+                    message: Resources.UiOperationCannotBeUndone,
                     actionCaption: Resources.UiDeleteButtonCaption))
             {
                 return;
@@ -178,7 +179,7 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
                 if (!UserPromptUtils.ActionPrompt(
                         prompt: String.Format(Resources.ResetPasswordConfirmationPromptMessage, user, _instance.Name),
                         title: Resources.ResetPasswordConfirmationPromptTitle,
-                        message: Resources.ResetPasswordConfirmationMessage,
+                        message: Resources.UiOperationCannotBeUndone,
                         actionCaption: Resources.UiResetButtonCaption,
                         isWarning: true))
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
@@ -105,7 +105,7 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
                 {
                     Title = String.Format(Resources.ShowPasswordWindowTitle, _instance.Name),
                     Password = SelectedCredentials.Password,
-                    Message = String.Format(Resources.ShowPasswordMessage, SelectedCredentials.User, _instance.Name)
+                    Message = String.Format(Resources.ShowPasswordMessage, SelectedCredentials.User)
                 });
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsWindowContent.xaml
@@ -44,7 +44,12 @@
             <!-- Caption row -->
             <Label Style="{StaticResource CommonLabelStyle}"
                    Content="{Binding Message}"
-                   Target="{Binding ElementName=_list}" />
+                   Target="{Binding ElementName=_list}">
+                <Label.ToolTip>
+                    <TextBlock Text="{x:Static ext:Resources.ManageWindowsCredentialsToolTip}"
+                               Style="{StaticResource CommonToolTipTextStyle}" />
+                </Label.ToolTip>
+            </Label>
 
             <!-- List of credentials -->
             <ListBox Grid.Row="1"

--- a/GoogleCloudExtension/GoogleCloudExtension/MySQLInstaller/MySQLInstallerWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/MySQLInstaller/MySQLInstallerWindow.cs
@@ -22,7 +22,7 @@ namespace GoogleCloudExtension.MySQLInstaller
     /// </summary>
     internal class MySQLInstallerWindow : CommonDialogWindowBase
     {
-        private MySQLInstallerWindow() : base(GoogleCloudExtension.Resources.MySqlInstallerWindowTitle, width: 300, height: 250)
+        private MySQLInstallerWindow() : base(GoogleCloudExtension.Resources.MySqlInstallerWindowTitle)
         {
             Content = new MySQLInstallerWindowContent
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/MySQLInstaller/MySQLInstallerWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/MySQLInstaller/MySQLInstallerWindowContent.xaml
@@ -5,9 +5,19 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:GoogleCloudExtension.MySQLInstaller"
              xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
-             xmlns:ext="clr-namespace:GoogleCloudExtension"
-             mc:Ignorable="d" 
-             d:DesignHeight="225" d:DesignWidth="300">
+             xmlns:ext="clr-namespace:GoogleCloudExtension">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicSmall}" />
+    </UserControl.Style>
     
     <theming:CommonDialogWindowBaseContent>
         <theming:CommonDialogWindowBaseContent.Buttons>
@@ -18,16 +28,11 @@
         </theming:CommonDialogWindowBaseContent.Buttons>
 
         <StackPanel>
-            <TextBlock HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       TextWrapping="WrapWithOverflow"
-                       Margin="5"
-                       Text="{x:Static ext:Resources.MySqlInstallerWindowTopMessage}" />
-            <TextBlock HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       TextWrapping="WrapWithOverflow"
-                       Margin="5"
-                       Text="{x:Static ext:Resources.MySqlInstallerWindowBottomMessage}" />
+            <TextBlock Text="{x:Static ext:Resources.MySqlInstallerWindowTopMessage}"
+                       Margin="0,0,0,5"
+                       Style="{StaticResource CommonTextStyle}"/>
+            <TextBlock Text="{x:Static ext:Resources.MySqlInstallerWindowBottomMessage}"
+                       Style="{StaticResource CommonTextStyle}"/>
         </StackPanel>
 
     </theming:CommonDialogWindowBaseContent>

--- a/GoogleCloudExtension/GoogleCloudExtension/OauthLoginFlow/OauthLoginFlowWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/OauthLoginFlow/OauthLoginFlowWindow.cs
@@ -36,7 +36,7 @@ namespace GoogleCloudExtension.OauthLoginFlow
         private OAuthLoginFlowViewModel ViewModel { get; }
 
         private OAuthLoginFlowWindow(OAuthCredentials credentials, IEnumerable<string> scopes)
-            : base(GoogleCloudExtension.Resources.OAuthFlowWindowTitle, width: 300, height: 300)
+            : base(GoogleCloudExtension.Resources.OAuthFlowWindowTitle)
         {
             _flow = new OAuthLoginFlow(
                 credentials,

--- a/GoogleCloudExtension/GoogleCloudExtension/OauthLoginFlow/OauthLoginFlowWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/OauthLoginFlow/OauthLoginFlowWindowContent.xaml
@@ -7,8 +7,20 @@
              xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
              mc:Ignorable="d" 
-             d:DataContext="{d:DesignInstance {x:Type local:OAuthLoginFlowViewModel}}" d:DesignHeight="300" d:DesignWidth="300">
+             d:DataContext="{d:DesignInstance {x:Type local:OAuthLoginFlowViewModel}}">
 
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicSmall}" />
+    </UserControl.Style>
+    
     <theming:CommonDialogWindowBaseContent>
         <theming:CommonDialogWindowBaseContent.Buttons>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCancelButtonCaption}"
@@ -16,7 +28,8 @@
                                       IsCancel="True" />
         </theming:CommonDialogWindowBaseContent.Buttons>
 
-        <TextBlock TextWrapping="Wrap" Text="{x:Static ext:Resources.OAuthFlowWindowMessage}" />
+        <TextBlock Text="{x:Static ext:Resources.OAuthFlowWindowMessage}"
+                   Style="{StaticResource CommonTextStyle}" />
 
     </theming:CommonDialogWindowBaseContent>
    

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1789,6 +1789,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to _Open.
+        /// </summary>
+        public static string UiOpenButtonCaption {
+            get {
+                return ResourceManager.GetString("UiOpenButtonCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open in the console.
         /// </summary>
         public static string UiOpenOnCloudConsoleMenuHeader {
@@ -1870,16 +1879,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Windows Credentials.
-        /// </summary>
-        public static string WindowsCredentialsChooserButtonToolTip {
-            get {
-                return ResourceManager.GetString("WindowsCredentialsChooserButtonToolTip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Manage credentials.
+        ///   Looks up a localized string similar to Manage Windows credentials.
         /// </summary>
         public static string WindowsCredentialsChooserManageCredentialsCaption {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1618,7 +1618,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The password for user {0} in instance {1} is:.
+        ///   Looks up a localized string similar to {0} password:.
         /// </summary>
         public static string ShowPasswordMessage {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1465,7 +1465,52 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Firewall Ports.
+        ///   Looks up a localized string similar to {0} ({1} {2}).
+        /// </summary>
+        public static string PortManagerDisplayStringFormat {
+            get {
+                return ResourceManager.GetString("PortManagerDisplayStringFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow HTTP traffic to the instance.
+        /// </summary>
+        public static string PortManagerHttpDescription {
+            get {
+                return ResourceManager.GetString("PortManagerHttpDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow HTTPS traffic to the instance.
+        /// </summary>
+        public static string PortManagerHttpsDescription {
+            get {
+                return ResourceManager.GetString("PortManagerHttpsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow Remote Desktop connections to the instance.
+        /// </summary>
+        public static string PortManagerRdpDescription {
+            get {
+                return ResourceManager.GetString("PortManagerRdpDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow publishing with WebDeploy to the instance.
+        /// </summary>
+        public static string PortManagerWebDeployDescription {
+            get {
+                return ResourceManager.GetString("PortManagerWebDeployDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Firewall Options.
         /// </summary>
         public static string PortManagerWindowCaption {
             get {
@@ -1474,7 +1519,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set Firewall rules and tags to enable traffic for the instance.
+        ///   Looks up a localized string similar to Firewall rules:.
         /// </summary>
         public static string PortManagerWindowMessage {
             get {
@@ -1659,6 +1704,15 @@ namespace GoogleCloudExtension {
         public static string ShowPasswordWindowTitle {
             get {
                 return ResourceManager.GetString("ShowPasswordWindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        public static string String1 {
+            get {
+                return ResourceManager.GetString("String1", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Generate the password for this user name.
+        ///   Looks up a localized string similar to Create a password for me.
         /// </summary>
         public static string AddWindowsCredentialGeneratePasswordMessage {
             get {
@@ -70,7 +70,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to I have a password for this user name.
+        ///   Looks up a localized string similar to I have a password for this user.
         /// </summary>
         public static string AddWindowsCredentialHavePasswordMessage {
             get {
@@ -97,7 +97,25 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User name:.
+        ///   Looks up a localized string similar to Add Windows Credential.
+        /// </summary>
+        public static string AddWindowsCredentialTitle {
+            get {
+                return ResourceManager.GetString("AddWindowsCredentialTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter a user name. If the user name already exists as an account on the Windows instance, then you can reset the password or enter the current one..
+        /// </summary>
+        public static string AddWindowsCredentialToolTip {
+            get {
+                return ResourceManager.GetString("AddWindowsCredentialToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _User name:.
         /// </summary>
         public static string AddWindowsCredentialUserNameCaption {
             get {
@@ -1348,7 +1366,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to the delete the credentials for user {0}?.
+        ///   Looks up a localized string similar to Delete user name {0} from this computer? The credentials will still exist on the Windows instance..
         /// </summary>
         public static string ManageWindowsCredentialsDeleteCredentialsPromptMessage {
             get {
@@ -1456,16 +1474,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can&apos;t undo this later..
-        /// </summary>
-        public static string ResetPasswordConfirmationMessage {
-            get {
-                return ResourceManager.GetString("ResetPasswordConfirmationMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to reset the password for {0}?.
+        ///   Looks up a localized string similar to Reset the password for {0} on instance {1}?.
         /// </summary>
         public static string ResetPasswordConfirmationPromptMessage {
             get {
@@ -1551,15 +1560,6 @@ namespace GoogleCloudExtension {
         public static string ResetPasswordProgressTitle {
             get {
                 return ResourceManager.GetString("ResetPasswordProgressTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Add Credential for VM {0}.
-        /// </summary>
-        public static string ResetPasswordWindowTitle {
-            get {
-                return ResourceManager.GetString("ResetPasswordWindowTitle", resourceCulture);
             }
         }
         
@@ -1690,7 +1690,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete.
+        ///   Looks up a localized string similar to _Delete.
         /// </summary>
         public static string UiDeleteButtonCaption {
             get {
@@ -1699,7 +1699,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download.
+        ///   Looks up a localized string similar to _Download.
         /// </summary>
         public static string UiDownloadButtonCaption {
             get {
@@ -1708,7 +1708,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No.
+        ///   Looks up a localized string similar to _No.
         /// </summary>
         public static string UiNoButtonCaption {
             get {
@@ -1735,6 +1735,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can&apos;t undo this later..
+        /// </summary>
+        public static string UiOperationCannotBeUndone {
+            get {
+                return ResourceManager.GetString("UiOperationCannotBeUndone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Properties.
         /// </summary>
         public static string UiPropertiesMenuHeader {
@@ -1744,7 +1753,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reset.
+        ///   Looks up a localized string similar to _Reset.
         /// </summary>
         public static string UiResetButtonCaption {
             get {
@@ -1753,7 +1762,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Save.
+        ///   Looks up a localized string similar to _Save.
         /// </summary>
         public static string UiSaveButtonCaption {
             get {
@@ -1780,7 +1789,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Undo.
+        ///   Looks up a localized string similar to _Undo.
         /// </summary>
         public static string UiUndoButtonCaption {
             get {
@@ -1789,7 +1798,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Yes.
+        ///   Looks up a localized string similar to _Yes.
         /// </summary>
         public static string UiYesButtonCaption {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1393,7 +1393,16 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Credentials for {0}. Windows credentials are used to log in to a Windows machine instance..
+        ///   Looks up a localized string similar to Windows credentials are used to log in to a Windows machine instance..
+        /// </summary>
+        public static string ManageWindowsCredentialsToolTip {
+            get {
+                return ResourceManager.GetString("ManageWindowsCredentialsToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Credentials for {0}. .
         /// </summary>
         public static string ManageWindowsCredentialsWindowMessage {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1276,7 +1276,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add....
+        ///   Looks up a localized string similar to _Add account.
         /// </summary>
         public static string ManageAccountsAddAccountButtonCaption {
             get {
@@ -1285,7 +1285,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Choose account:.
+        ///   Looks up a localized string similar to _Choose account:.
         /// </summary>
         public static string ManageAccountsChooseAccountMessage {
             get {
@@ -1303,7 +1303,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete.
+        ///   Looks up a localized string similar to _Delete.
         /// </summary>
         public static string ManageAccountsDeleteAccountButtonCaption {
             get {
@@ -1339,7 +1339,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set As Current.
+        ///   Looks up a localized string similar to _Set current.
         /// </summary>
         public static string ManageAccountsSetAsCurrentAccountButtonCaption {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1159,7 +1159,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Authorized Networks.
+        ///   Looks up a localized string similar to Manage authorized networks....
         /// </summary>
         public static string CloudExplorerSqlManageAuthorizedNetworksMenuHeader {
             get {
@@ -1177,7 +1177,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Data Connection.
+        ///   Looks up a localized string similar to Add Data Connection....
         /// </summary>
         public static string CloudExplorerSqlOpenAddDataConnectionMenuHeader {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1330,6 +1330,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} ({1}).
+        /// </summary>
+        public static string ManageAccountsDisplayStringFormat {
+            get {
+                return ResourceManager.GetString("ManageAccountsDisplayStringFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Set As Current.
         /// </summary>
         public static string ManageAccountsSetAsCurrentAccountButtonCaption {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -511,7 +511,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Firewall Ports....
+        ///   Looks up a localized string similar to Firewall options....
         /// </summary>
         public static string CloudExplorerGceManageFirewallPortsMenuHeader {
             get {
@@ -520,7 +520,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Windows Credentials....
+        ///   Looks up a localized string similar to Manage Windows credentials....
         /// </summary>
         public static string CloudExplorerGceManageWindowsCredentialsMenuHeader {
             get {
@@ -574,7 +574,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Terminal Server Session....
+        ///   Looks up a localized string similar to Open terminal session....
         /// </summary>
         public static string CloudExplorerGceOpenTerminalSessionMenuHeader {
             get {
@@ -583,7 +583,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Web Site....
+        ///   Looks up a localized string similar to Open website.
         /// </summary>
         public static string CloudExplorerGceOpenWebSiteMenuHeader {
             get {
@@ -1330,7 +1330,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Credentials.
+        ///   Looks up a localized string similar to _Add credentials.
         /// </summary>
         public static string ManageWindowsCredentialsAddCredentialsCaption {
             get {
@@ -1339,7 +1339,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete Credentials.
+        ///   Looks up a localized string similar to _Delete credentials.
         /// </summary>
         public static string ManageWindowsCredentialsDeleteCredentialsCaption {
             get {
@@ -1357,7 +1357,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete Credentials.
+        ///   Looks up a localized string similar to Delete Credential.
         /// </summary>
         public static string ManageWindowsCredentialsDeleteCredentialsPromptTitle {
             get {
@@ -1366,7 +1366,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show Credentials.
+        ///   Looks up a localized string similar to _Show password.
         /// </summary>
         public static string ManageWindowsCredentialsShowCredentialsCaption {
             get {
@@ -1375,7 +1375,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows _credentials for {0}.
+        ///   Looks up a localized string similar to _Credentials for {0}. Windows credentials are used to log in to a Windows machine instance..
         /// </summary>
         public static string ManageWindowsCredentialsWindowMessage {
             get {
@@ -1384,7 +1384,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Windows Credentials.
+        ///   Looks up a localized string similar to Windows Credentials.
         /// </summary>
         public static string ManageWindowsCredentialsWindowTitle {
             get {
@@ -1573,6 +1573,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Password copied to clipboard..
+        /// </summary>
+        public static string ShowPasswordCopiedMessage {
+            get {
+                return ResourceManager.GetString("ShowPasswordCopiedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The copy operation failed, this might happen if another program has the Windows Clipboard open, such as a virtual machine agent..
         /// </summary>
         public static string ShowPasswordCopyFailedMessage {
@@ -1717,7 +1726,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open on Cloud Console.
+        ///   Looks up a localized string similar to Open in the console.
         /// </summary>
         public static string UiOpenOnCloudConsoleMenuHeader {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -546,11 +546,11 @@
     <comment>The title for the prompt indicating the account already exists.</comment>
   </data>
   <data name="ManageAccountsAddAccountButtonCaption" xml:space="preserve">
-    <value>Add...</value>
+    <value>_Add account</value>
     <comment>Caption for the add account button.</comment>
   </data>
   <data name="ManageAccountsChooseAccountMessage" xml:space="preserve">
-    <value>Choose account:</value>
+    <value>_Choose account:</value>
     <comment>The message at the top of the manage accounts window.</comment>
   </data>
   <data name="ManageAccountsCurrentAccountMessage" xml:space="preserve">
@@ -558,7 +558,7 @@
     <comment>Message shown in the current account.</comment>
   </data>
   <data name="ManageAccountsDeleteAccountButtonCaption" xml:space="preserve">
-    <value>Delete</value>
+    <value>_Delete</value>
     <comment>Caption for the delete account button.</comment>
   </data>
   <data name="ManageAccountsDeleteAccountPromptMessage" xml:space="preserve">
@@ -570,7 +570,7 @@
     <comment>Title for the confirmation prompt for deleting an account.</comment>
   </data>
   <data name="ManageAccountsSetAsCurrentAccountButtonCaption" xml:space="preserve">
-    <value>Set As Current</value>
+    <value>_Set current</value>
     <comment>Caption for the set as current account button.</comment>
   </data>
   <data name="ManageAccountsWindowTitle" xml:space="preserve">

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -250,7 +250,7 @@
     <comment>The description of the zone property for a GCE instance.</comment>
   </data>
   <data name="CloudExplorerGceManageFirewallPortsMenuHeader" xml:space="preserve">
-    <value>Manage Firewall Ports...</value>
+    <value>Firewall options...</value>
     <comment>Header for the manage firewall ports menu item.</comment>
   </data>
   <data name="CloudExplorerGceNewAspNetInstanceMenuHeader" xml:space="preserve">
@@ -274,11 +274,11 @@
     <comment>The tooltip for the filter button.</comment>
   </data>
   <data name="CloudExplorerGceOpenTerminalSessionMenuHeader" xml:space="preserve">
-    <value>Open Terminal Server Session...</value>
+    <value>Open terminal session...</value>
     <comment>Header for the open terminal session menu item.</comment>
   </data>
   <data name="CloudExplorerGceOpenWebSiteMenuHeader" xml:space="preserve">
-    <value>Open Web Site...</value>
+    <value>Open website</value>
     <comment>Header for the open website menu item.</comment>
   </data>
   <data name="CloudExplorerGcePublishingSettingsSavedMessage" xml:space="preserve">
@@ -730,7 +730,7 @@
     <comment>Caption for Undo buttons.</comment>
   </data>
   <data name="UiOpenOnCloudConsoleMenuHeader" xml:space="preserve">
-    <value>Open on Cloud Console</value>
+    <value>Open in the console</value>
     <comment>Header for the menu that opens the item in the cloud console.</comment>
   </data>
   <data name="UiPropertiesMenuHeader" xml:space="preserve">
@@ -754,11 +754,11 @@
     <comment>The command to use use to show the buckets per location.</comment>
   </data>
   <data name="ManageWindowsCredentialsAddCredentialsCaption" xml:space="preserve">
-    <value>Add Credentials</value>
+    <value>_Add credentials</value>
     <comment>The caption for the add credentials button in the dialog.</comment>
   </data>
   <data name="ManageWindowsCredentialsDeleteCredentialsCaption" xml:space="preserve">
-    <value>Delete Credentials</value>
+    <value>_Delete credentials</value>
     <comment>The caption for the delete credentials button in the dialog.</comment>
   </data>
   <data name="ManageWindowsCredentialsDeleteCredentialsPromptMessage" xml:space="preserve">
@@ -766,19 +766,19 @@
     <comment>The message for the confirmation prompt to delete credentials. The {0} placeholder is the username.</comment>
   </data>
   <data name="ManageWindowsCredentialsDeleteCredentialsPromptTitle" xml:space="preserve">
-    <value>Delete Credentials</value>
+    <value>Delete Credential</value>
     <comment>Title for the confirmation prompt to delete credentials.</comment>
   </data>
   <data name="ManageWindowsCredentialsShowCredentialsCaption" xml:space="preserve">
-    <value>Show Credentials</value>
+    <value>_Show password</value>
     <comment>The caption or the show credentials button in the dialog.</comment>
   </data>
   <data name="ManageWindowsCredentialsWindowMessage" xml:space="preserve">
-    <value>Windows _credentials for {0}</value>
+    <value>_Credentials for {0}. Windows credentials are used to log in to a Windows machine instance.</value>
     <comment>Message at the top of the Manage Windows Credentials dialog. The {0} placeholder is the name of the instance.</comment>
   </data>
   <data name="ManageWindowsCredentialsWindowTitle" xml:space="preserve">
-    <value>Manage Windows Credentials</value>
+    <value>Windows Credentials</value>
     <comment>Title for the Manage Windows Credentials dialog.</comment>
   </data>
   <data name="TerminalServerManagerWindowMessage" xml:space="preserve">
@@ -798,7 +798,7 @@
     <comment>Message shown in the dropdown when no credentials are found.</comment>
   </data>
   <data name="CloudExplorerGceManageWindowsCredentialsMenuHeader" xml:space="preserve">
-    <value>Manage Windows Credentials...</value>
+    <value>Manage Windows credentials...</value>
     <comment>Header for the menu entry to manage credentials.</comment>
   </data>
   <data name="CloudExplorerGceInstanceWindowsVersionDescription" xml:space="preserve">
@@ -891,5 +891,9 @@
   <data name="AddWindowsCredentialValidationErrorTtitle" xml:space="preserve">
     <value>Add Windows Credential</value>
     <comment>Title for the validation error dialogs in the add windows credential dialog.</comment>
+  </data>
+  <data name="ShowPasswordCopiedMessage" xml:space="preserve">
+    <value>Password copied to clipboard.</value>
+    <comment>Message shown in the popup for the copy operation.</comment>
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -690,8 +690,8 @@
     <comment>The tooltip shown to hide the password.</comment>
   </data>
   <data name="ShowPasswordMessage" xml:space="preserve">
-    <value>The password for user {0} in instance {1} is:</value>
-    <comment>The message shown for the password textblock. {0} is the user name, {1} is the instance name.</comment>
+    <value>{0} password:</value>
+    <comment>The message shown for the password textblock. {0} is the user name.</comment>
   </data>
   <data name="ShowPasswordShowPasswordTooltip" xml:space="preserve">
     <value>Show password</value>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -789,10 +789,6 @@
     <value>Start Terminal Server session</value>
     <comment>Title for the manage terminal server window.</comment>
   </data>
-  <data name="WindowsCredentialsChooserButtonToolTip" xml:space="preserve">
-    <value>Manage Windows Credentials</value>
-    <comment>Tooltip for the manage credentials button in the terminal server window.</comment>
-  </data>
   <data name="WindowsCredentialsChooserNoCredentialsFoundMessage" xml:space="preserve">
     <value>No credentials found...</value>
     <comment>Message shown in the dropdown when no credentials are found.</comment>
@@ -826,7 +822,7 @@
     <comment>Message shown to the user when the password for the Windows user is being set. {0} is the user name.</comment>
   </data>
   <data name="WindowsCredentialsChooserManageCredentialsCaption" xml:space="preserve">
-    <value>Manage credentials</value>
+    <value>Manage Windows credentials</value>
     <comment>Caption used in the hyperlink shown in the Windows credentials chooser dialog.</comment>
   </data>
   <data name="ExceptionPromptMessage" xml:space="preserve">
@@ -925,5 +921,9 @@
   </data>
   <data name="String1" xml:space="preserve">
     <value />
+  </data>
+  <data name="UiOpenButtonCaption" xml:space="preserve">
+    <value>_Open</value>
+    <comment>Caption for the open button in dialogs.</comment>
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -891,6 +891,10 @@
   <data name="AddWindowsCredentialToolTip" xml:space="preserve">
     <value>Enter a user name. If the user name already exists as an account on the Windows instance, then you can reset the password or enter the current one.</value>
   </data>
+  <data name="ManageAccountsDisplayStringFormat" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>Format for the display string for an account. {0} is the user name, {1} is the email address.</comment>
+  </data>
   <data name="ManageWindowsCredentialsToolTip" xml:space="preserve">
     <value>Windows credentials are used to log in to a Windows machine instance.</value>
     <comment>Tooltip shown in the manage windows credentials window.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -598,11 +598,11 @@
     <comment>OAUTH flow window title.</comment>
   </data>
   <data name="PortManagerWindowCaption" xml:space="preserve">
-    <value>Manage Firewall Ports</value>
+    <value>Firewall Options</value>
     <comment>Caption for the port manager dialog.</comment>
   </data>
   <data name="PortManagerWindowMessage" xml:space="preserve">
-    <value>Set Firewall rules and tags to enable traffic for the instance</value>
+    <value>Firewall rules:</value>
     <comment>Main message in the port manager dialog.</comment>
   </data>
   <data name="AuthorizedNetworksWindowCaption" xml:space="preserve">
@@ -899,8 +899,31 @@
     <value>Windows credentials are used to log in to a Windows machine instance.</value>
     <comment>Tooltip shown in the manage windows credentials window.</comment>
   </data>
+  <data name="PortManagerDisplayStringFormat" xml:space="preserve">
+    <value>{0} ({1} {2})</value>
+    <comment>Format string to compose the display string for a prot. {0} is the port description, {1} is the protocol name, {2} is the port number.</comment>
+  </data>
+  <data name="PortManagerHttpDescription" xml:space="preserve">
+    <value>Allow HTTP traffic to the instance</value>
+    <comment>Description for the HTTP port.</comment>
+  </data>
+  <data name="PortManagerHttpsDescription" xml:space="preserve">
+    <value>Allow HTTPS traffic to the instance</value>
+    <comment>Description for the HTTPS port.</comment>
+  </data>
+  <data name="PortManagerRdpDescription" xml:space="preserve">
+    <value>Allow Remote Desktop connections to the instance</value>
+    <comment>Description for the RDP port.</comment>
+  </data>
+  <data name="PortManagerWebDeployDescription" xml:space="preserve">
+    <value>Allow publishing with WebDeploy to the instance</value>
+    <comment>Description for the WebDeploy port.</comment>
+  </data>
   <data name="ShowPasswordCopiedMessage" xml:space="preserve">
     <value>Password copied to clipboard.</value>
     <comment>Message shown in the popup for the copy operation.</comment>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -634,8 +634,8 @@
     <comment>Message for an error message in the authorized networks dialog for an ipv4 address.</comment>
   </data>
   <data name="ResetPasswordConfirmationPromptMessage" xml:space="preserve">
-    <value>Are you sure you want to reset the password for {0}?</value>
-    <comment>The message for the confirmation prompt for resetting or creating a password. {0) is the user name.</comment>
+    <value>Reset the password for {0} on instance {1}?</value>
+    <comment>The message for the confirmation prompt for resetting or creating a password. {0) is the user name, {1} is the instance name.</comment>
   </data>
   <data name="ResetPasswordConfirmationPromptTitle" xml:space="preserve">
     <value>Reset Password</value>
@@ -666,12 +666,12 @@
     <comment>Title for the prompts shown when gcloud is not installed.</comment>
   </data>
   <data name="AddWindowsCredentialUserNameCaption" xml:space="preserve">
-    <value>User name:</value>
+    <value>_User name:</value>
     <comment>Caption for the user name textbox.</comment>
   </data>
-  <data name="ResetPasswordWindowTitle" xml:space="preserve">
-    <value>Add Credential for VM {0}</value>
-    <comment>The title for the reset password dialog. {0} is the instance name.</comment>
+  <data name="AddWindowsCredentialTitle" xml:space="preserve">
+    <value>Add Windows Credential</value>
+    <comment>The title for the reset password dialog. </comment>
   </data>
   <data name="ShowPasswordCopyFailedMessage" xml:space="preserve">
     <value>The copy operation failed, this might happen if another program has the Windows Clipboard open, such as a virtual machine agent.</value>
@@ -710,7 +710,7 @@
     <comment>Caption for the close window button.</comment>
   </data>
   <data name="UiDownloadButtonCaption" xml:space="preserve">
-    <value>Download</value>
+    <value>_Download</value>
     <comment>The caption for the general download button.</comment>
   </data>
   <data name="UiOkButtonCaption" xml:space="preserve">
@@ -718,15 +718,15 @@
     <comment>Caption for Ok buttons.</comment>
   </data>
   <data name="UiSaveButtonCaption" xml:space="preserve">
-    <value>Save</value>
+    <value>_Save</value>
     <comment>Caption for Save buttons.</comment>
   </data>
   <data name="UiDeleteButtonCaption" xml:space="preserve">
-    <value>Delete</value>
+    <value>_Delete</value>
     <comment>Caption for Delete buttons.</comment>
   </data>
   <data name="UiUndoButtonCaption" xml:space="preserve">
-    <value>Undo</value>
+    <value>_Undo</value>
     <comment>Caption for Undo buttons.</comment>
   </data>
   <data name="UiOpenOnCloudConsoleMenuHeader" xml:space="preserve">
@@ -762,7 +762,7 @@
     <comment>The caption for the delete credentials button in the dialog.</comment>
   </data>
   <data name="ManageWindowsCredentialsDeleteCredentialsPromptMessage" xml:space="preserve">
-    <value>Are you sure you want to the delete the credentials for user {0}?</value>
+    <value>Delete user name {0} from this computer? The credentials will still exist on the Windows instance.</value>
     <comment>The message for the confirmation prompt to delete credentials. The {0} placeholder is the username.</comment>
   </data>
   <data name="ManageWindowsCredentialsDeleteCredentialsPromptTitle" xml:space="preserve">
@@ -814,11 +814,11 @@
     <comment>The title for the choose credentials used during the save publish settings flow.</comment>
   </data>
   <data name="AddWindowsCredentialGeneratePasswordMessage" xml:space="preserve">
-    <value>Generate the password for this user name</value>
+    <value>Create a password for me</value>
     <comment>Message shown in the radio button of the Reset password dialog to signify that the password will be generated instead of provided by the user.</comment>
   </data>
   <data name="AddWindowsCredentialHavePasswordMessage" xml:space="preserve">
-    <value>I have a password for this user name</value>
+    <value>I have a password for this user</value>
     <comment>Message shown in the radio button of the Reset Password dialog to signify that the user will provide the password.</comment>
   </data>
   <data name="ResetWindowSettingPasswordProgressMessage" xml:space="preserve">
@@ -853,15 +853,15 @@
     <value>Type password:</value>
     <comment>Content for the label used for the custom password.</comment>
   </data>
-  <data name="ResetPasswordConfirmationMessage" xml:space="preserve">
+  <data name="UiOperationCannotBeUndone" xml:space="preserve">
     <value>You can't undo this later.</value>
-    <comment>Message shown for the reset password confirmation dialog.</comment>
+    <comment>Message shown in dialogs to indicate that the operation cannot be undone.</comment>
   </data>
   <data name="UiNoButtonCaption" xml:space="preserve">
-    <value>No</value>
+    <value>_No</value>
   </data>
   <data name="UiResetButtonCaption" xml:space="preserve">
-    <value>Reset</value>
+    <value>_Reset</value>
   </data>
   <data name="UiStartButtonCaption" xml:space="preserve">
     <value>Start</value>
@@ -870,7 +870,7 @@
     <value>Stop</value>
   </data>
   <data name="UiYesButtonCaption" xml:space="preserve">
-    <value>Yes</value>
+    <value>_Yes</value>
   </data>
   <data name="ShowPasswordNewPasswordMessage" xml:space="preserve">
     <value>The password for {0} has been set:</value>
@@ -891,6 +891,9 @@
   <data name="AddWindowsCredentialValidationErrorTtitle" xml:space="preserve">
     <value>Add Windows Credential</value>
     <comment>Title for the validation error dialogs in the add windows credential dialog.</comment>
+  </data>
+  <data name="AddWindowsCredentialToolTip" xml:space="preserve">
+    <value>Enter a user name. If the user name already exists as an account on the Windows instance, then you can reset the password or enter the current one.</value>
   </data>
   <data name="ShowPasswordCopiedMessage" xml:space="preserve">
     <value>Password copied to clipboard.</value>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -514,11 +514,11 @@
     <comment>Caption shown when the authorized networks are being updated.</comment>
   </data>
   <data name="CloudExplorerSqlOpenAddDataConnectionMenuHeader" xml:space="preserve">
-    <value>Add Data Connection</value>
+    <value>Add Data Connection...</value>
     <comment>Menu header for the open add data connection dialog menu item.</comment>
   </data>
   <data name="CloudExplorerSqlManageAuthorizedNetworksMenuHeader" xml:space="preserve">
-    <value>Manage Authorized Networks</value>
+    <value>Manage authorized networks...</value>
     <comment>Menu header for the option to manage authorized networks.</comment>
   </data>
   <data name="CloudExplorerSqlRootNodeCaption" xml:space="preserve">

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -774,7 +774,7 @@
     <comment>The caption or the show credentials button in the dialog.</comment>
   </data>
   <data name="ManageWindowsCredentialsWindowMessage" xml:space="preserve">
-    <value>_Credentials for {0}. Windows credentials are used to log in to a Windows machine instance.</value>
+    <value>_Credentials for {0}. </value>
     <comment>Message at the top of the Manage Windows Credentials dialog. The {0} placeholder is the name of the instance.</comment>
   </data>
   <data name="ManageWindowsCredentialsWindowTitle" xml:space="preserve">
@@ -894,6 +894,10 @@
   </data>
   <data name="AddWindowsCredentialToolTip" xml:space="preserve">
     <value>Enter a user name. If the user name already exists as an account on the Windows instance, then you can reset the password or enter the current one.</value>
+  </data>
+  <data name="ManageWindowsCredentialsToolTip" xml:space="preserve">
+    <value>Windows credentials are used to log in to a Windows machine instance.</value>
+    <comment>Tooltip shown in the manage windows credentials window.</comment>
   </data>
   <data name="ShowPasswordCopiedMessage" xml:space="preserve">
     <value>Password copied to clipboard.</value>

--- a/GoogleCloudExtension/GoogleCloudExtension/ShowPassword/ShowPasswordWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/ShowPassword/ShowPasswordWindowContent.xaml
@@ -26,7 +26,6 @@
 
     <UserControl.InputBindings>
         <KeyBinding Key="C" Modifiers="Ctrl" Command="{Binding CopyCommand}" />
-        <KeyBinding Key="W" Modifiers="Ctrl" Command="{Binding TogglePasswordCommand}" />
     </UserControl.InputBindings>
 
     <theming:CommonDialogWindowBaseContent>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBase.cs
@@ -21,22 +21,6 @@ namespace GoogleCloudExtension.Theming
     /// </summary>
     public class CommonDialogWindowBase : DialogWindow
     {
-        public CommonDialogWindowBase(string title, double width, double height)
-        {
-            Title = title;
-            Width = width;
-            Height = height;
-
-            // Common settings to all dialogs.
-            ResizeMode = System.Windows.ResizeMode.NoResize;
-            WindowStartupLocation = System.Windows.WindowStartupLocation.CenterOwner;
-            ShowInTaskbar = false;
-        }
-
-        /// <summary>
-        /// Use this constructor when the dialog size must be calculated from the content.
-        /// </summary>
-        /// <param name="title"></param>
         public CommonDialogWindowBase(string title)
         {
             Title = title;

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -13,6 +13,12 @@
     <Style x:Key="CommonTextStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="Black" />
     </Style>
+    
+    <!-- Text style to be used inside of a tooltip. -->
+    <Style x:Key="CommonToolTipTextStyle" BasedOn="{StaticResource CommonTextStyle}" TargetType="{x:Type TextBlock}">
+        <Setter Property="MaxWidth" Value="200px" />
+        <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
 
     <!-- Label style. -->
     <Style x:Key="CommonLabelStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type Label}">

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -12,6 +12,7 @@
     <!-- Text style. -->
     <Style x:Key="CommonTextStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="Black" />
+        <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
     
     <!-- Text style to be used inside of a tooltip. -->
@@ -180,6 +181,16 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+    
+    <!-- Variations on the style of listboxes. -->
+    
+    <!-- Medium sized listbox item. -->
+    <Style x:Key="CommonMediumListItemStyle" BasedOn="{StaticResource CommonListItemContainerStyle}" TargetType="{x:Type ListBoxItem}">
+        <Setter Property="Height" Value="35px" />
+    </Style>
+    <Style x:Key="CommonMediumListBoxStyle" BasedOn="{StaticResource CommonListBoxStyle}" TargetType="{x:Type ListBox}">
+        <Setter Property="ItemContainerStyle" Value="{StaticResource CommonMediumListItemStyle}" />
     </Style>
 
     <!-- Style for all GroupBox instances. -->

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -192,6 +192,14 @@
     <Style x:Key="CommonMediumListBoxStyle" BasedOn="{StaticResource CommonListBoxStyle}" TargetType="{x:Type ListBox}">
         <Setter Property="ItemContainerStyle" Value="{StaticResource CommonMediumListItemStyle}" />
     </Style>
+    
+    <!-- Large sized listobx item. -->
+    <Style x:Key="CommonLargeListItemStyle" BasedOn="{StaticResource CommonListItemContainerStyle}" TargetType="{x:Type ListBoxItem}">
+        <Setter Property="Height" Value="70px" />
+    </Style>
+    <Style x:Key="CommonLargeListBoxStyle" BasedOn="{StaticResource CommonListBoxStyle}" TargetType="{x:Type ListBox}">
+        <Setter Property="ItemContainerStyle" Value="{StaticResource CommonLargeListItemStyle}" />
+    </Style>
 
     <!-- Style for all GroupBox instances. -->
     <Style x:Key="CommonGroupBoxStyle" TargetType="{x:Type GroupBox}">

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -521,5 +521,109 @@
         <Setter Property="BorderBrush" Value="{StaticResource CommonBorderColors.Border}" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
+    
+    <!-- Common buttons. -->
+
+    <!-- Colors for the dialog button for the various UI states. -->
+    
+    <!-- Normal state -->
+    <SolidColorBrush x:Key="CommonButtonColors.Static.Background" Color="White"/>
+    <SolidColorBrush x:Key="CommonButtonColors.Static.Border" Color="#FFBDBDBD"/>
+    <SolidColorBrush x:Key="CommonButtonColors.Static.Foreground" Color="Black"/>
+
+    <!-- Mouse over state -->
+    <SolidColorBrush x:Key="CommonButtonColors.MouseOver.Background" Color="White"/>
+    <SolidColorBrush x:Key="CommonButtonColors.MouseOver.Border" Color="#FF82B1FF"/>
+    <SolidColorBrush x:Key="CommonButtonColors.MouseOver.Foreground" Color="Black"/>
+
+    <!-- Pressed state -->
+    <SolidColorBrush x:Key="CommonButtonColors.Pressed.Background" Color="#FFF5F5F5"/>
+    <SolidColorBrush x:Key="CommonButtonColors.Pressed.Border" Color="#FF82B1FF"/>
+    <SolidColorBrush x:Key="CommonButtonColors.Pressed.Foreground" Color="Black"/>
+
+    <!-- Disabled state -->
+    <SolidColorBrush x:Key="CommonButtonColors.Disabled.Background" Color="#FFE0E0E0"/>
+    <SolidColorBrush x:Key="CommonButtonColors.Disabled.Border" Color="#FFBDBDBD"/>
+    <SolidColorBrush x:Key="CommonButtonColors.Disabled.Foreground" Color="#FF9E9E9E"/>
+
+
+    <!-- The dialog button visuals. -->
+    <Style x:Key="CommonButtonFocusVisualStyle">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="CommonButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="Background" Value="Blue" />
+        <Setter Property="Width" Value="96px" />
+        <Setter Property="Height" Value="25px" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource CommonButtonFocusVisualStyle}"/>
+        <Setter Property="Background" Value="{StaticResource CommonButtonColors.Static.Background}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource CommonButtonColors.Static.Border}"/>
+        <Setter Property="Foreground" Value="{StaticResource CommonButtonColors.Static.Foreground}" />
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Padding" Value="1"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="true" CornerRadius="2">
+                        <ContentPresenter x:Name="contentPresenter"
+                                          Focusable="False"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          Margin="{TemplateBinding Padding}"
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Style="{StaticResource CommonTextStyleBase}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="Background" TargetName="border" Value="{StaticResource CommonButtonColors.MouseOver.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource CommonButtonColors.MouseOver.Border}"/>
+                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource CommonButtonColors.MouseOver.Foreground}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="true">
+                            <Setter Property="Background" TargetName="border" Value="{StaticResource CommonButtonColors.Pressed.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource CommonButtonColors.Pressed.Border}"/>
+                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource CommonButtonColors.Pressed.Foreground}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Background" TargetName="border" Value="{StaticResource CommonButtonColors.Disabled.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource CommonButtonColors.Disabled.Border}"/>
+                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource CommonButtonColors.Disabled.Foreground}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <!-- Common variations of buttons. -->
+
+    <!-- Dynamic button that adjusts to the contents. -->
+    <Style x:Key="CommonButtonDynamicStyle" BasedOn="{StaticResource CommonButtonStyle}" TargetType="{x:Type Button}">
+        <Setter Property="Width" Value="auto" />
+        <Setter Property="Padding" Value="5,0" />
+    </Style>
+
+    <!-- Style for wide buttons. -->
+    <Style x:Key="CommonButtonWideStyle" BasedOn="{StaticResource CommonButtonStyle}" TargetType="{x:Type Button}">
+        <Setter Property="Width" Value="110px" />
+    </Style>
+
+    <!-- Style for the standard buttons. -->
+    <Style x:Key="CommonButtonStandardStyle" BasedOn="{StaticResource CommonButtonStyle}" TargetType="{x:Type Button}">
+        <Setter Property="Width" Value="75px" />
+    </Style>
 
 </ResourceDictionary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -9,16 +9,42 @@
         <Setter Property="TextElement.FontSize" Value="12px" />
     </Style>
 
-    <!-- Label style. -->
-    <Style x:Key="CommonLabelStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type Label}">
-        <Setter Property="TextElement.Foreground" Value="Black" />
-        <Setter Property="Padding" Value="0" />
-        <Setter Property="Margin" Value="0,0,0,5" />
-    </Style>
-
     <!-- Text style. -->
     <Style x:Key="CommonTextStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="Black" />
+    </Style>
+
+    <!-- Label style. -->
+    <Style x:Key="CommonLabelStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type Label}">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Margin" Value="0,0,0,5" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Label}">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                        <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            <ContentPresenter.Resources>
+                                <!-- Ensure that the text in the label wraps. -->
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource CommonTextStyle}">
+                                    <Setter Property="TextWrapping" Value="Wrap" />
+                                </Style>
+                            </ContentPresenter.Resources>
+                        </ContentPresenter>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- Common sizes for dialogs. -->

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -55,29 +55,34 @@
     </Style>
 
     <!-- Common sizes for dialogs. -->
+    
+    <!-- Base style for all dialog styles. -->
+    <Style x:Key="CommonDialogStyleBase" TargetType="{x:Type UserControl}">
+        <Setter Property="Focusable" Value="False" />
+    </Style>
 
     <!-- Static sizes. -->
     <!-- Small dialog, typical for prompts. -->
-    <Style x:Key="CommonDialogStyleSmall" TargetType="{x:Type UserControl}">
+    <Style x:Key="CommonDialogStyleSmall" BasedOn="{StaticResource CommonDialogStyleBase}" TargetType="{x:Type UserControl}">
         <Setter Property="Width" Value="300px" />
         <Setter Property="Height" Value="100px" />
     </Style>
 
-    <!-- Larget dialog, typical for wizards or main entry dialogs. -->
-    <Style x:Key="CommonDialogStyleLarge" TargetType="{x:Type UserControl}">
+    <!-- Large dialog, typical for wizards or main entry dialogs. -->
+    <Style x:Key="CommonDialogStyleLarge" BasedOn="{StaticResource CommonDialogStyleBase}" TargetType="{x:Type UserControl}">
         <Setter Property="Width" Value="500px" />
         <Setter Property="Height" Value="350px" />
     </Style>
 
     <!-- Dynamic sizes. -->
     <!-- Small dialog, fixed on the width but allows it to grow vertically. -->
-    <Style x:Key="CommonDialogStyleDynamicSmall" TargetType="{x:Type UserControl}">
+    <Style x:Key="CommonDialogStyleDynamicSmall" BasedOn="{StaticResource CommonDialogStyleBase}" TargetType="{x:Type UserControl}">
         <Setter Property="Width" Value="300px" />
         <Setter Property="MinHeight" Value="100px" />
     </Style>
 
     <!-- Large dialog, fixed on the width but allows it to grow vertically. -->
-    <Style x:Key="CommonDialogStyleDynamicLarge" TargetType="{x:Type UserControl}">
+    <Style x:Key="CommonDialogStyleDynamicLarge" BasedOn="{StaticResource CommonDialogStyleBase}" TargetType="{x:Type UserControl}">
         <Setter Property="Width" Value="500px" />
         <Setter Property="MinHeight" Value="350px" />
     </Style>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/ThemingResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/ThemingResources.xaml
@@ -56,6 +56,7 @@
 
     <!-- The dialog visuals. -->
     <Style TargetType="{x:Type local:CommonDialogWindowBaseContent}">
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:CommonDialogWindowBaseContent}">
@@ -91,6 +92,7 @@
                                 <Border Grid.Row="1" Style="{StaticResource DialogButtonBar}">
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                         <local:ButtonsList ItemsSource="{Binding Buttons.Collection, RelativeSource={RelativeSource TemplatedParent}}"
+                                                           Focusable="False"
                                                            ItemTemplateSelector="{StaticResource DialogButtonTemplateSelector}">
                                             <ItemsControl.ItemsPanel>
                                                 <ItemsPanelTemplate>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/ThemingResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/ThemingResources.xaml
@@ -7,99 +7,6 @@
         <ResourceDictionary Source="CommonResources.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <!-- Colors for the dialog button for the various UI states. -->
-
-    <!-- Normal state -->
-    <SolidColorBrush x:Key="DialogButtonColors.Static.Background" Color="White"/>
-    <SolidColorBrush x:Key="DialogButtonColors.Static.Border" Color="#FFBDBDBD"/>
-    <SolidColorBrush x:Key="DialogButtonColors.Static.Foreground" Color="Black"/>
-
-    <!-- Mouse over state -->
-    <SolidColorBrush x:Key="DialogButtonColors.MouseOver.Background" Color="White"/>
-    <SolidColorBrush x:Key="DialogButtonColors.MouseOver.Border" Color="#FF82B1FF"/>
-    <SolidColorBrush x:Key="DialogButtonColors.MouseOver.Foreground" Color="Black"/>
-
-    <!-- Pressed state -->
-    <SolidColorBrush x:Key="DialogButtonColors.Pressed.Background" Color="#FFF5F5F5"/>
-    <SolidColorBrush x:Key="DialogButtonColors.Pressed.Border" Color="#FF82B1FF"/>
-    <SolidColorBrush x:Key="DialogButtonColors.Pressed.Foreground" Color="Black"/>
-
-    <!-- Disabled state -->
-    <SolidColorBrush x:Key="DialogButtonColors.Disabled.Background" Color="#FFE0E0E0"/>
-    <SolidColorBrush x:Key="DialogButtonColors.Disabled.Border" Color="#FFBDBDBD"/>
-    <SolidColorBrush x:Key="DialogButtonColors.Disabled.Foreground" Color="#FF9E9E9E"/>
-
-    <!-- The dialog button visuals. -->
-    <Style x:Key="DialogFocusVisual">
-        <Setter Property="Control.Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style x:Key="DialogButtonStyle" TargetType="{x:Type Button}">
-        <Setter Property="Background" Value="Blue" />
-        <Setter Property="Width" Value="96px" />
-        <Setter Property="Height" Value="25px" />
-        <Setter Property="FocusVisualStyle" Value="{StaticResource DialogFocusVisual}"/>
-        <Setter Property="Background" Value="{StaticResource DialogButtonColors.Static.Background}"/>
-        <Setter Property="BorderBrush" Value="{StaticResource DialogButtonColors.Static.Border}"/>
-        <Setter Property="Foreground" Value="{StaticResource DialogButtonColors.Static.Foreground}" />
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Padding" Value="1"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
-                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}"
-                            SnapsToDevicePixels="true" CornerRadius="2">
-                        <ContentPresenter x:Name="contentPresenter"
-                                          Focusable="False"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          Margin="{TemplateBinding Padding}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Style="{StaticResource CommonTextStyleBase}"/>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" TargetName="border" Value="{StaticResource DialogButtonColors.MouseOver.Background}"/>
-                            <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource DialogButtonColors.MouseOver.Border}"/>
-                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource DialogButtonColors.MouseOver.Foreground}"/>
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" TargetName="border" Value="{StaticResource DialogButtonColors.Pressed.Background}"/>
-                            <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource DialogButtonColors.Pressed.Border}"/>
-                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource DialogButtonColors.Pressed.Foreground}"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Background" TargetName="border" Value="{StaticResource DialogButtonColors.Disabled.Background}"/>
-                            <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource DialogButtonColors.Disabled.Border}"/>
-                            <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource DialogButtonColors.Disabled.Foreground}"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <!-- Style for wide buttons. -->
-    <Style x:Key="DialogButtonWide" BasedOn="{StaticResource DialogButtonStyle}" TargetType="{x:Type Button}">
-        <Setter Property="Width" Value="110px" />
-    </Style>
-
-    <!-- Style for the standard buttons. -->
-    <Style x:Key="DialogButtonStandard" BasedOn="{StaticResource DialogButtonStyle}" TargetType="{x:Type Button}">
-        <Setter Property="Width" Value="75px" />
-    </Style>
-
     <!-- Styles for the dialog. -->
 
     <!-- Style for the background of the dialog. -->
@@ -120,7 +27,7 @@
 
     <!-- Template to display the button using the wide size in the button bar. -->
     <DataTemplate x:Key="DialogButtonTemplateWide">
-        <Button Style="{StaticResource DialogButtonWide}"
+        <Button Style="{StaticResource CommonButtonWideStyle}"
                 Margin="{StaticResource DialogButtonMargin}"
                 Command="{Binding Command}"
                 IsDefault="{Binding IsDefault}"
@@ -132,7 +39,7 @@
 
     <!-- Template to display the button in the standard size in the button bar. -->
     <DataTemplate x:Key="DialogButtonTemplateStandard">
-        <Button Style="{StaticResource DialogButtonStandard}"
+        <Button Style="{StaticResource CommonButtonStandardStyle}"
                 Margin="{StaticResource DialogButtonMargin}"
                 Command="{Binding Command}"
                 IsDefault="{Binding IsDefault}"

--- a/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserViewModel.cs
@@ -46,6 +46,11 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
         public string Message => _options.Message;
 
         /// <summary>
+        /// The caption for the aciton button.
+        /// </summary>
+        public string ActionButtonCaption => _options.ActionButtonCaption;
+
+        /// <summary>
         /// The list of credentials for the current instance.
         /// </summary>
         public IEnumerable<WindowsInstanceCredentials> InstanceCredentials
@@ -66,7 +71,7 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
         /// <summary>
         /// The command to execute in the OK button.
         /// </summary>
-        public ProtectedCommand OkCommand { get; }
+        public ProtectedCommand ActionCommand { get; }
 
         /// <summary>
         /// The command to exectue from the manage credentials button.
@@ -96,7 +101,7 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
             _options = options;
             _owner = owner;
 
-            OkCommand = new ProtectedCommand(OnOkCommand, canExecuteCommand: false);
+            ActionCommand = new ProtectedCommand(OnActionCommand, canExecuteCommand: false);
             ManageCredentialsCommand = new ProtectedCommand(OnManageCredentialsCommand);
 
             LoadCredentials();
@@ -120,11 +125,11 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
             {
                 HasCredentials = true;
             }
-            OkCommand.CanExecuteCommand = HasCredentials;
+            ActionCommand.CanExecuteCommand = HasCredentials;
             CurrentCredentials = InstanceCredentials.FirstOrDefault();
         }
 
-        private void OnOkCommand()
+        private void OnActionCommand()
         {
             Result = CurrentCredentials;
             _owner.Close();

--- a/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserWindow.cs
@@ -37,12 +37,16 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
             /// The message to show in the dialog.
             /// </summary>
             public string Message { get; set; }
+
+            /// <summary>
+            /// The caption for the aciton button.
+            /// </summary>
+            public string ActionButtonCaption { get; set; }
         }
 
         private WindowsCredentialsChooserViewModel ViewModel { get; }
 
-        private WindowsCredentialsChooserWindow(Instance instance, Options options) :
-            base(options.Title, 300, 200)
+        private WindowsCredentialsChooserWindow(Instance instance, Options options) : base(options.Title)
         {
             ViewModel = new WindowsCredentialsChooserViewModel(instance, options, this);
             Content = new WindowsCredentialsChooserWindowContent { DataContext = ViewModel };

--- a/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserWindowContent.xaml
@@ -7,14 +7,25 @@
              xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300"
              d:DataContext="{d:DesignInstance {x:Type local:WindowsCredentialsChooserViewModel}}">
 
-    <theming:CommonDialogWindowBaseContent>
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicLarge}" />
+    </UserControl.Style>
+
+    <theming:CommonDialogWindowBaseContent HasBanner="True">
         <theming:CommonDialogWindowBaseContent.Buttons>
-            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiOkButtonCaption}"
+            <theming:DialogButtonInfo Caption="{Binding ActionButtonCaption}"
                                       IsDefault="True"
-                                      Command="{Binding OkCommand}" />
+                                      Command="{Binding ActionCommand}" />
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCancelButtonCaption}"
                                       IsCancel="true" />
         </theming:CommonDialogWindowBaseContent.Buttons>


### PR DESCRIPTION
This PR ensures that the right elements in the tree are focusable and adds some missing shortcut keys to the caption of buttons in the main dialogs.

This fixes #263 and the PR is based on PR #265 and contains part of those changes. Will be merged after all other PRs are in.