### PR TITLE
Reset the credentials on refresh, which include reloading the projects.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
@@ -286,7 +286,7 @@ namespace GoogleCloudExtension.CloudExplorer
 
         private void OnRefreshCommand()
         {
-            RefreshSources();
+            ResetCredentials();
         }
 
         #endregion


### PR DESCRIPTION
This PR fixes #268 by acting as if the credentials have changed when the user presses the refresh button. On this the cloud explorer will re-load the list of projects and attempt to use the current project as the new current project, if that fails then the very first project will be chosen.

Incredibly simple change.