### PR TITLE
Disable the commands if the items is busy.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
@@ -190,14 +190,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         private void UpdateContextMenu()
         {
-            // If the instance is busy, then there's no context menu.
-            // TODO(ivann): Should we have a "Cancel Operation" menu item?
-            if (IsLoading || IsError)
-            {
-                ContextMenu = null;
-                return;
-            }
-
             var getPublishSettingsCommand = new ProtectedCommand(OnSavePublishSettingsCommand, canExecuteCommand: Instance.IsAspnetInstance());
             var openWebSite = new ProtectedCommand(OnOpenWebsite, canExecuteCommand: Instance.IsAspnetInstance() && Instance.IsRunning());
             var openTerminalServerSessionCommand = new ProtectedCommand(
@@ -230,6 +222,23 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             menuItems.Add(new MenuItem { Header = Resources.UiPropertiesMenuHeader, Command = new ProtectedCommand(OnPropertiesWindowCommand) });
 
             ContextMenu = new ContextMenu { ItemsSource = menuItems };
+
+            // If the instance is busy or in error then we need to disable all commands.
+            if (IsError || IsLoading)
+            {
+                foreach (var item in ContextMenu.ItemsSource)
+                {
+                    var menu = item as MenuItem;
+                    if (menu != null)
+                    {
+                        if (menu.Command is ProtectedCommand)
+                        {
+                            var cmd = (ProtectedCommand)menu.Command;
+                            cmd.CanExecuteCommand = false;
+                        }
+                    }
+                }
+            }
         }
 
         private void OnSavePublishSettingsCommand()


### PR DESCRIPTION
This PR fixes #158 by disabling all of the commands in the context menu if the GCE VM is either busy or in error.

To disable all of the commands the code will iterate through all of the `MenuItem` instances, ignoring all others. Also only the plain `ProtectedCommand` class is supported. If further generalization is required more work will have to be done.