### PR TITLE
Updating the version.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 
 // This version number matches the version in the .vsixmanifest. Please update both versions at the
 // same time.
-[assembly: AssemblyVersion("0.9.4.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
+++ b/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     The Version attribute of the Identity element *must* match the version number in Properties\AssemblyInfo.cs, to ensure 
     accurate metrics.
     -->
-    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="0.9.4.0" Language="en-US" Publisher="Google Inc." />
+    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="1.0.2.0" Language="en-US" Publisher="Google Inc." />
     <DisplayName>Google Cloud Tools for Visual Studio</DisplayName>
     <Description xml:space="preserve">Tools to develop applications for Google Cloud Platform.</Description>
     <MoreInfo>https://cloud.google.com/visual-studio/</MoreInfo>


### PR DESCRIPTION
Updating the version number for GA.

This version number is higher than internal versions as well to allow for automatic update.