### PR TITLE
Adding support for invalidating the UI state of the commands.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
@@ -212,6 +212,10 @@ namespace GoogleCloudExtension
 
             // Update the installation status of the package.
             CheckInstallationStatus();
+
+            // Ensure the commands UI state is updated when the GCP project changes.
+            CredentialsStore.Default.Reset += (o, e) => ShellUtils.InvalidateCommandsState();
+            CredentialsStore.Default.CurrentProjectIdChanged += (o, e) => ShellUtils.InvalidateCommandsState();
         }
 
         public static GoogleCloudExtensionPackage Instance { get; private set; }

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/ShellUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/ShellUtils.cs
@@ -67,6 +67,26 @@ namespace GoogleCloudExtension.Utils
             return new Disposable(SetShellNormal);
         }
 
+        /// <summary>
+        /// Updates the UI state of all commands in the VS shell. This is useful when the state that determines
+        /// if a command is enabled/disabled (or visible/invisiable) changes and the commands in the menus need
+        /// to be updated.
+        /// In essence this method will cause the <seealso cref="OnBeforeQueryStatus"/> method in all commands to be
+        /// called again.
+        /// </summary>
+        public static void InvalidateCommandsState()
+        {
+            var shell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell;
+            if (shell == null)
+            {
+                Debug.WriteLine($"Could not acquire {nameof(SVsUIShell)}");
+                return;
+            }
+
+            // Updates the UI asynchronously.
+            shell.UpdateCommandUI(fImmediateUpdate: 0);
+        }
+
         private static void SetShellNormal()
         {
             var monitorSelection = GetMonitorSelectionService();


### PR DESCRIPTION
This PR introduces a way for the code to programmatically invalidate the UI state of the menu commands by invoking the `SVsUIShell` service to invalidate the UI state of all commands.

Visual Studio will normally invalidate the UI state of the commands frequently enough that this is not needed, such as when a solution is loaded or closed, during the transition to debug mode, etc... There are sometimes however when we need to force this to happen, such as when the current GCP project changes.

This PR also adds event handlers to the GCP project change events to ensure that refresh the UI in that case.