### PR TITLE
Master reimplement connection dialog

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -173,28 +173,28 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             // Check if the MySQL data source exists.
             // TODO(talarico): This is added when the user has MySQL for Visual Studio installed.  We should also
             // probably check for the needed pieces in the MySQL Connector/Net.
-            if (dialog.AvailableSources.Contains(MySQLUtils.MySQLDataSource))
+            if (dialog.AvailableSources.Contains(CloudSqlUtils.DataSource))
             {
                 EventsReporterWrapper.ReportEvent(OpenCloudSqlConnectionDialogEvent.Create());
 
                 // Pre select the MySQL data source.
-                dialog.SelectedSource = MySQLUtils.MySQLDataSource;
+                dialog.SelectedSource = CloudSqlUtils.DataSource;
 
                 // Create the connection string to pre populate the server address in the dialog.
                 InstanceItem instance = GetItem();
                 var server = String.IsNullOrEmpty(instance.IpAddress) ? instance.Ipv6Address : instance.IpAddress;
-                dialog.DisplayConnectionString = MySQLUtils.FormatServerConnectionString(server);
+                dialog.DisplayConnectionString = CloudSqlUtils.FormatServerConnectionString(server);
 
                 bool addDataConnection = dialog.ShowDialog();
                 if (addDataConnection)
                 {
                     // Create a name for the data connection
-                    var parsedConnection = MySQLUtils.ParseConnection(dialog.DisplayConnectionString);
+                    var parsedConnection = CloudSqlUtils.ParseConnection(dialog.DisplayConnectionString);
                     string database = $"{Instance.Project}[{parsedConnection.Server}][{parsedConnection.Database}]";
 
                     // Add the MySQL data connection to the data explorer
                     DataExplorerConnectionManager manager = (DataExplorerConnectionManager)Package.GetGlobalService(typeof(DataExplorerConnectionManager));
-                    manager.AddConnection(database, MySQLUtils.MySQLDataProvider, dialog.EncryptedConnectionString, true);
+                    manager.AddConnection(database, CloudSqlUtils.DataProvider, dialog.EncryptedConnectionString, true);
                 }
             }
             else

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -182,19 +182,27 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
 
                 // Create the connection string to pre populate the server address in the dialog.
                 InstanceItem instance = GetItem();
-                var server = String.IsNullOrEmpty(instance.IpAddress) ? instance.Ipv6Address : instance.IpAddress;
-                dialog.DisplayConnectionString = CloudSqlUtils.FormatServerConnectionString(server);
+                var serverAddress = String.IsNullOrEmpty(instance.IpAddress) ? instance.Ipv6Address : instance.IpAddress;
+                dialog.DisplayConnectionString = CloudSqlUtils.FormatServerConnectionString(serverAddress);
 
                 bool addDataConnection = dialog.ShowDialog();
                 if (addDataConnection)
                 {
                     // Create a name for the data connection
                     var parsedConnection = CloudSqlUtils.ParseConnection(dialog.DisplayConnectionString);
-                    string database = $"{Instance.Project}[{parsedConnection.Server}][{parsedConnection.Database}]";
+                    string connectionName;
+                    if (parsedConnection.Server == serverAddress)
+                    {
+                        connectionName = $"{Instance.Project}[{Instance.Name}][{parsedConnection.Database}]";
+                    }
+                    else
+                    {
+                        connectionName = $"{parsedConnection.Server}[{parsedConnection.Database}]";
+                    }
 
                     // Add the MySQL data connection to the data explorer
                     DataExplorerConnectionManager manager = (DataExplorerConnectionManager)Package.GetGlobalService(typeof(DataExplorerConnectionManager));
-                    manager.AddConnection(database, CloudSqlUtils.DataProvider, dialog.EncryptedConnectionString, true);
+                    manager.AddConnection(connectionName, CloudSqlUtils.DataProvider, dialog.EncryptedConnectionString, true);
                 }
             }
             else

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -22,7 +22,6 @@ using GoogleCloudExtension.MySQLInstaller;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Data;
 using Microsoft.VisualStudio.Shell;
-using MySql.Data.MySqlClient;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -182,17 +181,16 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
                 dialog.SelectedSource = MySQLUtils.MySQLDataSource;
 
                 // Create the connection string to pre populate the server address in the dialog.
-                MySqlConnectionStringBuilder builderPrePopulate = new MySqlConnectionStringBuilder();
                 InstanceItem instance = GetItem();
-                builderPrePopulate.Server = String.IsNullOrEmpty(instance.IpAddress) ? instance.Ipv6Address : instance.IpAddress;
-                dialog.DisplayConnectionString = builderPrePopulate.GetConnectionString(false);
+                var server = String.IsNullOrEmpty(instance.IpAddress) ? instance.Ipv6Address : instance.IpAddress;
+                dialog.DisplayConnectionString = MySQLUtils.FormatServerConnectionString(server);
 
                 bool addDataConnection = dialog.ShowDialog();
                 if (addDataConnection)
                 {
                     // Create a name for the data connection
-                    MySqlConnectionStringBuilder builder = new MySqlConnectionStringBuilder(dialog.DisplayConnectionString);
-                    string database = $"{Instance.Project}[{builder.Server}][{builder.Database}]";
+                    var parsedConnection = MySQLUtils.ParseConnection(dialog.DisplayConnectionString);
+                    string database = $"{Instance.Project}[{parsedConnection.Server}][{parsedConnection.Database}]";
 
                     // Add the MySQL data connection to the data explorer
                     DataExplorerConnectionManager manager = (DataExplorerConnectionManager)Package.GetGlobalService(typeof(DataExplorerConnectionManager));

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -256,6 +256,9 @@
     <Resource Include="Controls\Resources\step_8_dark.png" />
     <Resource Include="Controls\Resources\step_9_dark.png" />
     <Resource Include="CloudExplorerSources\Gcs\Resources\zone_icon.png" />
+    <Content Include="Licenses.txt">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="ProjectTemplates\Google Cloud Platform\GoogleAspnetMvc.zip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -218,7 +218,7 @@
     <Compile Include="Utils\LocalizedCategoryAttribute.cs" />
     <Compile Include="Utils\LocalizedDescriptionAttribute.cs" />
     <Compile Include="Utils\LocalizedDisplayNameAttribute.cs" />
-    <Compile Include="Utils\MySQLUtils.cs" />
+    <Compile Include="Utils\CloudSqlUtils.cs" />
     <Compile Include="Utils\PropertyWindowItemBase.cs" />
     <Compile Include="Utils\ResourceUtils.cs" />
     <Compile Include="Utils\SelectionUtils.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -452,10 +452,6 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/GoogleCloudExtension/GoogleCloudExtension/Licenses.txt
+++ b/GoogleCloudExtension/GoogleCloudExtension/Licenses.txt
@@ -1,0 +1,238 @@
+﻿BouncyCastle:
+
+LICENSE
+Copyright (c) 2000 - 2015 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Google.Apis
+Google.Apis.Auth
+Google.Apis.CloudResourceManager.v1
+Google.Apis.Compute.v1
+Google.Apis.Core
+Google.Apis.Plus.v1
+Google.Apis.SQLAdmin.v1beta4
+Google.Apis.Storage.v1
+Log4net
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+NewtonSoft.Json:
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ZLib.Portable.Signed:
+
+Copyright (c) <''year''> <''copyright holders''>
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
@@ -30,20 +30,27 @@ namespace GoogleCloudExtension.Utils
         }
     }
 
-    internal static class MySQLUtils
+    internal static class CloudSqlUtils
     {
         /// <summary>
-        /// The GUID for the MySQL Database.
+        /// The GUID for the Cloud SQL database.
         /// </summary>
-        public static Guid MySQLDataSource { get; } = new Guid("{98FBE4D8-5583-4233-B219-70FF8C7FBBBD}");
+        public static Guid DataSource { get; } = new Guid("{98FBE4D8-5583-4233-B219-70FF8C7FBBBD}");
 
         /// <summary>
         /// The GUID for the MySQL Database Provider.
         /// </summary>
-        public static Guid MySQLDataProvider { get; } = new Guid("{C6882346-E592-4da5-80BA-D2EADCDA0359}");
+        public static Guid DataProvider { get; } = new Guid("{C6882346-E592-4da5-80BA-D2EADCDA0359}");
 
+        /// <summary>
+        /// Formats a connection string for the given server.
+        /// </summary>
+        /// <param name="server">The server name or IP address.</param>
         public static string FormatServerConnectionString(string server) => $"server={server}";
 
+        /// <summary>
+        /// Parses the connection string into its portions.
+        /// </summary>
         public static CloudSqlInstanceConnection ParseConnection(string connection)
         {
             var values = connection.Split(';');

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
@@ -46,7 +46,7 @@ namespace GoogleCloudExtension.Utils
         /// Formats a connection string for the given server.
         /// </summary>
         /// <param name="server">The server name or IP address.</param>
-        public static string FormatServerConnectionString(string server) => $"Server={server};User Id=root";
+        public static string FormatServerConnectionString(string server) => $"server={server}";
 
         /// <summary>
         /// Parses the connection string into its portions.

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
@@ -17,10 +17,19 @@ using System.Diagnostics;
 
 namespace GoogleCloudExtension.Utils
 {
+    /// <summary>
+    /// This class contains the basic information for a connection string to a Cloud SQL instance.
+    /// </summary>
     internal class CloudSqlInstanceConnection
     {
+        /// <summary>
+        /// The the IP address of the Cloud SQL instance.
+        /// </summary>
         public string Server { get; }
 
+        /// <summary>
+        /// The database we're connected to.
+        /// </summary>
         public string Database { get; }
 
         public CloudSqlInstanceConnection(string server, string database)

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/CloudSqlUtils.cs
@@ -46,7 +46,7 @@ namespace GoogleCloudExtension.Utils
         /// Formats a connection string for the given server.
         /// </summary>
         /// <param name="server">The server name or IP address.</param>
-        public static string FormatServerConnectionString(string server) => $"server={server}";
+        public static string FormatServerConnectionString(string server) => $"Server={server};User Id=root";
 
         /// <summary>
         /// Parses the connection string into its portions.
@@ -66,7 +66,7 @@ namespace GoogleCloudExtension.Utils
                     continue;
                 }
 
-                switch (parsedValue[0])
+                switch (parsedValue[0].ToLowerInvariant())
                 {
                     case "server":
                         server = parsedValue[1];

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/MySQLUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/MySQLUtils.cs
@@ -13,19 +13,65 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics;
 
 namespace GoogleCloudExtension.Utils
 {
+    internal class CloudSqlInstanceConnection
+    {
+        public string Server { get; }
+
+        public string Database { get; }
+
+        public CloudSqlInstanceConnection(string server, string database)
+        {
+            Server = server;
+            Database = database;
+        }
+    }
+
     internal static class MySQLUtils
     {
         /// <summary>
         /// The GUID for the MySQL Database.
         /// </summary>
-        public static readonly Guid MySQLDataSource = new Guid("{98FBE4D8-5583-4233-B219-70FF8C7FBBBD}");
+        public static Guid MySQLDataSource { get; } = new Guid("{98FBE4D8-5583-4233-B219-70FF8C7FBBBD}");
 
         /// <summary>
         /// The GUID for the MySQL Database Provider.
         /// </summary>
-        public static readonly Guid MySQLDataProvider = new Guid("{C6882346-E592-4da5-80BA-D2EADCDA0359}");
+        public static Guid MySQLDataProvider { get; } = new Guid("{C6882346-E592-4da5-80BA-D2EADCDA0359}");
+
+        public static string FormatServerConnectionString(string server) => $"server={server}";
+
+        public static CloudSqlInstanceConnection ParseConnection(string connection)
+        {
+            var values = connection.Split(';');
+            string server = null;
+            string database = null;
+
+            foreach (var value in values)
+            {
+                var parsedValue = value.Split('=');
+                if (parsedValue.Length != 2)
+                {
+                    Debug.WriteLine($"Invalid value in connection string: {value}");
+                    continue;
+                }
+
+                switch (parsedValue[0])
+                {
+                    case "server":
+                        server = parsedValue[1];
+                        break;
+
+                    case "database":
+                        database = parsedValue[1];
+                        break;
+                }
+            }
+
+            return new CloudSqlInstanceConnection(server: server, database: database);
+        }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/app.config
+++ b/GoogleCloudExtension/GoogleCloudExtension/app.config
@@ -13,9 +13,4 @@
     </assemblyBinding>
   </runtime>
 
-<system.data>
-    <DbProviderFactories>
-      <remove invariant="MySql.Data.MySqlClient" />
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
-    </DbProviderFactories>
-  </system.data></configuration>
+</configuration>

--- a/GoogleCloudExtension/GoogleCloudExtension/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension/packages.config
@@ -30,7 +30,6 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net452" />
   <package id="Microsoft.VSSDK.BuildTools" version="14.3.25420" targetFramework="net452" developmentDependency="true" />
-  <package id="MySql.Data" version="6.9.9" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Re-implementing the connection dialog functionality by directly modifying the connection string syntax. Also cleaned up a little bit the logic to create the name of the connection string to always try to use the name of the Cloud SQL instance if possible, it is more descriptive.

This should fix #307