### PR TITLE
Styling the tooltip for the help label.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -680,6 +680,23 @@
            TargetType="{x:Type ComboBox}">
         <Setter Property="Height" Value="30px" />
     </Style>
+    
+    <!-- Default tyle for a tooltip. -->
+    <SolidColorBrush x:Key="CommonTooltipColors.Border" Color="#FFBDBDBD" />
+    <SolidColorBrush x:Key="CommonTooltipColors.Background" Color="#FFEEEEEE" />
+
+    <Style x:Key="CommonTooltipStyle" TargetType="{x:Type ToolTip}">
+        <Setter Property="BorderBrush" Value="{StaticResource CommonTooltipColors.Border}" />
+        <Setter Property="Background" Value="{StaticResource CommonTooltipColors.Background}" />
+        <Setter Property="Padding" Value="8px" />
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" Style="{StaticResource CommonToolTipTextStyle}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
     <!-- Default style for the LabelWithHelp control. -->
     <Style x:Key="{x:Type controls:LabelWithHelp}"
@@ -713,8 +730,7 @@
                                    Width="14px"
                                    Height="14px">
                                 <Image.ToolTip>
-                                    <TextBlock Text="{TemplateBinding HelpContent}"
-                                               Style="{StaticResource CommonToolTipTextStyle}" />
+                                    <ToolTip Content="{TemplateBinding HelpContent}" Style="{StaticResource CommonTooltipStyle}" />
                                 </Image.ToolTip>
                             </Image>
 


### PR DESCRIPTION
Styling the tooltip that is shown from the `LabelWithHelp` control to match the redlines. It now looks like this:
<img width="276" alt="screen shot 2016-11-24 at 3 15 21 pm" src="https://cloud.githubusercontent.com/assets/9807532/20603310/d5c0c010-b258-11e6-98d2-91da791f150e.png">

