### PR TITLE
Ensure that all strings are extracted.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksWindowContent.xaml
@@ -40,7 +40,7 @@
             <!-- Header of the dialog. -->
             <StackPanel Margin="0,0,0,18">
                 <GroupBox Grid.Row="1"
-                          Header="Network"
+                          Header="{x:Static ext:Resources.AuthorizedNetworksNetworkHeader}"
                           Style="{StaticResource CommonGroupBoxStyle}">
                     <StackPanel>
                         <Grid>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
@@ -34,13 +34,13 @@ namespace GoogleCloudExtension.CloudExplorer
             new TreeLeaf
             {
                 IsError = true,
-                Caption = "No credentials, please login.",
+                Caption = Resources.CloudExplorerNoLoggedInMessage,
             };
         private static readonly TreeLeaf s_noProjectPlaceholder =
             new TreeLeaf
             {
                 IsError = true,
-                Caption = "No project selected.",
+                Caption = Resources.CloudExplorerNoProjectSelectedMessage,
             };
         private static readonly Lazy<ImageSource> s_nodeIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(NodeIconPath));
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
@@ -42,7 +42,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             _owner = owner;
             _zone = zone;
 
-            Caption = $"{zone.Name} ({instances.Count()})";
+            Caption = String.Format(Resources.CloudExplorerGceZoneCaption, zone.Name, instances.Count());
             Icon = s_zoneIcon.Value;
 
             foreach (var instance in instances)

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/BucketLocationViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/BucketLocationViewModel.cs
@@ -39,7 +39,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
             _owner = owner;
             _buckets = buckets;
 
-            Caption = $"{name} ({buckets.Count()})";
+            Caption = String.Format(Resources.CloudExplorerGcsBucketLocationCaption, name, buckets.Count());
             Icon = s_zoneIcon.Value;
             foreach (var bucket in _buckets)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -210,6 +210,15 @@ namespace GoogleCloudExtension
         public static string AnalyticsPromptTitle {
             get {
                 return ResourceManager.GetString("AnalyticsPromptTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Network.
+        /// </summary>
+        public static string AuthorizedNetworksNetworkHeader {
+            get {
+                return ResourceManager.GetString("AuthorizedNetworksNetworkHeader", resourceCulture);
             }
         }
         
@@ -1330,6 +1339,15 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} ({1}).
+        /// </summary>
+        public static string CloudExplorerGceZoneCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGceZoneCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Zone Properties.
         /// </summary>
         public static string CloudExplorerGceZoneCategory {
@@ -1389,6 +1407,15 @@ namespace GoogleCloudExtension
         public static string CloudExplorerGcsBucketCreatedDescription {
             get {
                 return ResourceManager.GetString("CloudExplorerGcsBucketCreatedDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} ({1}).
+        /// </summary>
+        public static string CloudExplorerGcsBucketLocationCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGcsBucketLocationCaption", resourceCulture);
             }
         }
         
@@ -1555,11 +1582,29 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No credentials, please login..
+        /// </summary>
+        public static string CloudExplorerNoLoggedInMessage {
+            get {
+                return ResourceManager.GetString("CloudExplorerNoLoggedInMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Go to the Cloud Platform Console.
         /// </summary>
         public static string CloudExplorerNoProjectButtonCaption {
             get {
                 return ResourceManager.GetString("CloudExplorerNoProjectButtonCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No project selected..
+        /// </summary>
+        public static string CloudExplorerNoProjectSelectedMessage {
+            get {
+                return ResourceManager.GetString("CloudExplorerNoProjectSelectedMessage", resourceCulture);
             }
         }
         
@@ -1839,6 +1884,15 @@ namespace GoogleCloudExtension
         public static string GcePublishSuccessMessage {
             get {
                 return ResourceManager.GetString("GcePublishSuccessMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Content Type.
+        /// </summary>
+        public static string GcsFileBrowserContentTypeHeader {
+            get {
+                return ResourceManager.GetString("GcsFileBrowserContentTypeHeader", resourceCulture);
             }
         }
         
@@ -2460,6 +2514,15 @@ namespace GoogleCloudExtension
         public static string ShowPasswordShowPasswordTooltip {
             get {
                 return ResourceManager.GetString("ShowPasswordShowPasswordTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password copied to clipboard..
+        /// </summary>
+        public static string ShowPasswordWindowPasswordCopiedMessage {
+            get {
+                return ResourceManager.GetString("ShowPasswordWindowPasswordCopiedMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1311,4 +1311,32 @@
     <value>_Allocations:</value>
     <comment>Label shown in the split traffic window to indicate the list of allocations.</comment>
   </data>
+  <data name="AuthorizedNetworksNetworkHeader" xml:space="preserve">
+    <value>Network</value>
+    <comment>Header for the control groupin.</comment>
+  </data>
+  <data name="CloudExplorerGceZoneCaption" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>Caption for the zone node. {0} is the zone name, {1} is the number of instances in the zone.</comment>
+  </data>
+  <data name="CloudExplorerGcsBucketLocationCaption" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>Caption for the bucket location node, {0} is the name of the location, {1} is the number of buckets in the location.</comment>
+  </data>
+  <data name="CloudExplorerNoLoggedInMessage" xml:space="preserve">
+    <value>No credentials, please login.</value>
+    <comment>Shown in the cloud explorer when there are no credentials available.</comment>
+  </data>
+  <data name="CloudExplorerNoProjectSelectedMessage" xml:space="preserve">
+    <value>No project selected.</value>
+    <comment>Shown in the cloud explorer when no project is selected.</comment>
+  </data>
+  <data name="GcsFileBrowserContentTypeHeader" xml:space="preserve">
+    <value>Content Type</value>
+    <comment>The header for the Content Type column in the data grid.</comment>
+  </data>
+  <data name="ShowPasswordWindowPasswordCopiedMessage" xml:space="preserve">
+    <value>Password copied to clipboard.</value>
+    <comment>Message shown to the user when the password is copied to the clipboard.</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/ShowPassword/ShowPasswordWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/ShowPassword/ShowPasswordWindowContent.xaml
@@ -41,7 +41,7 @@
                    IsOpen="{Binding ShowCopyFeedback}"
                    Style="{StaticResource CommonPopupStyle}">
                 <Border Style="{StaticResource CommonPopupBorderStyle}">
-                    <TextBlock Text="Password copied to clipboard."
+                    <TextBlock Text="{x:Static ext:Resources.ShowPasswordCopiedMessage}"
                                Style="{StaticResource CommonTextStyle}" />
                 </Border>
             </Popup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ image: Visual Studio 2015
 # Perform the build.
 # TODO: Fetch the output of the build and publish it.
 build_script:
+  - bash -c ./tools/ensure_strings_extracted.sh
   - nuget restore .\GoogleCloudExtension
   - msbuild .\GoogleCloudExtension\GoogleCloudExtension.sln /p:Configuration=Debug
   - msbuild .\GoogleCloudExtension\GoogleCloudExtension.sln /p:Configuration=Release

--- a/tools/ensure_strings_extracted.sh
+++ b/tools/ensure_strings_extracted.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+# This script will fail if there are string literals left in the code.
+
+readonly workspace=$(dirname $0)/..
+
+if [ -n "$(${workspace}/tools/find_strings.sh ${workspace}/GoogleCloudExtension/GoogleCloudExtension)" ]; then
+    ${workspace}/tools/find_strings.sh ${workspace}/GoogleCloudExtension/GoogleCloudExtension
+    echo "Found strings that are not extracted."
+    exit -1
+fi
+exit 0
+
+
+    

--- a/tools/find_files.py
+++ b/tools/find_files.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+"""Script that lists all files that match the given extension
+
+This script takes a directory and will list all of the files
+recursively filtering by the given extension.
+
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+import msvcrt
+
+# Parse for the program.
+parser = argparse.ArgumentParser()
+parser.add_argument('-d', '--directory',
+                    help='The root directory',
+                    required=True)
+parser.add_argument('-e', '--extension',
+                    help='The extension to filter by.',
+                    required=True)
+
+
+def print_all_files(dir):
+    for root, dirnames, filenames in os.walk(dir):
+        for name in filenames:
+            filename, ext = os.path.splitext(name)
+            if ext == params.extension:
+                sys.stdout.write(os.path.join(root, name).replace("\\", "/"))
+                sys.stdout.write("\n")
+
+
+def main():
+    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+    print_all_files(params.directory)
+
+# Entrypoint into the script.
+if __name__ == "__main__":
+    params = parser.parse_args()
+    main()
+

--- a/tools/find_files.py
+++ b/tools/find_files.py
@@ -24,7 +24,7 @@ parser.add_argument('-e', '--extension',
 
 
 def print_all_files(dir):
-    for root, dirnames, filenames in os.walk(dir):
+    for root, _, filenames in os.walk(dir):
         for name in filenames:
             filename, ext = os.path.splitext(name)
             if ext == params.extension:

--- a/tools/find_strings.sh
+++ b/tools/find_strings.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+# Finds strings that should have been localized but are specified as literals in
+# the code.
+#   $1, the root directory where to start.
+
+readonly workspace=$(dirname $0)/../
+
+# Look for literal strings on .cs files.
+${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
+    "caption: \"|message: \"|title: \"|Header = \"|Caption = \""
+${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
+    "caption: \\$\"|message: \\$\"|title: \"|Header = \\$\"|Caption = \\$\""
+
+# Look for literal strings on .xaml files.
+${workspace}/tools/find_files.py -d $1 -e .xaml | xargs grep -HnE \
+    "Header=\"[A-Z]|Content=\"[A-Z]|Text=\"[A-Z]"


### PR DESCRIPTION
This PR adds scripts that will scan the main code on the extension looking for patterns of strings that are not extracted out to `Resources.resx`. This script will be invoked from the `appveryor.yaml` build script and will make the build fail, ensuring that all strings are extracted before a PR can make it through.

The script found already some strings that were not extracted, this PR includes the fixes for those so the build stays green.