### PR TITLE
Enforce that Category, DisplayName and Description are not used directly

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/AnalyticsOptionsPage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AnalyticsOptionsPage.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using GoogleCloudExtension.Analytics;
+using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.ComponentModel;
@@ -28,9 +29,9 @@ namespace GoogleCloudExtension
         /// <summary>
         /// Whether the user is opt-in or not into report usage statistics. By default is false.
         /// </summary>
-        [Category("Usage Report")]
-        [DisplayName("Report Usage Statistics Enabled")]
-        [Description("Whether to report usage statistics to Google")]
+        [LocalizedCategory(nameof(Resources.AnalyticsOptionsCategory))]
+        [LocalizedDisplayName(nameof(Resources.AnalyticsOptionsOptInDisplayName))]
+        [LocalizedDescription(nameof(Resources.AnalyticsOptionsOptInDescription))]
         public bool OptIn { get; set; }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -196,6 +196,33 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Usage Report.
+        /// </summary>
+        public static string AnalyticsOptionsCategory {
+            get {
+                return ResourceManager.GetString("AnalyticsOptionsCategory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Whether to report usage statistics to Google.
+        /// </summary>
+        public static string AnalyticsOptionsOptInDescription {
+            get {
+                return ResourceManager.GetString("AnalyticsOptionsOptInDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Report Usage Statistics Enabled.
+        /// </summary>
+        public static string AnalyticsOptionsOptInDisplayName {
+            get {
+                return ResourceManager.GetString("AnalyticsOptionsOptInDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Do you want to help Google by reporting usage statics?.
         /// </summary>
         public static string AnalyticsPromptMessage {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1303,4 +1303,16 @@
     <value>IPv6 Address (First Gen)</value>
     <comment>The display name for the IP v6 address.</comment>
   </data>
+  <data name="AnalyticsOptionsCategory" xml:space="preserve">
+    <value>Usage Report</value>
+    <comment>The category for the analytics options in the options page.</comment>
+  </data>
+  <data name="AnalyticsOptionsOptInDescription" xml:space="preserve">
+    <value>Whether to report usage statistics to Google</value>
+    <comment>Description for the opt-in option in the analytics options.</comment>
+  </data>
+  <data name="AnalyticsOptionsOptInDisplayName" xml:space="preserve">
+    <value>Report Usage Statistics Enabled</value>
+    <comment>The display name of the opt-in for the analytics options page.</comment>
+  </data>
 </root>

--- a/tools/find_strings.sh
+++ b/tools/find_strings.sh
@@ -10,6 +10,8 @@ ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
     "caption: \"|message: \"|title: \"|Header = \"|Caption = \""
 ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
     "caption: \\$\"|message: \\$\"|title: \"|Header = \\$\"|Caption = \\$\""
+${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
+    "\\[Category\\(|\\[DisplayName\\(|\\[Description\\("
 
 # Look for literal strings on .xaml files.
 ${workspace}/tools/find_files.py -d $1 -e .xaml | xargs grep -HnE \


### PR DESCRIPTION
This PR adds a check to the `find_strings.sh` script to check for direct uses of the `Category`, `DisplayName` or `Description` attributes. Those attributes specify strings that will be shown to the user in the UI and therefore should be extracted to the resources.

This PR also adds strings for the usages of the attributes that were found.