### PR TITLE
Use env: flex in default app.yaml

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreDeployment.cs
@@ -32,7 +32,7 @@ namespace GoogleCloudExtension.Deployment
 
         private const string AppYamlDefaultContent =
             "runtime: custom\n" +
-            "vm: true\n";
+            "env: flex\n";
 
         private const string DockerfileName = "Dockerfile";
 


### PR DESCRIPTION
The `vm: true` option is deprecated.

Fixes #343.