### PR TITLE
Fix #341, #347

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogItem.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogItem.cs
@@ -204,7 +204,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 message = String.Join(";", Entry?.Resource.Labels);
             }
 
-            return message?.Replace(Environment.NewLine, "\\n").Replace("\t", "\\t");
+            return message?.Replace("\r\n", "\\r\\n ").Replace("\t", "\\t ").Replace("\n", "\\n ");
         }
 
         private DateTime ConvertTimestamp(object timestamp)

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
@@ -14,7 +14,6 @@
 
 using GoogleCloudExtension.Utils;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
@@ -46,7 +46,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         {
             var grid = sender as DataGrid;
             ScrollViewer sv = e.OriginalSource as ScrollViewer;
-            if (ViewModel == null || sv == null || !sv.IsMouseOver)
+            if (sv == null || !sv.IsMouseOver)
             {
                 return;
             }
@@ -54,22 +54,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             if (e.VerticalOffset > 0 && e.VerticalOffset == sv.ScrollableHeight)
             {
                 Debug.WriteLine($"Now scrollbar is at bottom. {sv.VerticalOffset}, {sv.ScrollableHeight}");
-                AutoReload(sv);
-            }
-        }
-
-        /// <summary>
-        /// There are cases that reloading new items automatically trigger ScrollChanged event.
-        /// Then it might end up into a infinite loop.
-        /// This method forces to scroll back 1 pixel to prevent such a infinite loop.
-        /// </summary>
-        private async Task AutoReload(ScrollViewer sv)
-        {
-            await ViewModel.LoadNextPage();
-            Debug.WriteLine($"After LoadNextPage. {sv.VerticalOffset}, {sv.ScrollableHeight}");
-            if (sv.ScrollableHeight > 0 && sv.VerticalOffset >= sv.ScrollableHeight)
-            {
-                sv.ScrollToVerticalOffset(sv.ScrollableHeight - 1);
+                ViewModel?.LoadNextPage();
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
@@ -46,27 +46,27 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         {
             var grid = sender as DataGrid;
             ScrollViewer sv = e.OriginalSource as ScrollViewer;
-            if (sv == null || sv.IsMouseOver == false)
+            if (ViewModel == null || sv == null || !sv.IsMouseOver)
             {
                 return;
             }
 
             if (e.VerticalOffset > 0 && e.VerticalOffset == sv.ScrollableHeight)
             {
-                Debug.WriteLine($"Now it is at bottom. {sv.VerticalOffset}, {sv.ScrollableHeight}");
+                Debug.WriteLine($"Now scrollbar is at bottom. {sv.VerticalOffset}, {sv.ScrollableHeight}");
                 AutoReload(sv);
             }
         }
 
         /// <summary>
         /// There are cases that reloading new items automatically trigger ScrollChanged event.
-        /// Then it might ends up into a deadloop.
-        /// This method forces to scroll back 1 pixel to prevent such a deadloop.
+        /// Then it might end up into a infinite loop.
+        /// This method forces to scroll back 1 pixel to prevent such a infinite loop.
         /// </summary>
         private async Task AutoReload(ScrollViewer sv)
         {
-            await ViewModel?.LoadNextPage();
-            Debug.WriteLine($"Now it is at bottom. {sv.VerticalOffset}, {sv.ScrollableHeight}");
+            await ViewModel.LoadNextPage();
+            Debug.WriteLine($"After LoadNextPage. {sv.VerticalOffset}, {sv.ScrollableHeight}");
             if (sv.ScrollableHeight > 0 && sv.VerticalOffset >= sv.ScrollableHeight)
             {
                 sv.ScrollToVerticalOffset(sv.ScrollableHeight - 1);

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
@@ -333,14 +333,14 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// <summary>
         /// Send request to get logs following prior requests.
         /// </summary>
-        public async Task LoadNextPage()
+        public void LoadNextPage()
         {
             if (String.IsNullOrWhiteSpace(_nextPageToken) || String.IsNullOrWhiteSpace(Project))
             {
                 return;
             }
 
-            await LogLoaddingWrapperAsync(async (cancelToken) => await LoadLogsAsync(cancelToken));
+            LogLoaddingWrapperAsync(async (cancelToken) => await LoadLogsAsync(cancelToken));
         }
 
         private void OnRefreshCommand()

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
@@ -333,14 +333,14 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// <summary>
         /// Send request to get logs following prior requests.
         /// </summary>
-        public void LoadNextPage()
+        public async Task LoadNextPage()
         {
             if (String.IsNullOrWhiteSpace(_nextPageToken) || String.IsNullOrWhiteSpace(Project))
             {
                 return;
             }
 
-            LogLoaddingWrapperAsync(async (cancelToken) => await LoadLogsAsync(cancelToken));
+            await LogLoaddingWrapperAsync(async (cancelToken) => await LoadLogsAsync(cancelToken));
         }
 
         private void OnRefreshCommand()


### PR DESCRIPTION
[#341](https://github.com/GoogleCloudPlatform/google-cloud-visualstudio/issues/341)  This is to fix the auto loading bug.
[#347](https://github.com/GoogleCloudPlatform/google-cloud-visualstudio/issues/347)  \r\n, \n both needs to be escaped.
 