### PR TITLE
Cleanup the name to ensure no invalid chars.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/WindowsCredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/WindowsCredentialsStore.cs
@@ -156,13 +156,10 @@ namespace GoogleCloudExtension.Accounts
         private static string GetInstancePath(Instance instance)
         {
             var credentials = CredentialsStore.Default;
-            return $@"{GetValidName(credentials.CurrentProjectId)}\{GetValidName(instance.GetZoneName())}\{GetValidName(instance.Name)}";
+            return $@"{ToValidPathName(credentials.CurrentProjectId)}\{ToValidPathName(instance.GetZoneName())}\{ToValidPathName(instance.Name)}";
         }
 
-        private static string GetValidName(string name)
-        {
-            return s_invalidNameCharPattern.Replace(name, "_");
-        }
+        private static string ToValidPathName(string name) => s_invalidNameCharPattern.Replace(name, "_");
 
         private static string GetFileName(WindowsInstanceCredentials credentials) => $"{credentials.User}{PasswordFileExtension}";
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/WindowsCredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/WindowsCredentialsStore.cs
@@ -21,6 +21,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace GoogleCloudExtension.Accounts
 {
@@ -40,6 +41,7 @@ namespace GoogleCloudExtension.Accounts
 
         private static readonly Lazy<WindowsCredentialsStore> s_defaultStore = new Lazy<WindowsCredentialsStore>();
         private static readonly string s_credentialsStoreRoot = GetCredentialsStoreRoot();
+        private static Regex s_invalidNameCharPattern = new Regex("[;:\\?\\\\]");
 
         /// <summary>
         /// In memory cache of the credentials for the current credentials (account and project pair).
@@ -154,7 +156,12 @@ namespace GoogleCloudExtension.Accounts
         private static string GetInstancePath(Instance instance)
         {
             var credentials = CredentialsStore.Default;
-            return $@"{credentials.CurrentProjectId}\{instance.GetZoneName()}\{instance.Name}";
+            return $@"{GetValidName(credentials.CurrentProjectId)}\{GetValidName(instance.GetZoneName())}\{GetValidName(instance.Name)}";
+        }
+
+        private static string GetValidName(string name)
+        {
+            return s_invalidNameCharPattern.Replace(name, "_");
         }
 
         private static string GetFileName(WindowsInstanceCredentials credentials) => $"{credentials.User}{PasswordFileExtension}";


### PR DESCRIPTION
The cause of this bug was the fact that the project ID had a character that is not a valid character for a path. We were taking the project ID verbatim and used it in the path for the credentials file. With this fix we will cleanup invalid chars from the project ID and replace them with the "_" character.

This PR fixes #381.

