### PR TITLE
Adding save all method, call it from the deployment steps.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -82,6 +82,8 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             var project = _publishDialog.Project;
             try
             {
+                ShellUtils.SaveAllFiles();
+
                 var context = new GCloudContext
                 {
                     CredentialsPath = CredentialsStore.Default.CurrentAccountPath,

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
@@ -138,6 +138,8 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
 
             try
             {
+                ShellUtils.SaveAllFiles();
+
                 GcpOutputWindow.Activate();
                 GcpOutputWindow.Clear();
                 GcpOutputWindow.OutputLine(String.Format(Resources.GcePublishStepStartMessage, project.Name));

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -176,6 +176,8 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             var project = _publishDialog.Project;
             try
             {
+                ShellUtils.SaveAllFiles();
+
                 var verifyGCloudTask = VerifyGCloudDependencies();
                 _publishDialog.TrackTask(verifyGCloudTask);
                 if (!await verifyGCloudTask)

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/ShellUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/ShellUtils.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -84,6 +85,15 @@ namespace GoogleCloudExtension.Utils
 
             // Updates the UI asynchronously.
             shell.UpdateCommandUI(fImmediateUpdate: 0);
+        }
+
+        /// <summary>
+        /// Executes the "File.SaveAll" command in the shell, which will save all currently dirty files.
+        /// </summary>
+        public static void SaveAllFiles()
+        {
+            var dte = Package.GetGlobalService(typeof(DTE)) as DTE;
+            dte.ExecuteCommand("File.SaveAll");
         }
 
         private static void SetShellNormal()


### PR DESCRIPTION
This PR adds functionality to the extension to save all dirty documents _before_ a deployment starts. We do this buy invoking the built-in `File.SaveAll` command in the Visual Studio shell. This is the same command that gets executed typically when the user presses `CTRL+SHIFT+S`.

Fixes issue #357 