### PR TITLE
Master app engine load upfront

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeVersionExtensions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeVersionExtensions.cs
@@ -22,7 +22,7 @@ namespace GoogleCloudExtension.DataSources
         /// <summary>
         /// The value of a .Net runtime for a GAE version.
         /// </summary>
-        public const string DotNetRuntime = "aspnetcore";
+        public const string AspNetCoreRuntime = "aspnetcore";
 
         /// <summary>
         /// The serving status for a GAE version serving.

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeVersionExtensions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeVersionExtensions.cs
@@ -22,7 +22,7 @@ namespace GoogleCloudExtension.DataSources
         /// <summary>
         /// The value of a .Net runtime for a GAE version.
         /// </summary>
-        public const string DotNetRuntime = "dotnet";
+        public const string DotNetRuntime = "aspnetcore";
 
         /// <summary>
         /// The serving status for a GAE version serving.
@@ -33,6 +33,11 @@ namespace GoogleCloudExtension.DataSources
         /// The serving status for a GAE version not serving.
         /// </summary>
         public const string StoppedStatus = "STOPPED";
+
+        /// <summary>
+        /// The identifier for the Flex environment.
+        /// </summary>
+        public const string FlexibleEnvironment = "flexible";
 
         /// <summary>
         /// Gets an operation id.

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/TreeNode.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/TreeNode.cs
@@ -117,5 +117,28 @@ namespace GoogleCloudExtension.CloudExplorer
             get { return _contextMenu; }
             set { SetValueAndRaise(ref _contextMenu, value); }
         }
+
+        /// <summary>
+        /// Disables all items in the context menu if the node is in the IsError or IsLoading state. It is expected
+        /// that after the state changes the node will be reloaded and the context menu replaced.
+        /// </summary>
+        protected void SyncContextMenuState()
+        {
+            if (IsError || IsLoading)
+            {
+                foreach (var item in ContextMenu.ItemsSource)
+                {
+                    var menu = item as MenuItem;
+                    if (menu != null)
+                    {
+                        if (menu.Command is ProtectedCommand)
+                        {
+                            var cmd = (ProtectedCommand)menu.Command;
+                            cmd.CanExecuteCommand = false;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -81,10 +81,12 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         public async void InvalidateService(string id)
         {
             int idx = 0;
+            ServiceViewModel oldService = null;
             foreach (ServiceViewModel service in Children)
             {
                 if (service.Service.Id == id)
                 {
+                    oldService = service;
                     break;
                 }
                 ++idx;
@@ -94,9 +96,11 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 return;
             }
 
+            var wasExpanded = oldService.IsExpanded;
             var newService = await _dataSource.Value.GetServiceAsync(id);
             var newModel = await LoadService(newService);
             Children[idx] = newModel;
+            newModel.IsExpanded = wasExpanded;
         }
 
         private void OnStatusCommand()

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -78,6 +78,11 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             ContextMenu = new ContextMenu { ItemsSource = menuItems };
         }
 
+        /// <summary>
+        /// Invalidates the state of the service given by <paramref name="id"/> reloading the entire
+        /// service and updating the UI.
+        /// </summary>
+        /// <param name="id">The id of the service to update.</param>
         public async void InvalidateService(string id)
         {
             int idx = 0;
@@ -91,8 +96,9 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 }
                 ++idx;
             }
-            if (idx >= Children.Count)
+            if (oldService == null)
             {
+                Debug.WriteLine($"Could not find the service {id}");
                 return;
             }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -119,20 +119,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 IList<ServiceViewModel> services = await LoadServiceList();
 
                 Children.Clear();
-                if (services == null)
+                foreach (var item in services)
                 {
-                    Children.Add(s_errorPlaceholder);
+                    Children.Add(item);
                 }
-                else
+                if (Children.Count == 0)
                 {
-                    foreach (var item in services)
-                    {
-                        Children.Add(item);
-                    }
-                    if (Children.Count == 0)
-                    {
-                        Children.Add(s_noItemsPlacehoder);
-                    }
+                    Children.Add(s_noItemsPlacehoder);
                 }
                 EventsReporterWrapper.ReportEvent(GaeServicesLoadedEvent.Create(CommandStatus.Success));
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -78,6 +78,27 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             ContextMenu = new ContextMenu { ItemsSource = menuItems };
         }
 
+        public async void InvalidateService(string id)
+        {
+            int idx = 0;
+            foreach (ServiceViewModel service in Children)
+            {
+                if (service.Service.Id == id)
+                {
+                    break;
+                }
+                ++idx;
+            }
+            if (idx >= Children.Count)
+            {
+                return;
+            }
+
+            var newService = await _dataSource.Value.GetServiceAsync(id);
+            var newModel = await LoadService(newService);
+            Children[idx] = newModel;
+        }
+
         private void OnStatusCommand()
         {
             Process.Start("https://status.cloud.google.com/");

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/InstanceViewModel.cs
@@ -54,7 +54,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             _instance = instance;
             root = _owner.root;
 
-            Caption = _instance.VmName;
+            Caption = _instance.Id;
             UpdateIcon();
 
             var menuItems = new List<MenuItem>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/InstanceViewModel.cs
@@ -38,22 +38,18 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         private static readonly Lazy<ImageSource> s_instanceStopedIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(IconStopedResourcePath));
         private static readonly Lazy<ImageSource> s_instanceTransitionIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(IconTransitionResourcePath));
 
-        private readonly VersionViewModel _owner;
-
-        public readonly GaeSourceRootViewModel root;
-
+        private readonly GaeSourceRootViewModel _owner;
         private readonly Instance _instance;
 
         public event EventHandler ItemChanged;
 
         public object Item => GetItem();
 
-        public InstanceViewModel(VersionViewModel owner, Instance instance)
+        public InstanceViewModel(GaeSourceRootViewModel owner, Instance instance)
         {
             _owner = owner;
             _instance = instance;
-            root = _owner.root;
-
+            
             Caption = _instance.Id;
             UpdateIcon();
 
@@ -66,7 +62,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         private void OnPropertiesWindowCommand()
         {
-            root.Context.ShowPropertiesWindow(Item);
+            _owner.Context.ShowPropertiesWindow(Item);
         }
 
         private void UpdateIcon()

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -59,7 +59,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         private bool _resourcesLoaded = false;
 
-        private bool _showOnlyFlexVersions = true;
+        private bool _showOnlyFlexVersions = false;
         private bool _showOnlyDotNetRuntimes = false;
         private bool _showOnlyVersionsWithTraffic = false;
 
@@ -216,12 +216,11 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 .OrderByDescending(x => x.TrafficAllocation);
             if (ShowOnlyFlexVersions)
             {
-                versions = versions.Where(x => x.version.Vm ?? false);
+                versions = versions.Where(x => x.version.Env == GaeVersionExtensions.FlexibleEnvironment);
             }
             if (ShowOnlyDotNetRuntimes)
             {
-                versions = versions.Where(
-                    x => x.version?.Runtime.Equals(GaeVersionExtensions.DotNetRuntime) ?? false);
+                versions = versions.Where(x => x.version.Runtime == GaeVersionExtensions.DotNetRuntime);
             }
             if (ShowOnlyVersionsWithTraffic)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -194,7 +194,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             }
             if (ShowOnlyDotNetRuntimes)
             {
-                versions = versions.Where(x => x.Version.Runtime == GaeVersionExtensions.DotNetRuntime);
+                versions = versions.Where(x => x.Version.Runtime == GaeVersionExtensions.AspNetCoreRuntime);
             }
             if (ShowOnlyVersionsWithTraffic)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -329,8 +329,8 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 {
                     throw new DataSourceException(operation.Error.Message);
                 }
-                _service = await datasource.GetServiceAsync(Service.Id);
-                Caption = Service.Id;
+
+                _owner.InvalidateService(_service.Id);
 
                 EventsReporterWrapper.ReportEvent(GaeTrafficSplitUpdatedEvent.Create(CommandStatus.Success));
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -39,33 +39,18 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         private static readonly Lazy<ImageSource> s_serviceIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(IconServiceResourcePath));
 
-        private static readonly TreeLeaf s_loadingPlaceholder = new TreeLeaf
-        {
-            Caption = Resources.CloudExplorerGaeLoadingVersionCaption,
-            IsLoading = true
-        };
         private static readonly TreeLeaf s_noItemsPlacehoder = new TreeLeaf
         {
             Caption = Resources.CloudExplorerGaeNoVersionsFoundCaption,
             IsWarning = true
         };
-        private static readonly TreeLeaf s_errorPlaceholder = new TreeLeaf
-        {
-            Caption = Resources.CloudExplorerGaeFailedToLoadVersionsCaption,
-            IsError = true
-        };
 
         private readonly GaeSourceRootViewModel _owner;
-
-        private bool _resourcesLoaded = false;
+        private readonly IList<VersionViewModel> _versions;
 
         private bool _showOnlyFlexVersions = false;
         private bool _showOnlyDotNetRuntimes = false;
         private bool _showOnlyVersionsWithTraffic = false;
-
-        private IList<Google.Apis.Appengine.v1.Data.Version> _versions;
-
-        public readonly GaeSourceRootViewModel root;
 
         public Service Service { get; private set; }
 
@@ -120,16 +105,24 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             }
         }
 
-        public ServiceViewModel(GaeSourceRootViewModel owner, Service service)
+        public ServiceViewModel(GaeSourceRootViewModel owner, Service service, IList<VersionViewModel> versions)
         {
             _owner = owner;
-            Service = service;
-            root = _owner;
+            _versions = versions;
 
-            Children.Add(s_loadingPlaceholder);
+            Service = service;
 
             Caption = Service.Id;
             Icon = s_serviceIcon.Value;
+
+            foreach (var version in versions)
+            {
+                Children.Add(version);
+            }
+            if (Children.Count == 0)
+            {
+                Children.Add(s_noItemsPlacehoder);
+            }
 
             UpdateContextMenu();
         }
@@ -139,24 +132,17 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         /// </summary>
         private void UpdateContextMenu()
         {
-            // Do not allow actions when the service is loading or in an error state.
-            if (IsLoading || IsError)
-            {
-                ContextMenu = null;
-                return;
-            }
-
             var menuItems = new List<FrameworkElement>
             {
                 new MenuItem { Header = Resources.UiOpenOnCloudConsoleMenuHeader, Command = new ProtectedCommand(OnOpenOnCloudConsoleCommand) },
                 new MenuItem { Header = Resources.UiPropertiesMenuHeader, Command = new ProtectedCommand(OnPropertiesWindowCommand) },
                 new MenuItem { Header = Resources.CloudExplorerGaeServiceOpen, Command = new ProtectedCommand(OnOpenService) },
-};
+            };
 
             menuItems.Add(new MenuItem
             {
                 Header = Resources.CloudExplorerGaeSplitTraffic,
-                Command = new ProtectedCommand(OnSplitTraffic, canExecuteCommand: Children.Count > 1)
+                Command = new ProtectedCommand(OnSplitTraffic, canExecuteCommand: _versions.Count > 1)
             });
 
             menuItems.Add(new Separator());
@@ -164,9 +150,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             menuItems.Add(new MenuItem
             {
                 Header = Resources.CloudExplorerGaeDeleteService,
-                Command = new ProtectedCommand(
-                    OnDeleteService,
-                    canExecuteCommand: !GaeUtils.AppEngineDefaultServiceName.Equals(Service.Id))
+                Command = new ProtectedCommand(OnDeleteService, canExecuteCommand: Service.Id != GaeUtils.AppEngineDefaultServiceName)
             });
 
 
@@ -211,20 +195,18 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 return;
             }
 
-            IEnumerable<VersionViewModel> versions = _versions
-                .Select(x => new VersionViewModel(this, x))
-                .OrderByDescending(x => x.TrafficAllocation);
+            IEnumerable<VersionViewModel> versions = _versions;
             if (ShowOnlyFlexVersions)
             {
-                versions = versions.Where(x => x.version.Env == GaeVersionExtensions.FlexibleEnvironment);
+                versions = versions.Where(x => x.Version.Env == GaeVersionExtensions.FlexibleEnvironment);
             }
             if (ShowOnlyDotNetRuntimes)
             {
-                versions = versions.Where(x => x.version.Runtime == GaeVersionExtensions.DotNetRuntime);
+                versions = versions.Where(x => x.Version.Runtime == GaeVersionExtensions.DotNetRuntime);
             }
             if (ShowOnlyVersionsWithTraffic)
             {
-                versions = versions.Where(x => x.TrafficAllocation != null);
+                versions = versions.Where(x => x.HasTrafficAllocation);
             }
 
             UpdateViewModels(versions);
@@ -252,7 +234,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         /// </summary>
         private void OnSplitTraffic()
         {
-            SplitTrafficChange change = SplitTrafficWindow.PromptUser(Service, _versions);
+            SplitTrafficChange change = SplitTrafficWindow.PromptUser(Service, _versions.Select(x => x.Version));
             if (change == null)
             {
                 return;
@@ -316,55 +298,21 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             ShowOnlyVersionsWithTraffic = false;
         }
 
-        protected override async void OnIsExpandedChanged(bool newValue)
-        {
-            base.OnIsExpandedChanged(newValue);
-            try
-            {
-                // If this is the first time the node has been expanded load it's resources.
-                if (!_resourcesLoaded && newValue)
-                {
-                    _resourcesLoaded = true;
-                    _versions = await root.DataSource.Value.GetVersionListAsync(Service.Id);
-                    Children.Clear();
-                    if (_versions == null)
-                    {
-                        Children.Add(s_errorPlaceholder);
-                    }
-                    else
-                    {
-                        PresentViewModels();
-                        UpdateContextMenu();
-                    }
-                }
-
-                EventsReporterWrapper.ReportEvent(GaeVersionsLoadedEvent.Create(CommandStatus.Success));
-            }
-            catch (DataSourceException ex)
-            {
-                GcpOutputWindow.OutputLine(Resources.CloudExplorerGaeFailedVersionsMessage);
-                GcpOutputWindow.OutputLine(ex.Message);
-                GcpOutputWindow.Activate();
-
-                EventsReporterWrapper.ReportEvent(GaeVersionsLoadedEvent.Create(CommandStatus.Failure));
-                throw new CloudExplorerSourceException(ex.Message, ex);
-            }
-        }
-
         private void OnOpenOnCloudConsoleCommand()
         {
-            var url = $"https://console.cloud.google.com/appengine/versions?project={root.Context.CurrentProject.ProjectId}&moduleId={Service.Id}";
+            var url = $"https://console.cloud.google.com/appengine/versions?project={_owner.Context.CurrentProject.ProjectId}&moduleId={Service.Id}";
             Process.Start(url);
         }
 
         private void OnPropertiesWindowCommand()
         {
-            root.Context.ShowPropertiesWindow(Item);
+            _owner.Context.ShowPropertiesWindow(Item);
         }
 
-        private void OnOpenService()
+        private async void OnOpenService()
         {
-            var url = GaeUtils.GetAppUrl(root.GaeApplication.DefaultHostname, Service.Id);
+            var app = await _owner.GaeApplication;
+            var url = GaeUtils.GetAppUrl(app.DefaultHostname, Service.Id);
             Process.Start(url);
         }
 
@@ -377,11 +325,11 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             Children.Clear();
             UpdateContextMenu();
             Caption = Resources.CloudExplorerGaeUpdateTrafficSplitMessage;
-            GaeDataSource datasource = root.DataSource.Value;
+            GaeDataSource datasource = _owner.DataSource;
 
             try
             {
-                Task<Operation> operationTask = root.DataSource.Value.UpdateServiceTrafficSplit(split, Service.Id);
+                Task<Operation> operationTask = _owner.DataSource.UpdateServiceTrafficSplit(split, Service.Id);
                 Func<Operation, Task<Operation>> fetch = (o) => datasource.GetOperationAsync(o.GetOperationId());
                 Predicate<Operation> stopPolling = (o) => o.Done ?? false;
                 Operation operation = await Polling<Operation>.Poll(await operationTask, fetch, stopPolling);
@@ -430,11 +378,11 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             Children.Clear();
             UpdateContextMenu();
             Caption = String.Format(Resources.CloudExplorerGaeServiceDeleteMessage, Service.Id);
-            GaeDataSource datasource = root.DataSource.Value;
+            GaeDataSource datasource = _owner.DataSource;
 
             try
             {
-                Task<Operation> operationTask = root.DataSource.Value.DeleteServiceAsync(Service.Id);
+                Task<Operation> operationTask = datasource.DeleteServiceAsync(Service.Id);
                 Func<Operation, Task<Operation>> fetch = (o) => datasource.GetOperationAsync(o.GetOperationId());
                 Predicate<Operation> stopPolling = (o) => o.Done ?? false;
                 Operation operation = await Polling<Operation>.Poll(await operationTask, fetch, stopPolling);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -46,13 +46,14 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         };
 
         private readonly GaeSourceRootViewModel _owner;
-        private readonly IList<VersionViewModel> _versions;
+        private Service _service;
+        private IList<VersionViewModel> _versions;
 
         private bool _showOnlyFlexVersions = false;
         private bool _showOnlyDotNetRuntimes = false;
         private bool _showOnlyVersionsWithTraffic = false;
 
-        public Service Service { get; private set; }
+        public Service Service => _service;
 
         public event EventHandler ItemChanged;
 
@@ -109,22 +110,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         {
             _owner = owner;
             _versions = versions;
-
-            Service = service;
+            _service = service;
 
             Caption = Service.Id;
             Icon = s_serviceIcon.Value;
 
-            foreach (var version in versions)
-            {
-                Children.Add(version);
-            }
-            if (Children.Count == 0)
-            {
-                Children.Add(s_noItemsPlacehoder);
-            }
-
             UpdateContextMenu();
+            PresentViewModels();
         }
 
         /// <summary>
@@ -337,7 +329,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 {
                     throw new DataSourceException(operation.Error.Message);
                 }
-                Service = await datasource.GetServiceAsync(Service.Id);
+                _service = await datasource.GetServiceAsync(Service.Id);
                 Caption = Service.Id;
 
                 EventsReporterWrapper.ReportEvent(GaeTrafficSplitUpdatedEvent.Create(CommandStatus.Success));

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -364,7 +364,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
                 Children.Add(s_errorPlaceholder);
                 EventsReporterWrapper.ReportEvent(GaeInstancesLoadedEvent.Create(CommandStatus.Failure));
-                throw new CloudExplorerSourceException(ex.Message, ex);
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -62,7 +62,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         public event EventHandler ItemChanged;
 
-        public object Item => GetItem();
+        public object Item => new VersionItem(_version);
 
         public VersionViewModel(
             GaeSourceRootViewModel owner,
@@ -94,8 +94,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             UpdateIcon();
             UpdateMenu();
         }
-
-        public VersionItem GetItem() => new VersionItem(_version);
 
         /// <summary>
         /// Update the context menu based on the current state of the version.

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -130,6 +130,8 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             }
 
             ContextMenu = new ContextMenu { ItemsSource = menuItems };
+
+            SyncContextMenuState();
         }
 
         private void OnStartVersion()

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
@@ -218,22 +218,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
             ContextMenu = new ContextMenu { ItemsSource = menuItems };
 
-            // If the instance is busy or in error then we need to disable all commands.
-            if (IsError || IsLoading)
-            {
-                foreach (var item in ContextMenu.ItemsSource)
-                {
-                    var menu = item as MenuItem;
-                    if (menu != null)
-                    {
-                        if (menu.Command is ProtectedCommand)
-                        {
-                            var cmd = (ProtectedCommand)menu.Command;
-                            cmd.CanExecuteCommand = false;
-                        }
-                    }
-                }
-            }
+            SyncContextMenuState();
         }
 
         private void OnSavePublishSettingsCommand()

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -412,15 +412,6 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load the list of Google Cloud App Engine instances.
-        /// </summary>
-        public static string CloudExplorerGaeFailedInstancesMessage {
-            get {
-                return ResourceManager.GetString("CloudExplorerGaeFailedInstancesMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Failed to load the list of Google Cloud App Engine services.
         /// </summary>
         public static string CloudExplorerGaeFailedServicesMessage {
@@ -430,38 +421,11 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load instances..
-        /// </summary>
-        public static string CloudExplorerGaeFailedToLoadInstancesCaption {
-            get {
-                return ResourceManager.GetString("CloudExplorerGaeFailedToLoadInstancesCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Failed to load services..
         /// </summary>
         public static string CloudExplorerGaeFailedToLoadServicesCaption {
             get {
                 return ResourceManager.GetString("CloudExplorerGaeFailedToLoadServicesCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to load versions..
-        /// </summary>
-        public static string CloudExplorerGaeFailedToLoadVersionsCaption {
-            get {
-                return ResourceManager.GetString("CloudExplorerGaeFailedToLoadVersionsCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to load the list of Google Cloud App Engine versions.
-        /// </summary>
-        public static string CloudExplorerGaeFailedVersionsMessage {
-            get {
-                return ResourceManager.GetString("CloudExplorerGaeFailedVersionsMessage", resourceCulture);
             }
         }
         
@@ -556,29 +520,11 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Loading instances....
-        /// </summary>
-        public static string CloudExplorerGaeLoadingInstancesCaption {
-            get {
-                return ResourceManager.GetString("CloudExplorerGaeLoadingInstancesCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Loading services....
         /// </summary>
         public static string CloudExplorerGaeLoadingServicesCaption {
             get {
                 return ResourceManager.GetString("CloudExplorerGaeLoadingServicesCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Loading versions....
-        /// </summary>
-        public static string CloudExplorerGaeLoadingVersionCaption {
-            get {
-                return ResourceManager.GetString("CloudExplorerGaeLoadingVersionCaption", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -893,45 +893,21 @@
     <value>Manage Windows credentials</value>
     <comment>Caption used in the hyperlink shown in the Windows credentials chooser dialog.</comment>
   </data>
-  <data name="CloudExplorerGaeFailedInstancesMessage" xml:space="preserve">
-    <value>Failed to load the list of Google Cloud App Engine instances</value>
-    <comment>Message shown in the output window when failed to load list of GAE instances</comment>
-  </data>
   <data name="CloudExplorerGaeFailedServicesMessage" xml:space="preserve">
     <value>Failed to load the list of Google Cloud App Engine services</value>
     <comment>Message shown in the output window when failed to load list of GAE services.</comment>
-  </data>
-  <data name="CloudExplorerGaeFailedToLoadInstancesCaption" xml:space="preserve">
-    <value>Failed to load instances.</value>
-    <comment>Caption shown when failed to load GAE instances.</comment>
   </data>
   <data name="CloudExplorerGaeFailedToLoadServicesCaption" xml:space="preserve">
     <value>Failed to load services.</value>
     <comment>Caption shown when failed to load GAE services,</comment>
   </data>
-  <data name="CloudExplorerGaeFailedToLoadVersionsCaption" xml:space="preserve">
-    <value>Failed to load versions.</value>
-    <comment>Caption shown when failed to load GAE versions.</comment>
-  </data>
-  <data name="CloudExplorerGaeFailedVersionsMessage" xml:space="preserve">
-    <value>Failed to load the list of Google Cloud App Engine versions</value>
-    <comment>Message shown in the output window when failed to load list of GAE versions</comment>
-  </data>
   <data name="CloudExplorerGaeInstanceCategory" xml:space="preserve">
     <value>Instance Properties</value>
     <comment>Category for the GAE instance properties.</comment>
   </data>
-  <data name="CloudExplorerGaeLoadingInstancesCaption" xml:space="preserve">
-    <value>Loading instances...</value>
-    <comment>Caption shown when loading GAE instances.</comment>
-  </data>
   <data name="CloudExplorerGaeLoadingServicesCaption" xml:space="preserve">
     <value>Loading services...</value>
     <comment>Caption shown when loading GAE services.</comment>
-  </data>
-  <data name="CloudExplorerGaeLoadingVersionCaption" xml:space="preserve">
-    <value>Loading versions...</value>
-    <comment>Caption shown when loading GAE versions.</comment>
   </data>
   <data name="CloudExplorerGaeNoInstancesFoundCaption" xml:space="preserve">
     <value>No instances found.</value>


### PR DESCRIPTION
This PR changes the model of how the GAE source works in the cloud explorer. Instead of loading parts of the information on demand we are going to be loading everything upfront in parallel. This fixes issues with whether we should enable the traffic split options or not, which was only enabled after the user expanded the version node.

This PR also fixes some minor bugs, the complete list is:
* Issue #371, using the id of the instance instead of the `VmName` property which inexplicably is empty.
* Issue #370, which came from how we detect whether a version is running in Flex or not. Also changed the defaults to show everything by default, the user can then filter down if needed.
* Issue #348, which I am now thinking was my own interpretation of #370.
* Issue #303, which required the user to expand the version node before the "Split Traffic" option was enabled. This was very counter intuitive. This bug more than anything else motivated to load everything upfront.
* Issue #243, the user could not navigate to a previous, and still serving, version on a service. This has been fixed by allowing opening the version as long as it is serving.

This PR also brings the question of whether we should keep showing the instances for a particular version. There's no much information that we can offer up to the user and it makes the loading process longer. Maybe this would be better served in the GCE source instead? Or perhaps loading the images can be done on demand still. Food for thought.

