### PR TITLE
Master fixing issue 253

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/WindowsCredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/WindowsCredentialsStore.cs
@@ -41,7 +41,7 @@ namespace GoogleCloudExtension.Accounts
 
         private static readonly Lazy<WindowsCredentialsStore> s_defaultStore = new Lazy<WindowsCredentialsStore>();
         private static readonly string s_credentialsStoreRoot = GetCredentialsStoreRoot();
-        private static Regex s_invalidNameCharPattern = new Regex("[;:\\?\\\\]");
+        private static readonly Regex s_invalidNameCharPattern = new Regex("[;:\\?\\\\]");
 
         /// <summary>
         /// In memory cache of the credentials for the current credentials (account and project pair).

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -234,6 +234,7 @@
     <Compile Include="SolutionUtils\ISolutionProject.cs" />
     <Compile Include="SolutionUtils\SolutionHelper.cs" />
     <Compile Include="Utils\GaeUtils.cs" />
+    <Compile Include="Utils\GcpPublishStepsUtils.cs" />
     <Compile Include="Utils\ProgressBarHelper.cs" />
     <Compile Include="Utils\ShellUtils.cs" />
     <Compile Include="Utils\StatusbarHelper.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
@@ -22,7 +22,7 @@
                Target="{Binding ElementName=_version}"
                Style="{StaticResource CommonLabelStyle}"/>
         <TextBox x:Name="_version"
-                 Text="{Binding Version, Mode=TwoWay}"
+                 Text="{Binding Version, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                  Style="{StaticResource CommonTextBoxStyle}"/>
 
         <CheckBox IsChecked="{Binding Promote, Mode=TwoWay}"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -30,7 +30,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
     {
         private readonly FlexStepContent _content;
         private IPublishDialog _publishDialog;
-        private string _version;
+        private string _version = GcpPublishStepsUtils.GetDefaultVersion();
         private bool _promote = true;
         private bool _openWebsite = true;
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -79,6 +79,12 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
 
         public override async void Publish()
         {
+            if (!ValidateInput())
+            {
+                Debug.WriteLine("Invalid input cancelled the operation.");
+                return;
+            }
+
             var project = _publishDialog.Project;
             try
             {
@@ -140,6 +146,24 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
                 GcpOutputWindow.OutputLine(String.Format(Resources.FlexPublishFailedMessage, project.Name));
                 StatusbarHelper.SetText(Resources.PublishFailureStatusMessage);
             }
+        }
+
+        private bool ValidateInput()
+        {
+            if (String.IsNullOrEmpty(Version))
+            {
+                UserPromptUtils.ErrorPrompt(Resources.FlexPublishEmptyVersionMessage, Resources.UiInvalidValueTitle);
+                return false;
+            }
+            if (!GcpPublishStepsUtils.IsValidName(Version))
+            {
+                UserPromptUtils.ErrorPrompt(
+                    String.Format(Resources.FlexPublishInvalidVersionMessage, Version),
+                    Resources.UiInvalidValueTitle);
+                return false;
+            }
+
+            return true;
         }
 
         #endregion

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -125,7 +125,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         /// Command to execute to refresh the list of clusters.
         /// </summary>
         public ICommand RefreshClustersListCommand { get; }
-                
+
         private GkeStepViewModel(GkeStepContent content)
         {
             _content = content;

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -156,7 +156,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             _publishDialog = dialog;
 
             DeploymentName = _publishDialog.Project.Name.ToLower();
-            DeploymentVersion = GetDefaultVersion();
+            DeploymentVersion = GcpPublishStepsUtils.GetDefaultVersion();
 
             // Mark that the dialog is going to be busy until we have loaded the data.
             _publishDialog.TrackTask(Clusters.ValueTask);
@@ -333,15 +333,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             content.DataContext = viewModel;
 
             return viewModel;
-        }
-
-        private static string GetDefaultVersion()
-        {
-            var now = DateTime.Now;
-            return String.Format(
-                "{0:0000}{1:00}{2:00}t{3:00}{4:00}{5:00}",
-                now.Year, now.Month, now.Day,
-                now.Hour, now.Minute, now.Second);
         }
 
         private async Task<bool> VerifyGCloudDependencies()

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -304,6 +304,32 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                 return false;
             }
 
+            if (String.IsNullOrEmpty(DeploymentName))
+            {
+                UserPromptUtils.ErrorPrompt(Resources.GkePublishEmptyDeploymentNameMessage, Resources.UiInvalidValueTitle);
+                return false;
+            }
+            if (String.IsNullOrEmpty(DeploymentVersion))
+            {
+                UserPromptUtils.ErrorPrompt(Resources.GkePublishEmptyDeploymentVersionMessage, Resources.UiInvalidValueTitle);
+                return false;
+            }
+
+            if (!GcpPublishStepsUtils.IsValidName(DeploymentName))
+            {
+                UserPromptUtils.ErrorPrompt(
+                    String.Format(Resources.GkePublishInvalidDeploymentNameMessage, DeploymentName),
+                    Resources.UiInvalidValueTitle);
+                return false;
+            }
+            if (!GcpPublishStepsUtils.IsValidName(DeploymentVersion))
+            {
+                UserPromptUtils.ErrorPrompt(
+                    String.Format(Resources.GkePublishInvalidDeploymentVersionMessage, DeploymentVersion),
+                    Resources.UiInvalidValueTitle);
+                return false;
+            }
+
             return true;
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1861,7 +1861,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid version {0}. The name must only user lowercase letters, digits and the - character..
+        ///   Looks up a localized string similar to Invalid version {0}. The version must only use lowercase letters, digits and the - character..
         /// </summary>
         public static string FlexPublishInvalidVersionMessage {
             get {
@@ -2077,7 +2077,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid deployment version {0}. The name must only user lowercase letters, digits and the - character..
+        ///   Looks up a localized string similar to Invalid deployment version {0}. The version must only use lowercase letters, digits and the - character..
         /// </summary>
         public static string GkePublishInvalidDeploymentVersionMessage {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -1843,11 +1843,29 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The version name cannot be empty..
+        /// </summary>
+        public static string FlexPublishEmptyVersionMessage {
+            get {
+                return ResourceManager.GetString("FlexPublishEmptyVersionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to deploy project {0} to App Engine Flex..
         /// </summary>
         public static string FlexPublishFailedMessage {
             get {
                 return ResourceManager.GetString("FlexPublishFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid version {0}. The name must only user lowercase letters, digits and the - character..
+        /// </summary>
+        public static string FlexPublishInvalidVersionMessage {
+            get {
+                return ResourceManager.GetString("FlexPublishInvalidVersionMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -2023,11 +2023,47 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The deployment name cannot be empty..
+        /// </summary>
+        public static string GkePublishEmptyDeploymentNameMessage {
+            get {
+                return ResourceManager.GetString("GkePublishEmptyDeploymentNameMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The deployment version cannot be empty..
+        /// </summary>
+        public static string GkePublishEmptyDeploymentVersionMessage {
+            get {
+                return ResourceManager.GetString("GkePublishEmptyDeploymentVersionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to E_xpose the service to the public internet.
         /// </summary>
         public static string GkePublishExposeServiceCaption {
             get {
                 return ResourceManager.GetString("GkePublishExposeServiceCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid deployment name {0}. The name must only user lowercase letters, digits and the - character..
+        /// </summary>
+        public static string GkePublishInvalidDeploymentNameMessage {
+            get {
+                return ResourceManager.GetString("GkePublishInvalidDeploymentNameMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid deployment version {0}. The name must only user lowercase letters, digits and the - character..
+        /// </summary>
+        public static string GkePublishInvalidDeploymentVersionMessage {
+            get {
+                return ResourceManager.GetString("GkePublishInvalidDeploymentVersionMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1415,6 +1415,14 @@
     <value>Refresh clusters</value>
     <comment>Caption for the refresh clusters hyperlink</comment>
   </data>
+  <data name="FlexPublishEmptyVersionMessage" xml:space="preserve">
+    <value>The version name cannot be empty.</value>
+    <comment>Message shown when the version name is empty.</comment>
+  </data>
+  <data name="FlexPublishInvalidVersionMessage" xml:space="preserve">
+    <value>Invalid version {0}. The name must only user lowercase letters, digits and the - character.</value>
+    <comment>Message shown for an invalid version name. {0} is the version name provided by the user.</comment>
+  </data>
   <data name="GkePublishEmptyDeploymentNameMessage" xml:space="preserve">
     <value>The deployment name cannot be empty.</value>
     <comment>Message shown when the deployment name is empty.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1415,4 +1415,20 @@
     <value>Refresh clusters</value>
     <comment>Caption for the refresh clusters hyperlink</comment>
   </data>
+  <data name="GkePublishEmptyDeploymentNameMessage" xml:space="preserve">
+    <value>The deployment name cannot be empty.</value>
+    <comment>Message shown when the deployment name is empty.</comment>
+  </data>
+  <data name="GkePublishEmptyDeploymentVersionMessage" xml:space="preserve">
+    <value>The deployment version cannot be empty.</value>
+    <comment>Message shown when the deployment version is empty.</comment>
+  </data>
+  <data name="GkePublishInvalidDeploymentNameMessage" xml:space="preserve">
+    <value>Invalid deployment name {0}. The name must only user lowercase letters, digits and the - character.</value>
+    <comment>Message shown for an invalid deployment name. {0} is the deployment name given by the user.</comment>
+  </data>
+  <data name="GkePublishInvalidDeploymentVersionMessage" xml:space="preserve">
+    <value>Invalid deployment version {0}. The name must only user lowercase letters, digits and the - character.</value>
+    <comment>Message shown for an invalid deployment version. {0} is the deployment version given by the user.</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1420,7 +1420,7 @@
     <comment>Message shown when the version name is empty.</comment>
   </data>
   <data name="FlexPublishInvalidVersionMessage" xml:space="preserve">
-    <value>Invalid version {0}. The name must only user lowercase letters, digits and the - character.</value>
+    <value>Invalid version {0}. The version must only use lowercase letters, digits and the - character.</value>
     <comment>Message shown for an invalid version name. {0} is the version name provided by the user.</comment>
   </data>
   <data name="GkePublishEmptyDeploymentNameMessage" xml:space="preserve">
@@ -1436,7 +1436,7 @@
     <comment>Message shown for an invalid deployment name. {0} is the deployment name given by the user.</comment>
   </data>
   <data name="GkePublishInvalidDeploymentVersionMessage" xml:space="preserve">
-    <value>Invalid deployment version {0}. The name must only user lowercase letters, digits and the - character.</value>
+    <value>Invalid deployment version {0}. The version must only use lowercase letters, digits and the - character.</value>
     <comment>Message shown for an invalid deployment version. {0} is the deployment version given by the user.</comment>
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -48,9 +48,6 @@ namespace GoogleCloudExtension.Utils
         /// </summary>
         /// <param name="name">The name to check.</param>
         /// <returns>True if the name is valid, false otherwise.</returns>
-        public static bool IsValidName(string name)
-        {
-            return !String.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
-        }
+        public static bool IsValidName(string name) => !String.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Text.RegularExpressions;
 
 namespace GoogleCloudExtension.Utils
 {
@@ -21,6 +22,8 @@ namespace GoogleCloudExtension.Utils
     /// </summary>
     public static class GcpPublishStepsUtils
     {
+        private static readonly Regex s_validNamePattern = new Regex(@"^(?!-)[a-z\d\-]{1,100}$");
+
         /// <summary>
         /// Returns a default version name suitable for publishing to GKE and Flex.
         /// </summary>
@@ -32,6 +35,16 @@ namespace GoogleCloudExtension.Utils
                 "{0:0000}{1:00}{2:00}t{3:00}{4:00}{5:00}",
                 now.Year, now.Month, now.Day,
                 now.Hour, now.Minute, now.Second);
+        }
+        
+        /// <summary>
+        /// Determines if the given name is a valid name.
+        /// </summary>
+        /// <param name="name">The name to check.</param>
+        /// <returns>True if the name is valid, false otherwise.</returns>
+        public static bool IsValidName(string name)
+        {
+            return !String.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace GoogleCloudExtension.Utils
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace GoogleCloudExtension.Utils
+{
+    /// <summary>
+    /// Common utils for publishing steps to GCP.
+    /// </summary>
+    public static class GcpPublishStepsUtils
+    {
+        /// <summary>
+        /// Returns a default version name suitable for publishing to GKE and Flex.
+        /// </summary>
+        /// <returns>The default name string.</returns>
+        public static string GetDefaultVersion()
+        {
+            var now = DateTime.Now;
+            return String.Format(
+                "{0:0000}{1:00}{2:00}t{3:00}{4:00}{5:00}",
+                now.Year, now.Month, now.Day,
+                now.Hour, now.Minute, now.Second);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -22,6 +22,12 @@ namespace GoogleCloudExtension.Utils
     /// </summary>
     public static class GcpPublishStepsUtils
     {
+        /// <summary>
+        /// This regexp defines what names are valid for GCP deployments. Basically it defines a valid name
+        /// as only containing lowercase letters and numbers and optionally the - character. It also specifies
+        /// that the name has to be less than 100 chars.
+        /// This regexp is the same one used by gcloud to validate version names.
+        /// </summary>
         private static readonly Regex s_validNamePattern = new Regex(@"^(?!-)[a-z\d\-]{1,100}$");
 
         /// <summary>


### PR DESCRIPTION
This PR adds shared functionality to create a default version name common between the Flex and GKE deployment steps. As a bonus this PR also adds validation of the names, following a similar regexp used by gcloud to determine if a version name is valid.

Fixes issue #253