### PR TITLE
Setting the working directory to the project's root for ASP.NET Core apps when deploying.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -63,7 +63,12 @@ namespace GoogleCloudExtension.Deployment
 
             Debug.WriteLine($"Using tools from {externalTools}");
             outputAction($"dotnet {arguments}");
-            return ProcessUtils.RunCommandAsync(s_dotnetPath.Value, arguments, (o, e) => outputAction(e.Line), env);
+            return ProcessUtils.RunCommandAsync(
+                file: s_dotnetPath.Value,
+                args: arguments,
+                workingDir: Path.GetDirectoryName(projectPath),
+                handler: (o, e) => outputAction(e.Line),
+                environment: env);
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -52,21 +52,21 @@ namespace GoogleCloudExtension.Deployment
         /// <param name="outputAction">The callback to call with output from the command.</param>
         internal static Task<bool> CreateAppBundleAsync(string projectPath, string stageDirectory, Action<string> outputAction)
         {
-            var arguments = $"publish \"{projectPath}\" " +
-                $"-o \"{stageDirectory}\" " +
-                "-c Release";
+            var arguments = $"publish -o \"{stageDirectory}\" -c Release";
             var externalTools = GetExternalToolsPath();
+            var workingDir = Path.GetDirectoryName(projectPath);
             var env = new Dictionary<string, string>
             {
                 { "PATH", $"{Environment.GetEnvironmentVariable("PATH")};{externalTools}" },
             };
 
             Debug.WriteLine($"Using tools from {externalTools}");
+            Debug.WriteLine($"Setting working directory to {workingDir}");
             outputAction($"dotnet {arguments}");
             return ProcessUtils.RunCommandAsync(
                 file: s_dotnetPath.Value,
                 args: arguments,
-                workingDir: Path.GetDirectoryName(projectPath),
+                workingDir: workingDir,
                 handler: (o, e) => outputAction(e.Line),
                 environment: env);
         }

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -214,7 +214,7 @@ namespace GoogleCloudExtension.GCloud
 
                 // This code depends on the fact that gcloud.cmd is a batch file.
                 Debug.Write($"Executing gcloud command: {actualCommand}");
-                return await ProcessUtils.GetJsonOutputAsync<T>("cmd.exe", $"/c {actualCommand}", environment);
+                return await ProcessUtils.GetJsonOutputAsync<T>(file: "cmd.exe", args: $"/c {actualCommand}", environment: environment);
             }
             catch (JsonOutputException ex)
             {
@@ -249,7 +249,11 @@ namespace GoogleCloudExtension.GCloud
 
             // This code depends on the fact that gcloud.cmd is a batch file.
             Debug.Write($"Executing gcloud command: {actualCommand}");
-            return ProcessUtils.RunCommandAsync("cmd.exe", $"/c {actualCommand}", (o, e) => outputAction?.Invoke(e.Line), environment);
+            return ProcessUtils.RunCommandAsync(
+                file: "cmd.exe",
+                args: $"/c {actualCommand}",
+                handler: (o, e) => outputAction?.Invoke(e.Line),
+                environment: environment);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/ProcessUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/ProcessUtils.cs
@@ -186,7 +186,8 @@ namespace GoogleCloudExtension.Utils
             IDictionary<string, string> environment)
         {
             // If the caller provides a working directory use it otherwise default to the user's profile directory
-            // random intereference from Visual Studio changing the working directory often.
+            // so we have a stable working directory instead of a random working directory as Visual Studio changes the
+            // current working directory often.
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 FileName = file,


### PR DESCRIPTION
This PR fixed issue #342 by adding functionality to the `ProcessUtils` class to set the working directory when launching a process. This new functionality is then used to set the working directory to the project's directory. With this now the "dotnet" tool should be able to find the right "global.json" file.

The way the "dotnet" tool is launched for publishing the app is now also simplified. Since we're setting the current directory to the project's root directory we don't need to explicitly point to the "project.json" file, the tool will find the right one automatically.

This fixes #342 