### PR TITLE
Take into account the "name" property from project.json.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -26,7 +26,9 @@ namespace GoogleCloudExtension.Deployment
     internal static class CommonUtils
     {
         /// <summary>
-        /// Returns the project name given the path to the project.json.
+        /// Returns the project name given the path to the project.json. If the project.json file defines a
+        /// "name" property then it is used as the name for the final assembly, otherwise the name of the directory
+        /// is used as the name of the final assembly.
         /// </summary>
         /// <param name="projectPath">The full path to the project.json of the project.</param>
         internal static string GetProjectName(string projectPath)

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
@@ -28,8 +31,25 @@ namespace GoogleCloudExtension.Deployment
         /// <param name="projectPath">The full path to the project.json of the project.</param>
         internal static string GetProjectName(string projectPath)
         {
-            var directory = Path.GetDirectoryName(projectPath);
-            return Path.GetFileName(directory);
+            try
+            {
+                var contents = File.ReadAllText(projectPath);
+                var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(contents);
+                object name = null;
+                if (parsed.TryGetValue("name", out name))
+                {
+                    return (string)name;
+                }
+                else
+                {
+                    var directory = Path.GetDirectoryName(projectPath);
+                    return Path.GetFileName(directory);
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is JsonException)
+            {
+                throw new DeploymentException(ex.Message, ex);
+            }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/DeploymentException.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/DeploymentException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Runtime.Serialization;
 
 namespace GoogleCloudExtension.Deployment

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/DeploymentException.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/DeploymentException.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Runtime.Serialization;
 
 namespace GoogleCloudExtension.Deployment

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/DeploymentException.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/DeploymentException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace GoogleCloudExtension.Deployment
+{
+    /// <summary>
+    /// Exception thrown from the methods implemented in this project.
+    /// </summary>
+    [Serializable]
+    internal class DeploymentException : Exception
+    {
+        public DeploymentException()
+        {
+        }
+
+        public DeploymentException(string message) : base(message)
+        {
+        }
+
+        public DeploymentException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected DeploymentException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
@@ -114,7 +114,6 @@ namespace GoogleCloudExtension.Deployment
             {
                 var appRootPath = Path.Combine(stageDirectory, "app");
                 var buildFilePath = Path.Combine(stageDirectory, "cloudbuild.yaml");
-                var projectName = CommonUtils.GetProjectName(projectPath);
 
                 if (!await ProgressHelper.UpdateProgress(
                         NetCoreAppUtils.CreateAppBundleAsync(projectPath, appRootPath, outputAction),

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GoogleCloudExtension.Deployment.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GoogleCloudExtension.Deployment.csproj
@@ -88,6 +88,7 @@
   <ItemGroup>
     <Compile Include="CloudBuilderUtils.cs" />
     <Compile Include="CommonUtils.cs" />
+    <Compile Include="DeploymentException.cs" />
     <Compile Include="GkeDeployment.cs" />
     <Compile Include="GkeDeploymentResult.cs" />
     <Compile Include="NetCoreAppUtils.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using GoogleCloudExtension.Deployment;
-using GoogleCloudExtension.PublishDialog;
 using GoogleCloudExtension.SolutionUtils;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Shell;

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>


### PR DESCRIPTION
When determining the name of the main assembly for an ASP.NET Core app we need to take into account the "name" property in project.json as it overrides the rule of using the name of the project's directory.

This PR implements this rule but loading the project.json and looking for the value of the "name" property, otherwise using the name of the enclosing directory.

Fixes #405