### PR TITLE
Adding support for parsing the 'service: name' portion of an app.yaml.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
@@ -179,7 +179,7 @@ namespace GoogleCloudExtension.Deployment
         /// <summary>
         /// This methods looks for lines of the form "service: name" in the app.yaml file provided.
         /// </summary>
-        /// <param name="appYamlPath">The path to the app.yaml to parse.</param>
+        /// <param name="projectPath">The path to the project.json for the project, the app.yaml should be next to it.</param>
         /// <returns>The service name if found, <seealso cref="DefaultServiceName"/> if not found.</returns>
         private static string GetAppEngineService(string projectPath)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
@@ -35,6 +35,7 @@ namespace GoogleCloudExtension.Deployment
             "env: flex\n";
 
         private const string DefaultServiceName = "default";
+        private const string ServiceStatement = "service:";
 
         /// <summary>
         /// The options for the deployment operation.
@@ -175,19 +176,38 @@ namespace GoogleCloudExtension.Deployment
             return new ProjectConfigurationStatus(hasAppYaml: hasAppYaml, hasDockerfile: hasDockefile);
         }
 
+        /// <summary>
+        /// This methods looks for lines of the form "service: name" in the app.yaml file provided.
+        /// </summary>
+        /// <param name="appYamlPath">The path to the app.yaml to parse.</param>
+        /// <returns>The service name if found, <seealso cref="DefaultServiceName"/> if not found.</returns>
         private static string GetAppEngineService(string projectPath)
         {
             var projectDirectory = Path.GetDirectoryName(projectPath);
             var appYaml = Path.Combine(projectDirectory, AppYamlName);
-            if (!File.Exists(appYaml))
+
+            // If the app.yaml exists attempt to find the "service: name" line and parse it out. If the file doesn't
+            // exist or if the line is not present then the service is going to be the "default" service.
+            if (File.Exists(appYaml))
             {
-                return DefaultServiceName;
+                try
+                {
+                    var lines = File.ReadLines(appYaml);
+                    foreach (var line in lines)
+                    {
+                        if (line.StartsWith(ServiceStatement))
+                        {
+                            var name = line.Substring(ServiceStatement.Length);
+                            return name.Trim();
+                        }
+                    }
+                }
+                catch (IOException ex)
+                {
+                    throw new DeploymentException(ex.Message, ex);
+                }
             }
-            else
-            {
-                // TODO: Load the app yaml and look for the service key.
-                return DefaultServiceName;
-            }
+            return DefaultServiceName;
         }
 
         private static string GetDefaultVersion()


### PR DESCRIPTION
This PR adds a simple parser that looks for the "service: name" portion of an app.yaml to determine the name of the service to navigate when the user requests that the extension opens the website after a successful deployment.

Fixes #419.