### PR TITLE
Showing long error details on optional TextBox.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
@@ -216,8 +216,9 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
             catch (GCloudException ex)
             {
                 UserPromptUtils.ErrorPrompt(
-                    String.Format(Resources.ResetPasswordFailedPromptMessage, _instance.Name, ex.Message),
-                    Resources.ResetPasswordConfirmationPromptTitle);
+                    message: String.Format(Resources.ResetPasswordFailedPromptMessage, _instance.Name),
+                    title: Resources.ResetPasswordConfirmationPromptTitle,
+                    errorDetails: ex.Message);
                 return null;
             }
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -2671,7 +2671,7 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to reset password for {0}. {1}.
+        ///   Looks up a localized string similar to Failed to reset password for {0}. .
         /// </summary>
         public static string ResetPasswordFailedPromptMessage {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -622,8 +622,8 @@
     <comment>The title for the confirmation prompt for resetting or creating a password. {0) is the user name, {1} is the instance name.</comment>
   </data>
   <data name="ResetPasswordFailedPromptMessage" xml:space="preserve">
-    <value>Failed to reset password for {0}. {1}</value>
-    <comment>Message shown when the reset operation fails. {0} is the instance name, {1} is the error message.</comment>
+    <value>Failed to reset password for {0}. </value>
+    <comment>Message shown when the reset operation fails. {0} is the instance name.</comment>
   </data>
   <data name="ResetPasswordGcloudLinkCaption" xml:space="preserve">
     <value>Install Google Cloud SDK</value>

--- a/GoogleCloudExtension/GoogleCloudExtension/UserPrompt/UserPromptWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/UserPrompt/UserPromptWindow.cs
@@ -44,6 +44,11 @@ namespace GoogleCloudExtension.UserPrompt
             public string Message { get; set; }
 
             /// <summary>
+            /// The error details to show in the dialog.
+            /// </summary>
+            public string ErrorDetails { get; set; }
+
+            /// <summary>
             /// The icon to use in the dialog. Should be 24x24 px.
             /// </summary>
             public ImageSource Icon { get; set; }

--- a/GoogleCloudExtension/GoogleCloudExtension/UserPrompt/UserPromptWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/UserPrompt/UserPromptWindowContent.xaml
@@ -48,6 +48,11 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
             <!-- Display the icon for the dialog. -->
             <StackPanel Margin="12,0,24,0" Visibility="{Binding HasIcon, Converter={utils:VisibilityConverter}}">
                 <Image Source="{Binding Icon}" Width="24px" Height="24px"/>
@@ -57,6 +62,17 @@
                 <TextBlock Text="{Binding Prompt}" Style="{StaticResource PromptStyle}" Margin="0,0,0,12" />
                 <TextBlock Text="{Binding Message}" Style="{StaticResource CommonTextStyle}" />
             </StackPanel>
+            
+            <!-- The text area with the error message. -->
+            <TextBox IsReadOnly="True"
+                     Text="{Binding ErrorDetails, Mode=OneTime}"
+                     Visibility="{Binding HasErrorDetails, Converter={utils:VisibilityConverter}, Mode=OneTime}"
+                     Height="100"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     Grid.Row="1"
+                     Grid.ColumnSpan="2"
+                     Style="{StaticResource CommonTextBoxStyle}" />
         </Grid>
     </theming:CommonDialogWindowBaseContent>
     

--- a/GoogleCloudExtension/GoogleCloudExtension/UserPrompt/UserPromptWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/UserPrompt/UserPromptWindowViewModel.cs
@@ -38,6 +38,16 @@ namespace GoogleCloudExtension.UserPrompt
         public string Message => _options.Message;
 
         /// <summary>
+        /// The error details to show in the dialog.
+        /// </summary>
+        public string ErrorDetails => _options.ErrorDetails;
+
+        /// <summary>
+        /// Returns true if there are error details to show.
+        /// </summary>
+        public bool HasErrorDetails => ErrorDetails != null;
+
+        /// <summary>
         /// The icon to use for the dialog.
         /// </summary>
         public ImageSource Icon => _options.Icon;

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/UserPromptUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/UserPromptUtils.cs
@@ -82,13 +82,15 @@ namespace GoogleCloudExtension.Utils
         /// </summary>
         /// <param name="message">The message for the dialog.</param>
         /// <param name="title">The title for the dialog.</param>
-        public static void ErrorPrompt(string message, string title)
+        /// <param name="errorDetails">The error details for the dialog, optional.</param>
+        public static void ErrorPrompt(string message, string title, string errorDetails = null)
         {
             UserPromptWindow.PromptUser(
                 new UserPromptWindow.Options
                 {
                     Title = title,
                     Prompt = message,
+                    ErrorDetails = errorDetails,
                     CancelButtonCaption = Resources.UiOkButtonCaption,
                     Icon = s_errorIcon.Value
                 });


### PR DESCRIPTION
The error messages coming from gcloud are specially bad because tend to be quite long and they make the error dialog unreadable. This PR adds a readonly `TextBox` to the error dialog to display the error details in a useable way.

The error dialog with error details will now look like this:
<img width="314" alt="screen shot 2017-02-14 at 5 08 29 pm" src="https://cloud.githubusercontent.com/assets/9807532/22940489/f43b0458-f2d9-11e6-942f-6d93944d76ba.png">


Fixes #397 