### PR TITLE
Adding --skip-staging to the App Engine deployment cmd line.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -78,7 +78,7 @@ namespace GoogleCloudExtension.GCloud
         {
             var versionParameter = version != null ? $"--version={version}" : "";
             var promoteParameter = promote ? "--promote" : "--no-promote";
-            return RunCommandAsync($"app deploy \"{appYaml}\" {versionParameter} {promoteParameter} --quiet", outputAction, context);
+            return RunCommandAsync($"app deploy \"{appYaml}\" {versionParameter} {promoteParameter} --skip-staging --quiet", outputAction, context);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds the `--skip-staging` parameter to the gcloud command line used to deploy the app to app engine flex. This will make gcloud not try to stage the app since VS already does all of the app staging before invoking gcloud

Fixes #427.