### PR TITLE
Add setting the GOOGLE_CLOUD_ENVIRONMENT variable.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
@@ -32,7 +32,12 @@ namespace GoogleCloudExtension.Deployment
 
         private const string AppYamlDefaultContent =
             "runtime: custom\n" +
-            "env: flex\n";
+            "env: flex\n" +
+            "\n" +
+            "# Setting the environment vairable to flex so the app can use that\n" +
+            "# for extra configuration.\n" +
+            "env_variables:\n" +
+            "  ASPNETCORE_ENVIRONMENT: flex\n";
 
         private const string DefaultServiceName = "default";
         private const string ServiceStatement = "service:";

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
@@ -37,7 +37,7 @@ namespace GoogleCloudExtension.Deployment
             "# Setting the environment vairable to flex so the app can use that\n" +
             "# for extra configuration.\n" +
             "env_variables:\n" +
-            "  ASPNETCORE_ENVIRONMENT: flex\n";
+            "  GOOGLE_CLOUD_ENVIRONMENT: flex\n";
 
         private const string DefaultServiceName = "default";
         private const string ServiceStatement = "service:";

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -26,7 +26,12 @@ namespace GoogleCloudExtension.Deployment
     internal static class CommonUtils
     {
         /// <summary>
-        /// Environment variable to be set with the current environment in which the app is running.
+        /// Environment variable to be set with the current environment in which the app is running. This variable
+        /// will have the following values:
+        /// * "flex", set by the default app.yaml when running on App Engine Flex.
+        /// * "gke", se by default in the deployment when running on Container Engine (GKE).
+        /// This variable is set by the default configuration, the user might choose to change this configuration. Because
+        /// of this, this variable is really just a convenience for the user to select the right settings based on it.
         /// </summary>
         public const string GoogleCloudEnvironmentVar = "GOOGLE_CLOUD_ENVIRONMENT";
 

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -26,6 +26,11 @@ namespace GoogleCloudExtension.Deployment
     internal static class CommonUtils
     {
         /// <summary>
+        /// Environment variable to be set with the current environment in which the app is running.
+        /// </summary>
+        public const string GoogleCloudEnvironmentVar = "GOOGLE_CLOUD_ENVIRONMENT";
+
+        /// <summary>
         /// Returns the project name given the path to the project.json. If the project.json file defines a
         /// "name" property then it is used as the name for the final assembly, otherwise the name of the directory
         /// is used as the name of the final assembly.

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
@@ -15,6 +15,7 @@
 using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.Utils;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -32,6 +33,11 @@ namespace GoogleCloudExtension.Deployment
 
         // Wait for up to 2 seconds in between calls when polling.
         private static readonly TimeSpan s_pollingDelay = new TimeSpan(0, 0, 2);
+
+        private static readonly Dictionary<string, string> s_gkeEnvironmentVariables = new Dictionary<string, string>
+        {
+            { "ASPNETCORE_ENVIRONMENT", "gke" }
+        };
 
         /// <summary>
         /// The options that define an app's deployment. All options are required.
@@ -157,6 +163,7 @@ namespace GoogleCloudExtension.Deployment
                             imageTag: image,
                             replicas: options.Replicas,
                             outputAction: outputAction,
+                            environment: s_gkeEnvironmentVariables,
                             context: options.KubectlContext))
                     {
                         Debug.WriteLine($"Failed to create deployment {options.DeploymentName}");

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
@@ -36,7 +36,7 @@ namespace GoogleCloudExtension.Deployment
 
         private static readonly Dictionary<string, string> s_gkeEnvironmentVariables = new Dictionary<string, string>
         {
-            { "ASPNETCORE_ENVIRONMENT", "gke" }
+            { CommonUtils.GoogleCloudEnvironmentVar, "gke" }
         };
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.GCloud
@@ -41,10 +42,20 @@ namespace GoogleCloudExtension.GCloud
             string name,
             string imageTag,
             int replicas,
+            Dictionary<string, string> environment,
             Action<string> outputAction,
             KubectlContext context)
         {
-            return RunCommandAsync($"run {name} --image={imageTag} --replicas={replicas} --port=8080 --record", outputAction, context);
+            string environmentVars = "";
+            if (environment != null)
+            {
+                environmentVars = String.Join(" ", environment.Select(x => $@"--env=""{x.Key}={x.Value}"""));
+            }
+
+            return RunCommandAsync(
+                $"run {name} --image={imageTag} --replicas={replicas} {environmentVars} --port=8080 --record",
+                outputAction,
+                context);
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.GCloud

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>


### PR DESCRIPTION
This PR modifies the default app.yaml and GKE configuration to set the GOOGLE_CLOUD_ENVIRONMENT to either "flex" for App Engine Flex or "gke" for when running on GKE.

With this environment variable the app can select the right configuration to use, etc... 

Fixes #432 