### PR TITLE
Ensuring right credentials for kubectl calls.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
@@ -1,4 +1,18 @@
-﻿namespace GoogleCloudExtension.GCloud
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GoogleCloudExtension.GCloud
 {
     /// <summary>
     /// This class contains defintions for the environment variables used the various wrappers.

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
@@ -15,7 +15,7 @@
 namespace GoogleCloudExtension.GCloud
 {
     /// <summary>
-    /// This class contains defintions for the environment variables used the various wrappers.
+    /// This class contains defintions for the environment variables used by the various wrappers.
     /// </summary>
     internal static class CommonEnvironmentVariables
     {

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GoogleCloudExtension.GCloud
+﻿namespace GoogleCloudExtension.GCloud
 {
     /// <summary>
     /// This class contains defintions for the environment variables used the various wrappers.

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/CommonEnvironmentVariables.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.GCloud
+{
+    /// <summary>
+    /// This class contains defintions for the environment variables used the various wrappers.
+    /// </summary>
+    internal static class CommonEnvironmentVariables
+    {
+        // This variables is used to force gcloud to use application default credentials when generating
+        // the cluster information for the cluster.
+        public const string GCloudContainerUseApplicationDefaultCredentialsVariable = "CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS";
+        public const string TrueValue = "true";
+
+        // This variable is used to override the location of the application default credentials
+        // with the current user's credentials.
+        public const string GoogleApplicationCredentialsVariable = "GOOGLE_APPLICATION_CREDENTIALS";
+
+        // This variable contains the path to the configuration to be used for kubernetes operations.
+        public const string GCloudKubeConfigVariable = "KUBECONFIG";
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -259,6 +259,5 @@ namespace GoogleCloudExtension.GCloud
 
             return environment;
         }
-
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GoogleCloudExtension.GCloud.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GoogleCloudExtension.GCloud.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommonEnvironmentVariables.cs" />
     <Compile Include="Models\GkeDeployment.cs" />
     <Compile Include="KubectlContext.cs" />
     <Compile Include="KubectlWrapper.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlContext.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlContext.cs
@@ -19,7 +19,8 @@ using System.IO;
 namespace GoogleCloudExtension.GCloud
 {
     /// <summary>
-    /// This class owns the context on which to run kubectl commands.
+    /// This class owns the context on which to run kubectl commands. This class owns
+    /// the config file, when the instance is disposed it will delete the file.
     /// </summary>
     public class KubectlContext : IDisposable
     {
@@ -28,9 +29,15 @@ namespace GoogleCloudExtension.GCloud
         /// </summary>
         public string ConfigPath { get; private set; }
 
-        public KubectlContext(string configPath)
+        /// <summary>
+        /// Path to the application credentials to use while calling into kubectl.
+        /// </summary>
+        public string CredentialsPath { get; private set; }
+
+        public KubectlContext(string configPath, string credentialsPath)
         {
             ConfigPath = configPath;
+            CredentialsPath = credentialsPath;
         }
 
         #region IDisposable implementation.

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -187,8 +187,6 @@ namespace GoogleCloudExtension.GCloud
         /// Returns the environment variables to use to invoke kubectl safely. This environemnt is necessary
         /// to ensure that the right credentials are used should the access token need to be refreshed.
         /// </summary>
-        /// <param name="context"></param>
-        /// <returns></returns>
         private static Dictionary<string, string> GetEnvironmentForContext(KubectlContext context)
         {
             return new Dictionary<string, string>

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -152,7 +152,13 @@ namespace GoogleCloudExtension.GCloud
         {
             var actualCommand = FormatCommand(command, context);
             Debug.WriteLine($"Executing kubectl command: kubectl {actualCommand}");
-            return ProcessUtils.RunCommandAsync("kubectl", actualCommand, (o, e) => outputAction(e.Line));
+            Dictionary<string, string> environment = GetEnvironmentForContext(context);
+
+            return ProcessUtils.RunCommandAsync(
+                "kubectl",
+                actualCommand,
+                (o, e) => outputAction(e.Line),
+                environment: environment);
         }
 
         private static async Task<T> GetJsonOutputAsync<T>(string command, KubectlContext context)
@@ -161,7 +167,8 @@ namespace GoogleCloudExtension.GCloud
             try
             {
                 Debug.WriteLine($"Executing kubectl command: kubectl {actualCommand}");
-                return await ProcessUtils.GetJsonOutputAsync<T>("kubectl", actualCommand);
+                var environment = GetEnvironmentForContext(context);
+                return await ProcessUtils.GetJsonOutputAsync<T>("kubectl", actualCommand, environment: environment);
             }
             catch (JsonOutputException ex)
             {
@@ -174,6 +181,21 @@ namespace GoogleCloudExtension.GCloud
             var format = jsonOutput ? "--output=json" : "";
 
             return $"{command} --kubeconfig=\"{context.ConfigPath}\" {format}";
+        }
+
+        /// <summary>
+        /// Returns the environment variables to use to invoke kubectl safely. This environemnt is necessary
+        /// to ensure that the right credentials are used should the access token need to be refreshed.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        private static Dictionary<string, string> GetEnvironmentForContext(KubectlContext context)
+        {
+            return new Dictionary<string, string>
+            {
+                [CommonEnvironmentVariables.GCloudContainerUseApplicationDefaultCredentialsVariable] = CommonEnvironmentVariables.TrueValue,
+                [CommonEnvironmentVariables.GoogleApplicationCredentialsVariable] = context.CredentialsPath
+            };
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>


### PR DESCRIPTION
There's an issue in which `kubectl` will use the application default credentials by default to obtain the credentials for calls into the cluster. If a user has more than one account registered with gcloud the default credentials will be one of the one registered with gcloud. This is also independent of the accounts registered with Visual Studio.

This could be workaround by setting `CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS` to `false` except that exposes a bug in how `kubectl` quotes the path to gcloud to invoke it to fetch credentials.

In order to workaround these two issues this PR changes the extension to set `CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS` to `true` to force `kubectl` to use the application default credentials and then the extension will also set the value of the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the credentials file that corresponds to the user selected in the extension. This way if `kubectl` will always use the same credentials as the extension no matter what.

This also as it turns out is the right behavior for wrapping `kubectl` and ensuring credentials, as we don't want `kubectl` to use `gcloud` to fetch credentials, we want to supply the credentials to it.

Fixes #424