### PR TITLE
Use the "runtime: aspnetcore" in the generated app.yaml.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/AppEngineFlexDeployment.cs
@@ -31,7 +31,7 @@ namespace GoogleCloudExtension.Deployment
         public const string DockerfileName = NetCoreAppUtils.DockerfileName;
 
         private const string AppYamlDefaultContent =
-            "runtime: custom\n" +
+            "runtime: aspnetcore\n" +
             "env: flex\n";
 
         private const string DefaultServiceName = "default";

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -34,6 +34,11 @@ namespace GoogleCloudExtension.GCloud
         private const string GCloudMetricsVariable = "CLOUDSDK_METRICS_ENVIRONMENT";
         private const string GCloudMetricsVersionVariable = "CLOUDSDK_METRICS_ENVIRONMENT_VERSION";
 
+        // Settings to enable the runtime builder in gcloud.
+        private const string GCloudAppUseRuntimeBuilders = "CLOUDSDK_APP_USE_RUNTIME_BUILDERS";
+        private const string GCloudAppRuntimeBuildersRoot = "CLOUDSDK_APP_RUNTIME_BUILDERS_ROOT";
+        private const string RuntimeBuildersRootValue = "gs://aspnet/";
+
         /// <summary>
         /// Finds the location of gcloud.cmd by following all of the directories in the PATH environment
         /// variable until it finds it. With this we assume that in order to run the extension gcloud.cmd is
@@ -76,7 +81,17 @@ namespace GoogleCloudExtension.GCloud
         {
             var versionParameter = version != null ? $"--version={version}" : "";
             var promoteParameter = promote ? "--promote" : "--no-promote";
-            return RunCommandAsync($"beta app deploy \"{appYaml}\" {versionParameter} {promoteParameter} --skip-staging --quiet", outputAction, context);
+            var environment = new Dictionary<string, string>
+            {
+                [GCloudAppUseRuntimeBuilders] = CommonEnvironmentVariables.TrueValue,
+                [GCloudAppRuntimeBuildersRoot] = RuntimeBuildersRootValue
+            };
+
+            return RunCommandAsync(
+                $"beta app deploy \"{appYaml}\" {versionParameter} {promoteParameter} --skip-staging --quiet",
+                outputAction,
+                context,
+                environment);
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -76,7 +76,7 @@ namespace GoogleCloudExtension.GCloud
         {
             var versionParameter = version != null ? $"--version={version}" : "";
             var promoteParameter = promote ? "--promote" : "--no-promote";
-            return RunCommandAsync($"app deploy \"{appYaml}\" {versionParameter} {promoteParameter} --skip-staging --quiet", outputAction, context);
+            return RunCommandAsync($"beta app deploy \"{appYaml}\" {versionParameter} {promoteParameter} --skip-staging --quiet", outputAction, context);
         }
 
         /// <summary>


### PR DESCRIPTION
This change configures `gcloud` via environment variables so the App Engine Flex deployment uses the runtime builders. This uses the dogfood version of the runtime builder so this change is temporary until the final version is out. This will allow us to verify the end to end deployment.