### PR TITLE
Adding checkbox to choose whether a service is public.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using GoogleCloudExtension.GCloud;
+using GoogleCloudExtension.GCloud.Models;
 using GoogleCloudExtension.Utils;
 using System;
 using System.Diagnostics;
@@ -209,7 +210,8 @@ namespace GoogleCloudExtension.Deployment
                 var service = services?.FirstOrDefault(x => x.Metadata.Name == options.DeploymentName);
                 if (options.ExposeService)
                 {
-                    var requestedType = options.ExposePublicService ? "LoadBalancer" : "ClusterIP";
+                    var requestedType = options.ExposePublicService ? 
+                        GkeServiceSpec.LoadBalancerType : GkeServiceSpec.ClusterIpType;
                     if (service != null && service?.Spec?.Type != requestedType)
                     {
                         Debug.WriteLine($"The existing service is {service?.Spec?.Type} the requested is {requestedType}");

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeploymentResult.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeploymentResult.cs
@@ -20,11 +20,17 @@ namespace GoogleCloudExtension.Deployment
     public class GkeDeploymentResult
     {
         /// <summary>
-        /// The IP address of the public service if one was exposed. This property will be null if:
-        ///   * There was a timeout while waiting for the service to go up.
-        ///   * No service was exposed.
+        /// The IP address of the public service if one was exposed. This property can be null
+        /// if no public service was exposed or if there was a timeout trying to obtain the public
+        /// IP address.
         /// </summary>
-        public string ServiceIpAddress { get; }
+        public string PublicServiceIpAddress { get; }
+
+        /// <summary>
+        /// The IP address within the cluster for the service. This property can only be null if there
+        /// was an error deploying the app.
+        /// </summary>
+        public string ClusterServiceIpAddress { get; }
 
         /// <summary>
         /// Is true if the a service was exposed publicly.
@@ -41,9 +47,15 @@ namespace GoogleCloudExtension.Deployment
         /// </summary>
         public bool DeploymentScaled { get; }
 
-        public GkeDeploymentResult(string serviceIpAddress, bool wasExposed, bool deploymentUpdated, bool deploymentScaled)
+        public GkeDeploymentResult(
+            string publicIpAddress,
+            string privateIpAddress,
+            bool wasExposed,
+            bool deploymentUpdated,
+            bool deploymentScaled)
         {
-            ServiceIpAddress = serviceIpAddress;
+            PublicServiceIpAddress = publicIpAddress;
+            ClusterServiceIpAddress = privateIpAddress;
             WasExposed = wasExposed;
             DeploymentUpdated = deploymentUpdated;
             DeploymentScaled = deploymentScaled;

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeploymentResult.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeploymentResult.cs
@@ -35,7 +35,17 @@ namespace GoogleCloudExtension.Deployment
         /// <summary>
         /// Is true if the a service was exposed publicly.
         /// </summary>
-        public bool WasExposed { get; }
+        public bool ServiceExposed { get; }
+
+        /// <summary>
+        /// Is true if the service was updated.
+        /// </summary>
+        public bool ServiceUpdated { get; }
+
+        /// <summary>
+        /// is true if the service was deleted.
+        /// </summary>
+        public bool ServiceDeleted { get; }
 
         /// <summary>
         /// Is true if the deployment was updated, false if a new deployment was created.
@@ -50,13 +60,17 @@ namespace GoogleCloudExtension.Deployment
         public GkeDeploymentResult(
             string publicIpAddress,
             string privateIpAddress,
-            bool wasExposed,
+            bool serviceExposed,
+            bool serviceUpdated,
+            bool serviceDeleted,
             bool deploymentUpdated,
             bool deploymentScaled)
         {
             PublicServiceIpAddress = publicIpAddress;
             ClusterServiceIpAddress = privateIpAddress;
-            WasExposed = wasExposed;
+            ServiceExposed = serviceExposed;
+            ServiceUpdated = serviceUpdated;
+            ServiceDeleted = serviceDeleted;
             DeploymentUpdated = deploymentUpdated;
             DeploymentScaled = deploymentScaled;
         }

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GoogleCloudExtension.GCloud.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GoogleCloudExtension.GCloud.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Models\GkeMetadata.cs" />
     <Compile Include="Models\GkeService.cs" />
     <Compile Include="Models\GkeList.cs" />
+    <Compile Include="Models\GkeServiceSpec.cs" />
     <Compile Include="Models\GkeSpec.cs" />
     <Compile Include="Models\GkeStatus.cs" />
     <Compile Include="WindowsInstanceCredentials.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -154,6 +154,16 @@ namespace GoogleCloudExtension.GCloud
                 context);
         }
 
+        /// <summary>
+        /// Deletes the service given by <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The name of the service to delete.</param>
+        /// <param name="outputAction">The output callback to be called with output from the command.</param>
+        /// <param name="context">The context for invoking kubectl.</param>
+        /// <returns>True if the operation succeeded false otherwise.</returns>
+        public static Task<bool> DeleteServiceAsync(string name, Action<string> outputAction, KubectlContext context)
+            => RunCommandAsync($"delete service {name}", outputAction, context);
+        
         private static Task<bool> RunCommandAsync(string command, Action<string> outputAction, KubectlContext context)
         {
             var actualCommand = FormatCommand(command, context);

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -52,13 +52,19 @@ namespace GoogleCloudExtension.GCloud
         /// to 80 for the service and 8080 for the target pods.
         /// </summary>
         /// <param name="deployment">The deployment for which to create and expose the service.</param>
+        /// <param name="makePublic">True if the service should be made public, false otherwise.</param>
         /// <param name="outputAction">The output callback to be called with output from the command.</param>
         /// <param name="context">The context for invoking kubectl.</param>
         /// <returns>True if the operation succeeded false otherwise.</returns>
-        public static Task<bool> ExposeServiceAsync(string deployment, Action<string> outputAction, KubectlContext context)
+        public static Task<bool> ExposeServiceAsync(
+            string deployment,
+            bool makePublic,
+            Action<string> outputAction,
+            KubectlContext context)
         {
+            var type = makePublic ? "--type=LoadBalancer" : "--type=ClusterIP";
             return RunCommandAsync(
-                $"expose deployment {deployment} --port=80 --target-port=8080 --type=LoadBalancer",
+                $"expose deployment {deployment} --port=80 --target-port=8080 {type}",
                 outputAction,
                 context);
         }

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/KubectlWrapper.cs
@@ -163,7 +163,7 @@ namespace GoogleCloudExtension.GCloud
         /// <returns>True if the operation succeeded false otherwise.</returns>
         public static Task<bool> DeleteServiceAsync(string name, Action<string> outputAction, KubectlContext context)
             => RunCommandAsync($"delete service {name}", outputAction, context);
-        
+
         private static Task<bool> RunCommandAsync(string command, Action<string> outputAction, KubectlContext context)
         {
             var actualCommand = FormatCommand(command, context);

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeService.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeService.cs
@@ -32,5 +32,8 @@ namespace GoogleCloudExtension.GCloud.Models
         /// </summary>
         [JsonProperty("status")]
         public GkeStatus Status { get; set; }
+
+        [JsonProperty("spec")]
+        public GkeServiceSpec Spec { get; set; }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeServiceSpec.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeServiceSpec.cs
@@ -16,8 +16,17 @@ using Newtonsoft.Json;
 
 namespace GoogleCloudExtension.GCloud.Models
 {
+    /// <summary>
+    /// This class contains the specification of a Kubernetest service in GKE.
+    /// </summary>
     public class GkeServiceSpec
     {
+        // The value of the Type property for a public service.
+        public const string LoadBalancerType = "LoadBalancer";
+
+        // The value of the Type property of a cluster only service.
+        public const string ClusterIpType = "ClusterIP";
+
         [JsonProperty("clusterIP")]
         public string ClusterIp { get; set; }
 

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeServiceSpec.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeServiceSpec.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace GoogleCloudExtension.GCloud.Models
+{
+    public class GkeServiceSpec
+    {
+        [JsonProperty("clusterIP")]
+        public string ClusterIp { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeServiceSpec.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeServiceSpec.cs
@@ -1,4 +1,18 @@
-﻿using Newtonsoft.Json;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
 
 namespace GoogleCloudExtension.GCloud.Models
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
@@ -89,13 +89,29 @@
                      Style="{StaticResource CommonTextBoxStyle}" />
         </Grid>
 
-        <CheckBox Content="{x:Static ext:Resources.GkePublishExposeServiceCaption}"
-                  IsChecked="{Binding ExposeService, Mode=TwoWay}"
-                  Style="{StaticResource CommonTextStyleBase}" />
-        <CheckBox IsChecked="{Binding OpenWebsite, Mode=TwoWay}"
-                  Margin="0,5,0,0"
-                  IsEnabled="{Binding ExposeService}"
-                  Content="{x:Static ext:Resources.PublishDialogOpenWebsiteCaption}"
-                  Style="{StaticResource CommonTextStyleBase}"/>
+        <GroupBox Header="Service">
+            <StackPanel>
+                <RadioButton GroupName="password"
+                             Content="Don't expose service."
+                             IsChecked="{Binding DontExposeService}"
+                             Style="{StaticResource CommonRadioButton}"
+                             Margin="{StaticResource CommonRadioButtonMargin}" />
+                <RadioButton GroupName="password"
+                             Content="Expose service."
+                             IsChecked="{Binding ExposeService}"
+                             Style="{StaticResource CommonRadioButton}"
+                             Margin="{StaticResource CommonRadioButtonMargin}" />
+
+                <CheckBox Content="Make service public."
+                          IsEnabled="{Binding ExposeService}"
+                          IsChecked="{Binding ExposePublicService}"
+                          Style="{StaticResource CommonTextStyleBase}" />
+                <CheckBox IsChecked="{Binding OpenWebsite}"
+                          Margin="0,5,0,0"
+                          IsEnabled="{Binding ExposePublicService}"
+                          Content="{x:Static ext:Resources.PublishDialogOpenWebsiteCaption}"
+                          Style="{StaticResource CommonTextStyleBase}"/>
+            </StackPanel>
+        </GroupBox>
     </StackPanel>
 </UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
@@ -89,20 +89,20 @@
                      Style="{StaticResource CommonTextBoxStyle}" />
         </Grid>
 
-        <GroupBox Header="Service">
+        <GroupBox Header="{x:Static ext:Resources.GkePublishServiceGroupHeader}">
             <StackPanel>
                 <RadioButton GroupName="password"
-                             Content="Don't expose service."
+                             Content="{x:Static ext:Resources.GkePublishDontExposeServiceCaption}"
                              IsChecked="{Binding DontExposeService}"
                              Style="{StaticResource CommonRadioButton}"
                              Margin="{StaticResource CommonRadioButtonMargin}" />
                 <RadioButton GroupName="password"
-                             Content="Expose service."
+                             Content="{x:Static ext:Resources.GkePublishExposeServiceCaption}"
                              IsChecked="{Binding ExposeService}"
                              Style="{StaticResource CommonRadioButton}"
                              Margin="{StaticResource CommonRadioButtonMargin}" />
 
-                <CheckBox Content="Make service public."
+                <CheckBox Content="{x:Static ext:Resources.GkePublishMakeServicePublicCaption}"
                           IsEnabled="{Binding ExposeService}"
                           IsChecked="{Binding ExposePublicService}"
                           Style="{StaticResource CommonTextStyleBase}" />

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -246,6 +246,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                         DeploymentName = DeploymentName,
                         DeploymentVersion = DeploymentVersion,
                         ExposeService = ExposeService,
+                        ExposePublicService = ExposePublicService,
                         GCloudContext = gcloudContext,
                         KubectlContext = kubectlContext,
                         Replicas = int.Parse(Replicas),
@@ -285,21 +286,28 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
                         if (result.WasExposed)
                         {
-                            if (result.ServiceIpAddress != null)
+                            if (result.PublicServiceIpAddress != null)
                             {
                                 GcpOutputWindow.OutputLine(
-                                    String.Format(Resources.GkePublishServiceIpMessage, DeploymentName, result.ServiceIpAddress));
+                                    String.Format(Resources.GkePublishServiceIpMessage, DeploymentName, result.PublicServiceIpAddress));
                             }
                             else
                             {
-                                GcpOutputWindow.OutputLine(Resources.GkePublishServiceIpTimeoutMessage);
+                                if (ExposePublicService)
+                                {
+                                    GcpOutputWindow.OutputLine(Resources.GkePublishServiceIpTimeoutMessage);
+                                }
+                                else
+                                {
+                                    GcpOutputWindow.OutputLine($"Service {DeploymentName} cluster IP address {result.ClusterServiceIpAddress}");
+                                }
                             }
                         }
                         StatusbarHelper.SetText(Resources.PublishSuccessStatusMessage);
 
-                        if (OpenWebsite && result.WasExposed && result.ServiceIpAddress != null)
+                        if (OpenWebsite && result.WasExposed && result.PublicServiceIpAddress != null)
                         {
-                            Process.Start($"http://{result.ServiceIpAddress}");
+                            Process.Start($"http://{result.PublicServiceIpAddress}");
                         }
                     }
                     else

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -284,7 +284,11 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                             GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishDeploymentScaledMessage, options.DeploymentName, options.Replicas));
                         }
 
-                        if (result.WasExposed)
+                        if (result.ServiceUpdated)
+                        {
+                            GcpOutputWindow.OutputLine($"Service {DeploymentName} was updated.");
+                        }
+                        if (result.ServiceExposed)
                         {
                             if (result.PublicServiceIpAddress != null)
                             {
@@ -303,9 +307,14 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                                 }
                             }
                         }
+                        if (result.ServiceDeleted)
+                        {
+                            GcpOutputWindow.OutputLine($"Service {DeploymentName} was deleted.");
+                        }
+
                         StatusbarHelper.SetText(Resources.PublishSuccessStatusMessage);
 
-                        if (OpenWebsite && result.WasExposed && result.PublicServiceIpAddress != null)
+                        if (OpenWebsite && result.ServiceExposed && result.PublicServiceIpAddress != null)
                         {
                             Process.Start($"http://{result.PublicServiceIpAddress}");
                         }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -286,7 +286,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
                         if (result.ServiceUpdated)
                         {
-                            GcpOutputWindow.OutputLine($"Service {DeploymentName} was updated.");
+                            GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishServiceUpdatedMessage, options.DeploymentName));
                         }
                         if (result.ServiceExposed)
                         {
@@ -303,13 +303,13 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                                 }
                                 else
                                 {
-                                    GcpOutputWindow.OutputLine($"Service {DeploymentName} cluster IP address {result.ClusterServiceIpAddress}");
+                                    GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishServiceClusterIpMessage, DeploymentName, result.ClusterServiceIpAddress));
                                 }
                             }
                         }
                         if (result.ServiceDeleted)
                         {
-                            GcpOutputWindow.OutputLine($"Service {DeploymentName} was deleted.");
+                            GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishServiceDeletedMessage, DeploymentName));
                         }
 
                         StatusbarHelper.SetText(Resources.PublishSuccessStatusMessage);

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -44,8 +44,10 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         private Cluster _selectedCluster;
         private string _deploymentName;
         private string _deploymentVersion;
-        private bool _exposeService = true;
-        private bool _openWebsite = true;
+        private bool _dontExposeService = true;
+        private bool _exposeService = false;
+        private bool _exposePublicService = false;
+        private bool _openWebsite = false;
         private string _replicas = "3";
 
         /// <summary>
@@ -99,12 +101,34 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         }
 
         /// <summary>
-        /// Whether a public service should be exposed for this deployment.
+        /// Whether the service should NOT be exposed, the opposite of <seealso cref="ExposeService"/>.
+        /// </summary>
+        public bool DontExposeService
+        {
+            get { return _dontExposeService; }
+            set { SetValueAndRaise(ref _dontExposeService, value); }
+        }
+
+        /// <summary>
+        /// Whether a service should be exposed for this deployment.
         /// </summary>
         public bool ExposeService
         {
             get { return _exposeService; }
-            set { SetValueAndRaise(ref _exposeService, value); }
+            set
+            {
+                SetValueAndRaise(ref _exposeService, value);
+                InvalidateExposeService();
+            }
+        }
+
+        /// <summary>
+        /// Whether the service to be exposed should be public on the internet or not.
+        /// </summary>
+        public bool ExposePublicService
+        {
+            get { return _exposePublicService; }
+            set { SetValueAndRaise(ref _exposePublicService, value); }
         }
 
         /// <summary>
@@ -294,6 +318,15 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         }
 
         #endregion
+
+        private void InvalidateExposeService()
+        {
+            if (!ExposeService)
+            {
+                ExposePublicService = false;
+                OpenWebsite = false;
+            }
+        }
 
         private bool ValidateInput()
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -2050,6 +2050,15 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t expose a service..
+        /// </summary>
+        public static string GkePublishDontExposeServiceCaption {
+            get {
+                return ResourceManager.GetString("GkePublishDontExposeServiceCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The deployment name cannot be empty..
         /// </summary>
         public static string GkePublishEmptyDeploymentNameMessage {
@@ -2068,7 +2077,7 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to E_xpose the service to the public internet.
+        ///   Looks up a localized string similar to Expose a service..
         /// </summary>
         public static string GkePublishExposeServiceCaption {
             get {
@@ -2100,6 +2109,15 @@ namespace GoogleCloudExtension
         public static string GkePublishInvalidReplicasMessage {
             get {
                 return ResourceManager.GetString("GkePublishInvalidReplicasMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make service public..
+        /// </summary>
+        public static string GkePublishMakeServicePublicCaption {
+            get {
+                return ResourceManager.GetString("GkePublishMakeServicePublicCaption", resourceCulture);
             }
         }
         
@@ -2149,6 +2167,33 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Service {0} cluster IP address {1}..
+        /// </summary>
+        public static string GkePublishServiceClusterIpMessage {
+            get {
+                return ResourceManager.GetString("GkePublishServiceClusterIpMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service {0} was deleted..
+        /// </summary>
+        public static string GkePublishServiceDeletedMessage {
+            get {
+                return ResourceManager.GetString("GkePublishServiceDeletedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service.
+        /// </summary>
+        public static string GkePublishServiceGroupHeader {
+            get {
+                return ResourceManager.GetString("GkePublishServiceGroupHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Service {0} ip address {1}.
         /// </summary>
         public static string GkePublishServiceIpMessage {
@@ -2163,6 +2208,15 @@ namespace GoogleCloudExtension
         public static string GkePublishServiceIpTimeoutMessage {
             get {
                 return ResourceManager.GetString("GkePublishServiceIpTimeoutMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service {0} was updated..
+        /// </summary>
+        public static string GkePublishServiceUpdatedMessage {
+            get {
+                return ResourceManager.GetString("GkePublishServiceUpdatedMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1256,7 +1256,7 @@
     <comment>The message shown in the UI for the depoyment version textbox.</comment>
   </data>
   <data name="GkePublishExposeServiceCaption" xml:space="preserve">
-    <value>E_xpose the service to the public internet</value>
+    <value>Expose a service.</value>
     <comment>Caption for the checkbox to set if the GKE service is to be exposed or not.</comment>
   </data>
   <data name="GkePublishMissingKubectlMessage" xml:space="preserve">
@@ -1458,5 +1458,29 @@
   <data name="CloudExplorerGaeVersionEnvironmentDisplayName" xml:space="preserve">
     <value>Environment</value>
     <comment>The display name for the Environment property.</comment>
+  </data>
+  <data name="GkePublishDontExposeServiceCaption" xml:space="preserve">
+    <value>Don't expose a service.</value>
+    <comment>Caption for the option of not exposing the service.</comment>
+  </data>
+  <data name="GkePublishMakeServicePublicCaption" xml:space="preserve">
+    <value>Make service public.</value>
+    <comment>Caption for the checkbox to make a service public.</comment>
+  </data>
+  <data name="GkePublishServiceClusterIpMessage" xml:space="preserve">
+    <value>Service {0} cluster IP address {1}.</value>
+    <comment>Message shown when a cluster-only service is deployed to show the ip address. {0} is the service name, {1} is the IP address.</comment>
+  </data>
+  <data name="GkePublishServiceDeletedMessage" xml:space="preserve">
+    <value>Service {0} was deleted.</value>
+    <comment>Message shown when a service is deleted due to changes in configuration. {0} is the name of the service.</comment>
+  </data>
+  <data name="GkePublishServiceGroupHeader" xml:space="preserve">
+    <value>Service</value>
+    <comment>The header for the service group in the UI.</comment>
+  </data>
+  <data name="GkePublishServiceUpdatedMessage" xml:space="preserve">
+    <value>Service {0} was updated.</value>
+    <comment>Messages shown when a GKE service is updated. {0} is the service name.</comment>
   </data>
 </root>

--- a/tools/find_strings.sh
+++ b/tools/find_strings.sh
@@ -12,6 +12,8 @@ ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
     "caption: \\$\"|message: \\$\"|title: \"|Header = \\$\"|Caption = \\$\""
 ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
     "\\[Category\\(|\\[DisplayName\\(|\\[Description\\("
+${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
+    "\\.OutputLine\\(\\$\"|\\.OutputLine\\(\""
 
 # Look for literal strings on .xaml files.
 ${workspace}/tools/find_files.py -d $1 -e .xaml | xargs grep -HnE \


### PR DESCRIPTION
This PR adds a notion of having an exposed service that doesn't have a public IP address. This allows us to have private backends that are not exposed to the world.

Having a private, cluster only, service is accomplished by using the "ClusterIP" type for a service. With this type the IP address that the service gets will only be accessible from the cluster itself.

This PR also adds the capability of _updating_ an existing service. If the user requests a different type of service, say the previous service was cluster only and the user requested a public service, then the extension will delete the previous service and create a new one. If the user selects the option of not exposing a service then if there's an existing service it will be deleted.

Fixes #438 