### PR TITLE
Add "Migrage all traffic" command for App Engine versions in Cloud Explorer

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/CloudSQLDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/CloudSQLDataSource.cs
@@ -19,6 +19,7 @@ using Google.Apis.SQLAdmin.v1beta4.Data;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 
@@ -97,6 +98,23 @@ namespace GoogleCloudExtension.DataSources
             {
                 Debug.WriteLine($"Failed to update database instance: {ex.Message}");
                 throw new DataSourceException(ex.Message, ex);
+            }
+        }
+
+        /// <summary>
+        /// Awaits for the operation to complete succesfully.
+        /// </summary>
+        /// <param name="operation">The operation to await.</param>
+        /// <returns>The task that will be done once the operation is succesful.</returns>
+        public async Task AwaitOperationAsync(Operation operation)
+        {
+            var completedOperation = await Polling<Operation>.Poll(
+                operation,
+                o => GetOperationAsync(o.Name),
+                o => o.Status == OperationStateDone);
+            if (completedOperation.Error != null)
+            {
+                throw new DataSourceException(completedOperation.Error.Errors.FirstOrDefault()?.Message);
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeDataSource.cs
@@ -156,12 +156,13 @@ namespace GoogleCloudExtension.DataSources
         /// <returns>The task that will be done once the operation is succesful.</returns>
         public async Task AwaitOperationAsync(Operation operation)
         {
-            Func<Operation, Task<Operation>> fetch = (o) => GetOperationAsync(o.GetOperationId());
-            Predicate<Operation> stopPolling = (o) => o.Done ?? false;
-            operation = await Polling<Operation>.Poll(operation, fetch, stopPolling);
-            if (operation.Error != null)
+            var completedOperation = await Polling<Operation>.Poll(
+                operation,
+                o => GetOperationAsync(o.GetOperationId()),
+                o => o.Done ?? false);
+            if (completedOperation.Error != null)
             {
-                throw new DataSourceException(operation.Error.Message);
+                throw new DataSourceException(completedOperation.Error.Message);
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeDataSource.cs
@@ -16,7 +16,6 @@ using Google;
 using Google.Apis.Appengine.v1;
 using Google.Apis.Appengine.v1.Data;
 using Google.Apis.Auth.OAuth2;
-using GoogleCloudExtension.Utils;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeServiceExtensions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeServiceExtensions.cs
@@ -34,12 +34,12 @@ namespace GoogleCloudExtension.DataSources
         /// </summary>
         /// <param name="service"></param>
         /// <param name="versionId"></param>
-        /// <returns>The traffic allocation if it exists, null otherwise.</returns>
-        public static double? GetTrafficAllocation(this Service service, string versionId)
+        /// <returns>The traffic allocation if it exists, 0.0 otherwise.</returns>
+        public static double GetTrafficAllocation(this Service service, string versionId)
         {
             IDictionary<string, double?> allocations = service.Split.Allocations;
             double? allocation;
-            return allocations.TryGetValue(versionId, out allocation) ? allocation : null;
+            return allocations.TryGetValue(versionId, out allocation) ? allocation.Value : 0.0;
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -125,6 +125,7 @@
     <Compile Include="GPlusDataSource.cs" />
     <Compile Include="GcsDataSource.cs" />
     <Compile Include="InstancesPerZone.cs" />
+    <Compile Include="Polling.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResourceManagerDataSource.cs" />
     <Compile Include="WindowsInstanceInfo.cs" />
@@ -133,12 +134,6 @@
     <None Include="app.config" />
     <None Include="Key.snk" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\GoogleCloudExtension.Utils\GoogleCloudExtension.Utils.csproj">
-      <Project>{21501704-9d0c-442f-ad39-292b3da4bc57}</Project>
-      <Name>GoogleCloudExtension.Utils</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -134,6 +134,12 @@
     <None Include="Key.snk" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GoogleCloudExtension.Utils\GoogleCloudExtension.Utils.csproj">
+      <Project>{21501704-9d0c-442f-ad39-292b3da4bc57}</Project>
+      <Name>GoogleCloudExtension.Utils</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/Polling.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/Polling.cs
@@ -16,12 +16,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace GoogleCloudExtension.Utils
+namespace GoogleCloudExtension.DataSources
 {
     /// <summary>
     /// This class represents a configuration to use for polling.
     /// </summary>
-    public class PollingConfiguration
+    internal class PollingConfiguration
     {
         /// <summary>
         /// The default polling interval.  This value is the delay between poll requests.
@@ -62,7 +62,7 @@ namespace GoogleCloudExtension.Utils
     /// <summary>
     /// This class handles polling for a resource.
     /// </summary>
-    public class Polling<T>
+    internal class Polling<T>
     {
         /// <summary>
         /// Poll for a resource.

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleCloudExtension.Utils.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/GoogleCloudExtension.Utils.csproj
@@ -61,7 +61,6 @@
     <Compile Include="JsonOutputException.cs" />
     <Compile Include="Model.cs" />
     <Compile Include="PlaceholderMessage.cs" />
-    <Compile Include="Polling.cs" />
     <Compile Include="ProcessUtils.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VisibilityConverter.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -111,10 +111,8 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             try
             {
                 // Poll until the update to completes.
-                Task<Operation> operation = _owner.DataSource.Value.UpdateInstanceAsync(Instance);
-                Func<Operation, Task<Operation>> fetch = (o) => dataSource.GetOperationAsync(o.Name);
-                Predicate<Operation> stopPolling = (o) => CloudSqlDataSource.OperationStateDone.Equals(o.Status);
-                await Polling<Operation>.Poll(await operation, fetch, stopPolling);
+                var operation = await _owner.DataSource.Value.UpdateInstanceAsync(Instance);
+                await _owner.DataSource.Value.AwaitOperationAsync(operation);
 
                 EventsReporterWrapper.ReportEvent(ManageCloudSqlAuthorizedNetworkEvent.Create(CommandStatus.Success));
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -183,7 +183,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             var versions = await _dataSource.Value.GetVersionListAsync(service.Id);
             var versionModels = versions
                 .Select(x => new VersionViewModel(this, service, x))
-                .OrderByDescending(x => GaeServiceExtensions.GetTrafficAllocation(service, x.Version.Id) ?? 0.0)
+                .OrderByDescending(x => GaeServiceExtensions.GetTrafficAllocation(service, x.Version.Id))
                 .ToList();
             return new ServiceViewModel(this, service, versionModels);
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -321,15 +321,8 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
             try
             {
-                Task<Operation> operationTask = _owner.DataSource.UpdateServiceTrafficSplitAsync(split, Service.Id);
-                Func<Operation, Task<Operation>> fetch = (o) => datasource.GetOperationAsync(o.GetOperationId());
-                Predicate<Operation> stopPolling = (o) => o.Done ?? false;
-                Operation operation = await Polling<Operation>.Poll(await operationTask, fetch, stopPolling);
-                if (operation.Error != null)
-                {
-                    throw new DataSourceException(operation.Error.Message);
-                }
-
+                var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, Service.Id);
+                await _owner.DataSource.AwaitOperationAsync(operation); 
                 _owner.InvalidateService(_service.Id);
 
                 EventsReporterWrapper.ReportEvent(GaeTrafficSplitUpdatedEvent.Create(CommandStatus.Success));
@@ -374,14 +367,9 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
             try
             {
-                Task<Operation> operationTask = datasource.DeleteServiceAsync(Service.Id);
-                Func<Operation, Task<Operation>> fetch = (o) => datasource.GetOperationAsync(o.GetOperationId());
-                Predicate<Operation> stopPolling = (o) => o.Done ?? false;
-                Operation operation = await Polling<Operation>.Poll(await operationTask, fetch, stopPolling);
-                if (operation.Error != null)
-                {
-                    throw new DataSourceException(operation.Error.Message);
-                }
+                var operation = await datasource.DeleteServiceAsync(Service.Id);
+                await datasource.AwaitOperationAsync(operation);
+
                 EventsReporterWrapper.ReportEvent(GaeServiceDeletedEvent.Create(CommandStatus.Success));
             }
             catch (Exception ex) when (ex is DataSourceException || ex is TimeoutException || ex is OperationCanceledException)

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -321,7 +321,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
             try
             {
-                Task<Operation> operationTask = _owner.DataSource.UpdateServiceTrafficSplit(split, Service.Id);
+                Task<Operation> operationTask = _owner.DataSource.UpdateServiceTrafficSplitAsync(split, Service.Id);
                 Func<Operation, Task<Operation>> fetch = (o) => datasource.GetOperationAsync(o.GetOperationId());
                 Predicate<Operation> stopPolling = (o) => o.Done ?? false;
                 Operation operation = await Polling<Operation>.Poll(await operationTask, fetch, stopPolling);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -119,18 +119,10 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         {
             try
             {
-                var split = new TrafficSplit
-                {
-                    Allocations = new Dictionary<string, double?>
-                    {
-                        [_version.Id] = 1.0
-                    }
-                };
-
-                var datasource = _owner.DataSource;
                 IsLoading = true;
                 Caption = String.Format(Resources.CloudExplorerGaeMigratingAllTrafficCaption, _version.Id);
 
+                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> { [_version.Id] = 1.0 } };
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, _service.Id);
                 await _owner.DataSource.AwaitOperationAsync(operation);
                 _owner.InvalidateService(_service.Id);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -89,7 +89,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 menuItems.Add(new MenuItem { Header = Resources.CloudExplorerGaeVersionOpen, Command = new ProtectedCommand(OnOpenVersion) });
                 if (_trafficAllocation < 1.0)
                 {
-                    menuItems.Add(new MenuItem { Header = "Migrate all traffic", Command = new ProtectedCommand(OnMigrateTrafficCommand) });
+                    menuItems.Add(new MenuItem { Header = Resources.CloudExplorerGaeMigrateAllTrafficHeader, Command = new ProtectedCommand(OnMigrateTrafficCommand) });
                 }
             }
 
@@ -129,7 +129,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
                 var datasource = _owner.DataSource;
                 IsLoading = true;
-                Caption = $"Updating split for {_version.Id}";
+                Caption = String.Format(Resources.CloudExplorerGaeMigratingAllTrafficCaption, _version.Id);
 
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, _service.Id);
                 await _owner.DataSource.AwaitOperationAsync(operation);
@@ -139,7 +139,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             {
                 Debug.WriteLine($"Faile to set traffic to 100%: {ex.Message}");
                 IsError = true;
-                Caption = "Failed to set traffic to 100%, please try again.";
+                Caption = String.Format(Resources.CloudExplorerGaeFailedToMigrateAllTrafficCaption, _version.Id);
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -46,11 +46,10 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         private readonly Service _service;
         private readonly Google.Apis.Appengine.v1.Data.Version _version;
         private readonly double _trafficAllocation;
-        private readonly bool _hasTrafficAllocation;
 
         public Google.Apis.Appengine.v1.Data.Version Version => _version;
 
-        public bool HasTrafficAllocation => _hasTrafficAllocation;
+        public bool HasTrafficAllocation => _trafficAllocation > 0;
 
         public event EventHandler ItemChanged;
 
@@ -65,9 +64,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             _service = service;
             _version = version;
 
-            var allocation = GaeServiceExtensions.GetTrafficAllocation(_service, _version.Id);
-            _trafficAllocation = allocation ?? 0.0;
-            _hasTrafficAllocation = allocation != null;
+            _trafficAllocation = GaeServiceExtensions.GetTrafficAllocation(_service, _version.Id);
 
             // Update the view.
             Caption = GetCaption();
@@ -104,7 +101,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             }
 
             // If the version is stopped and has no traffic allocated to it allow it to be deleted.
-            if (!_hasTrafficAllocation && _version.IsStopped())
+            if (HasTrafficAllocation && _version.IsStopped())
             {
                 menuItems.Add(new MenuItem { Header = Resources.CloudExplorerGaeDeleteVersion, Command = new ProtectedCommand(OnDeleteVersion) });
             }
@@ -255,7 +252,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         /// </summary>
         private string GetCaption()
         {
-            if (!_hasTrafficAllocation)
+            if (!HasTrafficAllocation)
             {
                 return _version.Id;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -105,7 +105,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             }
 
             // If the version is stopped and has no traffic allocated to it allow it to be deleted.
-            if (HasTrafficAllocation && _version.IsStopped())
+            if (!HasTrafficAllocation && _version.IsStopped())
             {
                 menuItems.Add(new MenuItem { Header = Resources.CloudExplorerGaeDeleteVersion, Command = new ProtectedCommand(OnDeleteVersion) });
             }
@@ -129,7 +129,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             }
             catch (DataSourceException ex)
             {
-                Debug.WriteLine($"Faile to set traffic to 100%: {ex.Message}");
+                Debug.WriteLine($"Failed to set traffic to 100%: {ex.Message}");
                 IsError = true;
                 Caption = String.Format(Resources.CloudExplorerGaeFailedToMigrateAllTrafficCaption, _version.Id);
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -430,11 +430,38 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to migrate all traffic to {0}, please try again..
+        /// </summary>
+        public static string CloudExplorerGaeFailedToMigrateAllTrafficCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGaeFailedToMigrateAllTrafficCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading services....
         /// </summary>
         public static string CloudExplorerGaeLoadingServicesCaption {
             get {
                 return ResourceManager.GetString("CloudExplorerGaeLoadingServicesCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Migrate all traffic.
+        /// </summary>
+        public static string CloudExplorerGaeMigrateAllTrafficHeader {
+            get {
+                return ResourceManager.GetString("CloudExplorerGaeMigrateAllTrafficHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Migrating all traffic to {0}.
+        /// </summary>
+        public static string CloudExplorerGaeMigratingAllTrafficCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGaeMigratingAllTrafficCaption", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1459,4 +1459,16 @@
     <value>Environment</value>
     <comment>The display name for the Environment property.</comment>
   </data>
+  <data name="CloudExplorerGaeFailedToMigrateAllTrafficCaption" xml:space="preserve">
+    <value>Failed to migrate all traffic to {0}, please try again.</value>
+    <comment>Caption for the error state when migrating all traffic. {0} is the id of the version.</comment>
+  </data>
+  <data name="CloudExplorerGaeMigrateAllTrafficHeader" xml:space="preserve">
+    <value>Migrate all traffic</value>
+    <comment>Header for the migrate all traffic command.</comment>
+  </data>
+  <data name="CloudExplorerGaeMigratingAllTrafficCaption" xml:space="preserve">
+    <value>Migrating all traffic to {0}</value>
+    <comment>Caption shown while migrating all traffic. {0} is the version id</comment>
+  </data>
 </root>


### PR DESCRIPTION
This PR implements a "Migrate all traffic" command for App Engine versions in Cloud Explorer as a shortcut to change the version that serves all traffic for a service. The same operation could be done by changing the split settings but this short cut will make things much more convenient. This also mirrors the same option in the Cloud Console.

There's also a bit of refactoring the `Poll<T>` class, making it internal to the `GoogleCloudExtension.DataSources` project and exposing `AwaitOperationAsync()` methods for those data sources that offer the option for creating operations. This way the client code only has to `await` a `Task` without having to deal with the details under the covers.

Fixes #244