### PR TITLE
Prevent context menu to show from nodes with no context menu.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/Polling.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/Polling.cs
@@ -39,13 +39,13 @@ namespace GoogleCloudExtension.DataSources
         /// <summary>
         /// The delay between poll requests.
         /// </summary>
-        public TimeSpan Interval;
+        public readonly TimeSpan Interval;
 
         /// <summary>
         /// The total time spent in delays between requests before a timeout is considered to
         /// have occured.
         /// </summary>
-        public TimeSpan Timeout;
+        public readonly TimeSpan Timeout;
 
         /// <summary>
         /// Create a new polling configuration.

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
@@ -210,7 +210,7 @@ namespace GoogleCloudExtension.Deployment
                 var service = services?.FirstOrDefault(x => x.Metadata.Name == options.DeploymentName);
                 if (options.ExposeService)
                 {
-                    var requestedType = options.ExposePublicService ? 
+                    var requestedType = options.ExposePublicService ?
                         GkeServiceSpec.LoadBalancerType : GkeServiceSpec.ClusterIpType;
                     if (service != null && service?.Spec?.Type != requestedType)
                     {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml
@@ -181,6 +181,7 @@
                 <Setter Property="Foreground" Value="{DynamicResource VsBrush.WindowText}"/>
                 <Setter Property="ContextMenu" Value="{Binding Header.ContextMenu, RelativeSource={RelativeSource Self}}" />
                 <EventSetter Event="TreeViewItem.PreviewMouseRightButtonDown" Handler="TreeViewItem_PreviewMouseRightButtonDown" />
+                <EventSetter Event="TreeViewItem.ContextMenuOpening" Handler="TreeViewItem_ContextMenuOpening" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type TreeViewItem}">

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml.cs
@@ -14,6 +14,7 @@
 
 using GoogleCloudExtension.Utils;
 using System;
+using System.Diagnostics;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -92,6 +93,24 @@ namespace GoogleCloudExtension.CloudExplorer
                 if (item != null)
                 {
                     item.IsSelected = true;
+                }
+            });
+        }
+
+        private void TreeViewItem_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            ErrorHandlerUtils.HandleExceptions(() =>
+            {
+                var item = sender as TreeViewItem;
+                if (item != null)
+                {
+                    var node = item.Header as TreeNode;
+                    if (node != null)
+                    {
+                        // If the node doesn't have a context menu defined then declare the event as
+                        // handled so no context menu is shown.
+                        e.Handled = node.ContextMenu == null;
+                    }
                 }
             });
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindowControl.xaml.cs
@@ -14,7 +14,6 @@
 
 using GoogleCloudExtension.Utils;
 using System;
-using System.Diagnostics;
 using System.Windows.Controls;
 using System.Windows.Input;
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -25,7 +25,6 @@ using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Media;
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -23,7 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -321,7 +321,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             try
             {
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, Service.Id);
-                await _owner.DataSource.AwaitOperationAsync(operation); 
+                await _owner.DataSource.AwaitOperationAsync(operation);
                 _owner.InvalidateService(_service.Id);
 
                 EventsReporterWrapper.ReportEvent(GaeTrafficSplitUpdatedEvent.Create(CommandStatus.Success));

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -22,7 +22,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -131,7 +131,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 IsLoading = true;
                 Caption = String.Format(Resources.CloudExplorerGaeMigratingAllTrafficCaption, _version.Id);
 
-                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> { [_version.Id] = 1.0 } };
+                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> {[_version.Id] = 1.0 } };
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, _service.Id);
                 await _owner.DataSource.AwaitOperationAsync(operation);
                 _owner.InvalidateService(_service.Id);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -45,7 +45,8 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
         };
         private static readonly TreeLeaf s_noItemsPlacehoder = new TreeLeaf
         {
-            Caption = Resources.CloudExplorerGceSourceNoInstancesCaption
+            Caption = Resources.CloudExplorerGceSourceNoInstancesCaption,
+            IsWarning = true
         };
 
         private bool _showOnlyWindowsInstances = false;

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>


### PR DESCRIPTION
This PR adds an event handler to all `TreeViewItem` instances used in the Cloud Explorer to verify that they have a a `ContextMenu` set before allowing the menu to be displayed. This way we avoid the existing issue in which the wrong menu will be shown because the framework is looking for one up the visual hierarchy.

This PR contains some extra changes because of running the formatting and "sort usings" scripts as well. 

Fixes #389