### PR TITLE
Fix xaml errors

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/BindableList.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/BindableList.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
@@ -27,68 +25,23 @@ namespace GoogleCloudExtension.Utils
     /// the DataContext can be set as they are added to the list.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class BindableList<T> : IList where T : FrameworkElement
+    public class BindableList<T> : ObservableCollection<T> where T : FrameworkElement
     {
-        private readonly IList<T> _storage = new ObservableCollection<T>();
         private readonly DependencyObject _dataContextSource;
 
-        public IList<T> Collection => _storage;
+        public IList<T> Collection => this;
 
-        #region IList
-
-        bool IList.IsReadOnly => _storage.IsReadOnly;
-
-        bool IList.IsFixedSize => false;
-
-        int ICollection.Count => _storage.Count;
-
-        object ICollection.SyncRoot => this;
-
-        bool ICollection.IsSynchronized => false;
-
-        object IList.this[int index]
+        protected override void SetItem(int index, T item)
         {
-            get
-            {
-                return _storage[index];
-            }
-
-            set
-            {
-                _storage[index] = (T)value;
-            }
-        }
-
-        int IList.Add(object value)
-        {
-            T item = (T)value;
+            base.SetItem(index, item);
             SetupDataContextBinding(item);
-            _storage.Add(item);
-            return _storage.Count;
         }
 
-        bool IList.Contains(object value) => _storage.Contains((T)value);
-
-        void IList.Clear() => _storage.Clear();
-
-        int IList.IndexOf(object value) => _storage.IndexOf((T)value);
-
-        void IList.Insert(int index, object value)
+        protected override void InsertItem(int index, T item)
         {
-            T item = (T)value;
+            base.InsertItem(index, item);
             SetupDataContextBinding(item);
-            _storage.Insert(index, item);
         }
-
-        void IList.Remove(object value) => _storage.Remove((T)value);
-
-        void IList.RemoveAt(int index) => _storage.RemoveAt(index);
-
-        void ICollection.CopyTo(Array array, int index) => _storage.CopyTo((T[])array, index);
-
-        IEnumerator IEnumerable.GetEnumerator() => _storage.GetEnumerator();
-
-        #endregion 
 
         public BindableList(DependencyObject dataContextSource)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/BindableList.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/BindableList.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Data;
@@ -29,7 +28,10 @@ namespace GoogleCloudExtension.Utils
     {
         private readonly DependencyObject _dataContextSource;
 
-        public IList<T> Collection => this;
+        public BindableList(DependencyObject dataContextSource)
+        {
+            _dataContextSource = dataContextSource;
+        }
 
         protected override void SetItem(int index, T item)
         {
@@ -41,11 +43,6 @@ namespace GoogleCloudExtension.Utils
         {
             base.InsertItem(index, item);
             SetupDataContextBinding(item);
-        }
-
-        public BindableList(DependencyObject dataContextSource)
-        {
-            _dataContextSource = dataContextSource;
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBaseContent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBaseContent.cs
@@ -14,7 +14,6 @@
 
 using GoogleCloudExtension.Utils;
 using System;
-using System.Collections;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -34,7 +33,7 @@ namespace GoogleCloudExtension.Theming
         public static readonly DependencyProperty ButtonsProperty =
             DependencyProperty.Register(
                 nameof(Buttons),
-                typeof(IList),
+                typeof(BindableList<DialogButtonInfo>),
                 typeof(CommonDialogWindowBaseContent));
 
         // Dependency property for the HasBanner property.
@@ -47,9 +46,9 @@ namespace GoogleCloudExtension.Theming
         /// <summary>
         /// The list of buttons to show in the dialog.
         /// </summary>
-        public IList Buttons
+        public BindableList<DialogButtonInfo> Buttons
         {
-            get { return (IList)GetValue(ButtonsProperty); }
+            get { return (BindableList<DialogButtonInfo>)GetValue(ButtonsProperty); }
             set { SetValue(ButtonsProperty, value); }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBaseContent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBaseContent.cs
@@ -14,6 +14,7 @@
 
 using GoogleCloudExtension.Utils;
 using System;
+using System.Collections;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -33,7 +34,7 @@ namespace GoogleCloudExtension.Theming
         public static readonly DependencyProperty ButtonsProperty =
             DependencyProperty.Register(
                 nameof(Buttons),
-                typeof(BindableList<DialogButtonInfo>),
+                typeof(IList),
                 typeof(CommonDialogWindowBaseContent));
 
         // Dependency property for the HasBanner property.
@@ -46,9 +47,9 @@ namespace GoogleCloudExtension.Theming
         /// <summary>
         /// The list of buttons to show in the dialog.
         /// </summary>
-        public BindableList<DialogButtonInfo> Buttons
+        public IList Buttons
         {
-            get { return (BindableList<DialogButtonInfo>)GetValue(ButtonsProperty); }
+            get { return (IList)GetValue(ButtonsProperty); }
             set { SetValue(ButtonsProperty, value); }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBaseContent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonDialogWindowBaseContent.cs
@@ -80,9 +80,10 @@ namespace GoogleCloudExtension.Theming
         /// </summary>
         private void Initialize()
         {
-            ResourceDictionary resources = new ResourceDictionary();
-            resources.Source = ResourceUtils.GetResourceUri("Theming/ThemingResources.xaml");
-            this.Resources = resources;
+            Resources = new ResourceDictionary
+            {
+                Source = ResourceUtils.GetResourceUri("Theming/ThemingResources.xaml")
+            };
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/ThemingResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/ThemingResources.xaml
@@ -91,7 +91,7 @@
                                 <!-- The row of buttons. -->
                                 <Border Grid.Row="1" Style="{StaticResource DialogButtonBar}">
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <local:ButtonsList ItemsSource="{Binding Buttons.Collection, RelativeSource={RelativeSource TemplatedParent}}"
+                                        <local:ButtonsList ItemsSource="{Binding Buttons, RelativeSource={RelativeSource TemplatedParent}}"
                                                            Focusable="False"
                                                            ItemTemplateSelector="{StaticResource DialogButtonTemplateSelector}">
                                             <ItemsControl.ItemsPanel>


### PR DESCRIPTION
Either Resharper or the built in visual studio designer does not like the explicit implementation of `IList` by `BindableList<T>`. The error "The type does not implement IList: BindableList\`1" exists on every `<theming:CommonDialogWindowBaseContent.Buttons>` element. This PR fixes all of those errors by making `BindableList<T>` implicitly implement `IList` by making it a subclass of `ObservableCollection<T>`.

Instead of overriding `Add()` and `Set()` to call `SetupDataContextBinding()`, it overrides `InsertItem()` and `SetItem()`.