### PR TITLE
Use 1.0 tag instead.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -37,7 +37,7 @@ namespace GoogleCloudExtension.Deployment
         /// All of the files composing the app are copied to the /app path, then it is set as the working directory.
         /// </summary>
         private const string DockerfileDefaultContent =
-            "FROM gcr.io/google-appengine/aspnetcore:1.0.3\n" +
+            "FROM gcr.io/google-appengine/aspnetcore:1.0\n" +
             "COPY . /app\n" +
             "WORKDIR /app\n" +
             "EXPOSE 8080\n" +


### PR DESCRIPTION
Trivial change to use the `1.0` tag instead of the `1.0.3` tag. By using the `1.0` tag we can ensure that we will always use the latest version in the 1.0.x branch.

Now we should think about how to pin to a specific version of the image within that version, how to list the different versions, etc... But pinning to `1.0` is the right default.