### PR TITLE
Adding more checks for strings.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/SourceBrowsing/StackdriverHighlightFormat.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/SourceBrowsing/StackdriverHighlightFormat.cs
@@ -25,14 +25,16 @@ namespace GoogleCloudExtension.SourceBrowsing
     /// </summary>
     internal class StackdriverTag : TextMarkerTag
     {
-        public StackdriverTag() : base("StackdriverMarkerFormat") { }
+        public const string StackdriverMarkerFormatName = "StackdriverMarkerFormat";
+
+        public StackdriverTag() : base(StackdriverMarkerFormatName) { }
     }
 
     /// <summary>
     /// Define a custom <seealso cref="EditorFormatDefinition"/> for highlighting source line.
     /// </summary>
     [Export(typeof(EditorFormatDefinition))]
-    [Name("StackdriverMarkerFormat")]
+    [Name(StackdriverTag.StackdriverMarkerFormatName)]
     internal class StackdriverHighlightFormat : MarkerFormatDefinition
     {
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingException.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingException.cs
@@ -22,6 +22,6 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
     public class ErrorReportingException : Exception
     {
         public ErrorReportingException(string message) : base(message) { }
-        public ErrorReportingException(Exception innerException) : base("", innerException: innerException) { }
+        public ErrorReportingException(Exception innerException) : base(String.Empty, innerException: innerException) { }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/TreeViewConverters/LogEntryNode.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/TreeViewConverters/LogEntryNode.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Google.Apis.Logging.v2.Data;
+using System;
 
 namespace GoogleCloudExtension.StackdriverLogsViewer
 {
@@ -25,7 +26,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// Create an instance of the <seealso cref="LogEntryNode"/> class.
         /// </summary>
         /// <param name="logEntry">A <seealso cref="LogEntry"/> object.</param>
-        public LogEntryNode(LogEntry logEntry) : base("", logEntry, null) { }
+        public LogEntryNode(LogEntry logEntry) : base(String.Empty, logEntry, null) { }
 
         /// <summary>
         /// Override <seealso cref="ObjectNodeTree.ParseObjectTree(object)"/>.

--- a/tools/find_strings.sh
+++ b/tools/find_strings.sh
@@ -13,6 +13,10 @@ ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
 ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
     "\\[Category\\(|\\[DisplayName\\(|\\[Description\\("
 ${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
+    "Prompt\\(\""
+${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
+    "base\\(\""
+${workspace}/tools/find_files.py -d $1 -e .cs | xargs grep -HnE \
     "\\.OutputLine\\(\\$\"|\\.OutputLine\\(\""
 
 # Look for literal strings on .xaml files.


### PR DESCRIPTION
This PR adds a couple more checks for non-extracted strings to the `find_strings.sh` script. The PR also fixes the code that triggers the check by extracting the string to a constant and using the constant instead.

The price for this inconvenience is that we are able to ensure that we have extracted all strings in the codebase.