### PR TITLE
Add source context to the app bundles.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.Utils;
 using System;
 using System.Collections.Generic;
@@ -49,7 +50,7 @@ namespace GoogleCloudExtension.Deployment
         /// <param name="stageDirectory">The directory to which to publish.</param>
         /// <param name="pathsProvider">The provider for paths.</param>
         /// <param name="outputAction">The callback to call with output from the command.</param>
-        internal static Task<bool> CreateAppBundleAsync(
+        internal static async Task<bool> CreateAppBundleAsync(
             IParsedProject project,
             string stageDirectory,
             IToolsPathProvider pathsProvider,
@@ -65,8 +66,10 @@ namespace GoogleCloudExtension.Deployment
 
             Debug.WriteLine($"Using tools from {externalTools}");
             Debug.WriteLine($"Setting working directory to {workingDir}");
+            Directory.CreateDirectory(stageDirectory);
+            await GCloudWrapper.GenerateSourceContext(project.DirectoryPath, stageDirectory, outputAction);
             outputAction($"dotnet {arguments}");
-            return ProcessUtils.RunCommandAsync(
+            return await ProcessUtils.RunCommandAsync(
                 file: pathsProvider.GetDotnetPath(),
                 args: arguments,
                 workingDir: workingDir,

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -67,7 +67,7 @@ namespace GoogleCloudExtension.Deployment
             Debug.WriteLine($"Using tools from {externalTools}");
             Debug.WriteLine($"Setting working directory to {workingDir}");
             Directory.CreateDirectory(stageDirectory);
-            await GCloudWrapper.GenerateSourceContext(project.DirectoryPath, stageDirectory, outputAction);
+            await GCloudWrapper.GenerateSourceContext(project.DirectoryPath, stageDirectory);
             outputAction($"dotnet {arguments}");
             return await ProcessUtils.RunCommandAsync(
                 file: pathsProvider.GetDotnetPath(),

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/WindowsVmDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/WindowsVmDeployment.cs
@@ -121,7 +121,7 @@ namespace GoogleCloudExtension.Deployment
         /// This method stages the application into the <paramref name="stageDirectory"/> by invoking the WebPublish target
         /// present in all Web projects. It publishes to the staging directory by using the FileSystem method.
         /// </summary>
-        private static Task<bool> CreateAppBundleAsync(
+        private static async Task<bool> CreateAppBundleAsync(
             IParsedProject project,
             string stageDirectory,
             IToolsPathProvider toolsPathProvider,
@@ -136,7 +136,8 @@ namespace GoogleCloudExtension.Deployment
                 $@"/p:publishUrl=""{stageDirectory}""";
 
             outputAction($"msbuild.exe {arguments}");
-            return ProcessUtils.RunCommandAsync(toolsPathProvider.GetMsbuildPath(), arguments, (o, e) => outputAction(e.Line));
+            await GCloudWrapper.GenerateSourceContext(project.DirectoryPath, stageDirectory, outputAction);
+            return await ProcessUtils.RunCommandAsync(toolsPathProvider.GetMsbuildPath(), arguments, (o, e) => outputAction(e.Line));
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/WindowsVmDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/WindowsVmDeployment.cs
@@ -136,7 +136,7 @@ namespace GoogleCloudExtension.Deployment
                 $@"/p:publishUrl=""{stageDirectory}""";
 
             outputAction($"msbuild.exe {arguments}");
-            await GCloudWrapper.GenerateSourceContext(project.DirectoryPath, stageDirectory, outputAction);
+            await GCloudWrapper.GenerateSourceContext(project.DirectoryPath, stageDirectory);
             return await ProcessUtils.RunCommandAsync(toolsPathProvider.GetMsbuildPath(), arguments, (o, e) => outputAction(e.Line));
         }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -187,6 +187,24 @@ namespace GoogleCloudExtension.GCloud
                 cloudSdkVersion: cloudSdkVersion);
         }
 
+        /// <summary>
+        /// Generates the source context information for the repo stored in <paramref name="sourcePath"/> and stores it
+        /// in <paramref name="outputPath"/>. If the <paramref name="sourcePath"/> does not refer to a supported CVS (currently git) then
+        /// nothing will be done.
+        /// </summary>
+        /// <param name="sourcePath">The directory for which to generate the source contenxt.</param>
+        /// <param name="outputPath">Where to store the source context files.</param>
+        /// <returns>The task to be completed when the operation finishes.</returns>
+        public static async Task GenerateSourceContext(string sourcePath, string outputPath)
+        {
+            var result = await RunCommandAsync(
+                $"debug source gen-repo-info-files --output-directory=\"{outputPath}\" --source-directory=\"{sourcePath}\"");
+            if (!result)
+            {
+                Debug.WriteLine($"Could not find git repo at {sourcePath}");
+            }
+        }
+
         private static async Task<IList<string>> GetInstalledComponentsAsync()
         {
             Debug.WriteLine("Reading list of components.");

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -195,10 +195,14 @@ namespace GoogleCloudExtension.GCloud
         /// <param name="sourcePath">The directory for which to generate the source contenxt.</param>
         /// <param name="outputPath">Where to store the source context files.</param>
         /// <returns>The task to be completed when the operation finishes.</returns>
-        public static async Task GenerateSourceContext(string sourcePath, string outputPath)
+        public static async Task GenerateSourceContext(
+            string sourcePath,
+            string outputPath,
+            Action<string> outputAction)
         {
             var result = await RunCommandAsync(
-                $"debug source gen-repo-info-files --output-directory=\"{outputPath}\" --source-directory=\"{sourcePath}\"");
+                $"debug source gen-repo-info-file --output-directory=\"{outputPath}\" --source-directory=\"{sourcePath}\"",
+                outputAction: outputAction);
             if (!result)
             {
                 Debug.WriteLine($"Could not find git repo at {sourcePath}");

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -197,12 +197,11 @@ namespace GoogleCloudExtension.GCloud
         /// <returns>The task to be completed when the operation finishes.</returns>
         public static async Task GenerateSourceContext(
             string sourcePath,
-            string outputPath,
-            Action<string> outputAction)
+            string outputPath)
         {
             var result = await RunCommandAsync(
                 $"debug source gen-repo-info-file --output-directory=\"{outputPath}\" --source-directory=\"{sourcePath}\"",
-                outputAction: outputAction);
+                outputAction: x => Debug.WriteLine(x));
             if (!result)
             {
                 Debug.WriteLine($"Could not find git repo at {sourcePath}");


### PR DESCRIPTION
This PR adds a method to `GCloudWrapper` that wraps the `gcloud debug gen-repo-info-file` command and generates the `source-context.json` for the app. If the source code is not stored in a git repo then this will have no effect, the error message from executing the command will be silently ignored.

The `source-context.json` file will be dropped at the root of the Docker container for ASP.NET Core apps and at the root of the app publish directory for ASP.NET Core 4.x apps.

Fixes #425 