### PR TITLE
Remove all warnings, enable warnings as errors on appveyor

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
@@ -151,7 +151,7 @@ namespace GoogleCloudExtension.CloudExplorer
                     Children.Add(NoItemsPlaceholder);
                 }
             }
-            catch (CloudExplorerSourceException ex)
+            catch (CloudExplorerSourceException)
             {
                 Children.Clear();
                 Children.Add(ErrorPlaceholder);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/InstanceViewModel.cs
@@ -123,7 +123,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
 
                 EventsReporterWrapper.ReportEvent(ManageCloudSqlAuthorizedNetworkEvent.Create(CommandStatus.Failure));
             }
-            catch (TimeoutException ex)
+            catch (TimeoutException)
             {
                 IsError = true;
                 UserPromptUtils.ErrorPrompt(
@@ -132,7 +132,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
 
                 EventsReporterWrapper.ReportEvent(ManageCloudSqlAuthorizedNetworkEvent.Create(CommandStatus.Failure));
             }
-            catch (OperationCanceledException ex)
+            catch (OperationCanceledException)
             {
                 IsError = true;
                 UserPromptUtils.ErrorPrompt(

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -55,9 +55,17 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         public Service Service => _service;
 
-        public event EventHandler ItemChanged;
+        #region ICloudExplorerItemSource implementation
 
-        public object Item => GetItem();
+        event EventHandler ICloudExplorerItemSource.ItemChanged
+        {
+            add { }
+            remove { }
+        }
+
+        object ICloudExplorerItemSource.Item => GetItem();
+
+        #endregion
 
         public bool ShowOnlyFlexVersions
         {
@@ -304,7 +312,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         private void OnPropertiesWindowCommand()
         {
-            _owner.Context.ShowPropertiesWindow(Item);
+            _owner.Context.ShowPropertiesWindow(GetItem());
         }
 
         private async void OnOpenService()

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -61,9 +61,17 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         /// </summary>
         private bool CanDeleteVersion => !_isLastVersion && !HasTrafficAllocation;
 
-        public event EventHandler ItemChanged;
+        #region ICloudExplorerItemSource implementation
 
-        public object Item => new VersionItem(_version);
+        event EventHandler ICloudExplorerItemSource.ItemChanged
+        {
+            add { }
+            remove { }
+        }
+
+        object ICloudExplorerItemSource.Item => GetItem();
+
+        #endregion
 
         public VersionViewModel(
             GaeSourceRootViewModel owner,
@@ -139,7 +147,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 IsLoading = true;
                 Caption = String.Format(Resources.CloudExplorerGaeMigratingAllTrafficCaption, _version.Id);
 
-                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> {[_version.Id] = 1.0 } };
+                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> { [_version.Id] = 1.0 } };
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, _service.Id);
                 await _owner.DataSource.AwaitOperationAsync(operation);
                 _owner.InvalidateService(_service.Id);
@@ -187,7 +195,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         private void OnPropertiesWindowCommand()
         {
-            _owner.Context.ShowPropertiesWindow(Item);
+            _owner.Context.ShowPropertiesWindow(GetItem());
         }
 
         private void OnOpenVersion()
@@ -305,5 +313,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                     break;
             }
         }
+
+        private VersionItem GetItem() => new VersionItem(_version);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/ZoneViewModel.cs
@@ -33,9 +33,17 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
         private readonly GceSourceRootViewModel _owner;
         private readonly Zone _zone;
 
-        public event EventHandler ItemChanged;
+        #region ICloudExplorerItemSource implementation
 
-        public object Item => new ZoneItem(_zone);
+        event EventHandler ICloudExplorerItemSource.ItemChanged
+        {
+            add { }
+            remove { }
+        }
+
+        object ICloudExplorerItemSource.Item => GetItem();
+
+        #endregion
 
         internal ZoneViewModel(GceSourceRootViewModel owner, Zone zone, IEnumerable<GceInstanceViewModel> instances)
         {
@@ -60,7 +68,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         private void OnPropertiesCommand()
         {
-            _owner.Context.ShowPropertiesWindow(Item);
+            _owner.Context.ShowPropertiesWindow(GetItem());
         }
 
         private void OnNewInstanceCommand()
@@ -68,5 +76,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             var url = $"https://console.cloud.google.com/compute/instancesAdd?project={_owner.Context.CurrentProject.ProjectId}&zone={_zone.Name}";
             Process.Start(url);
         }
+
+        private object GetItem() => new ZoneItem(_zone);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/BucketViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/BucketViewModel.cs
@@ -40,7 +40,9 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
         private readonly Lazy<BucketItem> _item;
         private readonly ProtectedCommand _openOnCloudConsoleCommand;
 
-        public object Item
+        #region ICloudExplorerItemSource implmentation
+
+        object ICloudExplorerItemSource.Item
         {
             get
             {
@@ -48,7 +50,16 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
             }
         }
 
-        public event EventHandler ItemChanged;
+        /// <summary>
+        /// This event is never raised, as the item does not change.
+        /// </summary>
+        event EventHandler ICloudExplorerItemSource.ItemChanged
+        {
+            add { }
+            remove { }
+        }
+
+        #endregion
 
         public BucketViewModel(GcsSourceRootViewModel owner, Bucket bucket)
         {
@@ -70,7 +81,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
 
         private void OnPropertiesCommand()
         {
-            _owner.Context.ShowPropertiesWindow(Item);
+            _owner.Context.ShowPropertiesWindow(_item.Value);
         }
 
         private void OnOpenOnCloudConsoleCommand()

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/SubscriptionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/SubscriptionViewModel.cs
@@ -46,12 +46,20 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
         /// </summary>
         public PubsubDataSource DataSource => _owner.DataSource;
 
+        #region ICloudExplorerItemSource implementation.
+
         /// <summary>
         /// The item this tree node represents.
         /// </summary>
-        public object Item => _subscriptionItem;
+        object ICloudExplorerItemSource.Item => _subscriptionItem;
 
-        public event EventHandler ItemChanged;
+        event EventHandler ICloudExplorerItemSource.ItemChanged
+        {
+            add { }
+            remove { }
+        }
+
+        #endregion
 
         public SubscriptionViewModel(TopicViewModelBase owner, Subscription subscription)
         {
@@ -117,7 +125,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
         /// </summary>
         private void OnPropertiesWindowCommand()
         {
-            Context.ShowPropertiesWindow(Item);
+            Context.ShowPropertiesWindow(_subscriptionItem);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingDetailViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingDetailViewModel.cs
@@ -124,7 +124,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
                 SetValueAndRaise(ref _selectedTimeRange, value);
                 if (value != null)
                 {
-                    ErrorHandlerUtils.HandleExceptionsAsync(UpdateGroupAndEventAsync);
+                    ErrorHandlerUtils.HandleAsyncExceptions(UpdateGroupAndEventAsync);
                 }
             }
         }
@@ -157,7 +157,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
             OnGotoSourceCommand = new ProtectedCommand<StackFrame>(
                 (frame) => ShowTooltipUtils.ErrorFrameToSourceLine(GroupItem, frame));
             OnBackToOverViewCommand = new ProtectedCommand(() => ToolWindowCommandUtils.ShowToolWindow<ErrorReportingToolWindow>());
-            OnAutoReloadCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleExceptionsAsync(UpdateGroupAndEventAsync));
+            OnAutoReloadCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleAsyncExceptions(UpdateGroupAndEventAsync));
             _datasource = new Lazy<StackdriverErrorReportingDataSource>(CreateDataSource);
             CredentialsStore.Default.Reset += (sender, e) => OnCurrentProjectChanged();
             CredentialsStore.Default.CurrentProjectIdChanged += (sender, e) => OnCurrentProjectChanged();
@@ -200,7 +200,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
             GroupItem = errorGroupItem;
             if (groupSelectedTimeRangeItem.GroupTimeRange == SelectedTimeRangeItem?.GroupTimeRange)
             {
-                ErrorHandlerUtils.HandleExceptionsAsync(UpdateEventAsync);
+                ErrorHandlerUtils.HandleAsyncExceptions(UpdateEventAsync);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingViewModel.cs
@@ -172,7 +172,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
                 return;
             }
 
-            ErrorHandlerUtils.HandleExceptionsAsync(LoadAsync);
+            ErrorHandlerUtils.HandleAsyncExceptions(LoadAsync);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         {
             _groupStatsCollection.Clear();
             _nextPageToken = null;
-            ErrorHandlerUtils.HandleExceptionsAsync(LoadAsync);
+            ErrorHandlerUtils.HandleAsyncExceptions(LoadAsync);
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
@@ -308,13 +308,13 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             LogItemCollection = new ListCollectionView(_logs);
             LogItemCollection.GroupDescriptions.Add(new PropertyGroupDescription(nameof(LogItem.Date)));
             CancelRequestCommand = new ProtectedCommand(CancelRequest);
-            SimpleTextSearchCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync));
+            SimpleTextSearchCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync));
             FilterSwitchCommand = new ProtectedCommand(SwapFilter);
-            SubmitAdvancedFilterCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync));
+            SubmitAdvancedFilterCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync));
             AdvancedFilterHelpCommand = new ProtectedCommand(ShowAdvancedFilterHelp);
             DateTimePickerModel = new DateTimePickerViewModel(
                 TimeZoneInfo.Local, DateTime.UtcNow, isDescendingOrder: true);
-            DateTimePickerModel.DateTimeFilterChange += (sender, e) => ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+            DateTimePickerModel.DateTimeFilterChange += (sender, e) => ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
             PropertyChanged += OnPropertyChanged;
             ResourceTypeSelector = new ResourceTypeMenuViewModel(_dataSource);
             ResourceTypeSelector.PropertyChanged += OnPropertyChanged;
@@ -334,7 +334,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 return;
             }
 
-            ErrorHandlerUtils.HandleExceptionsAsync(() => RequestLogFiltersWrapperAsync(PopulateResourceTypes));
+            ErrorHandlerUtils.HandleAsyncExceptions(() => RequestLogFiltersWrapperAsync(PopulateResourceTypes));
         }
 
         /// <summary>
@@ -348,14 +348,14 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 return;
             }
 
-            ErrorHandlerUtils.HandleExceptionsAsync(() => LogLoaddingWrapperAsync(async (cancelToken) => await LoadLogsAsync(cancelToken)));
+            ErrorHandlerUtils.HandleAsyncExceptions(() => LogLoaddingWrapperAsync(async (cancelToken) => await LoadLogsAsync(cancelToken)));
         }
 
         /// <summary>
         /// Send an advanced filter to Logs Viewer and display the results.
         /// </summary>
         /// <param name="advancedSearchText">The advance filter in text format.</param>
-        public void FilterLog(string advancedSearchText)
+        public async void FilterLog(string advancedSearchText)
         {
             IsAutoReloadChecked = false;
             if (String.IsNullOrWhiteSpace(advancedSearchText))
@@ -372,7 +372,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             }
 
             AdvancedFilterText = filter.ToString();
-            ReloadAsync();
+            await ReloadAsync();
         }
 
         /// <summary>
@@ -423,14 +423,14 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             // Show advanced filter.
             AdvancedFilterText = newFilter.ToString();
             ShowAdvancedFilter = true;
-            ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+            ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
         }
 
         private void OnRefreshCommand()
         {
             DateTimePickerModel.IsDescendingOrder = true;
             DateTimePickerModel.DateTimeUtc = DateTime.UtcNow;
-            ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+            ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
         }
 
         /// <summary>
@@ -659,7 +659,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             ShowAdvancedFilter = !ShowAdvancedFilter;
             AdvancedFilterText = ShowAdvancedFilter ? ComposeSimpleFilters() : null;
             SimpleSearchText = null;
-            ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+            ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
         }
 
         /// <summary>
@@ -751,15 +751,15 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 case nameof(LogIdsList.SelectedLogId):
                     if (LogIdList != null)
                     {
-                        ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+                        ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
                     }
                     break;
                 case nameof(ResourceTypeMenuViewModel.SelectedMenuItem):
                     LogIdList = null;
-                    ErrorHandlerUtils.HandleExceptionsAsync(() => RequestLogFiltersWrapperAsync(PopulateLogIds));
+                    ErrorHandlerUtils.HandleAsyncExceptions(() => RequestLogFiltersWrapperAsync(PopulateLogIds));
                     break;
                 case nameof(SelectedLogSeverity):
-                    ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+                    ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
                     break;
                 default:
                     break;
@@ -840,12 +840,12 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             // If it is in advanced filter, just do reload. 
             if (ShowAdvancedFilter)
             {
-                ErrorHandlerUtils.HandleExceptionsAsync(ReloadAsync);
+                ErrorHandlerUtils.HandleAsyncExceptions(ReloadAsync);
                 return;
             }
 
             // TODO: auto scroll to last item in ascending order.
-            ErrorHandlerUtils.HandleExceptionsAsync(AppendNewerLogsAsync);
+            ErrorHandlerUtils.HandleAsyncExceptions(AppendNewerLogsAsync);
         }
 
         private async Task AppendNewerLogsAsync()

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/MenuItemViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/MenuItemViewModel.cs
@@ -101,12 +101,12 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// <summary>
         /// Inherited classes implement this to perform delay loading of sub menu items. 
         /// </summary>
-        protected virtual async Task LoadSubMenu() 
-        {   
-            return;
+        protected virtual Task LoadSubMenu() 
+        {
+            return Task.FromResult(0);
         }
 
-        private async Task AddItems()
+        private async void AddItems()
         {
             if (IsSubmenuPopulated || Loading)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/ErrorHandlerUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/ErrorHandlerUtils.cs
@@ -76,7 +76,7 @@ namespace GoogleCloudExtension.Utils
         /// error dialog to the user. If the exception is critical, as determiend by <seealso cref="ErrorHandler.IsCriticalException(Exception)"/>
         /// then it is re-thrown as this could be that the process is not in a good state to continue executing.
         /// </summary>
-        public static async Task HandleExceptionsAsync(Func<Task> task)
+        public static async void HandleAsyncExceptions(Func<Task> task)
         {
             try
             {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ build_script:
   - bash -c ./tools/ensure_strings_extracted.sh
   - bash -c ./tools/ensure_no_unused_strings.sh
   - nuget restore .\GoogleCloudExtension
-  - msbuild .\GoogleCloudExtension\GoogleCloudExtension.sln /p:Configuration=Debug /p:DeployExtension=false
-  - msbuild .\GoogleCloudExtension\GoogleCloudExtension.sln /p:Configuration=Release /p:DeployExtension=false
+  - msbuild .\GoogleCloudExtension\GoogleCloudExtension.sln /p:Configuration=Debug /p:DeployExtension=False /p:TreatWarningsAsErrors=True
+  - msbuild .\GoogleCloudExtension\GoogleCloudExtension.sln /p:Configuration=Release /p:DeployExtension=False /p:TreatWarningsAsErrors=True
 
 # Defines the artifacts to be saved.
 artifacts:


### PR DESCRIPTION
This PR enables the `TreatWarningsAsErrors` setting to fail the build on compiler warnings. The PR also contain the necessary changes to eliminate the existing warnings from the code base.

The decision to only enable this setting on the CI server is to allow low friction local development. You can always duplicate the setting locally before sending the PR or let the CI system build the code when submitting the PR.