### PR TITLE
Rename single files feature.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GcsDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GcsDataSource.cs
@@ -165,13 +165,13 @@ namespace GoogleCloudExtension.DataSources
         }
 
         /// <summary>
-        /// Renames a file in a given <paramref name="bucket"/>. Renaming consists on copying the file
+        /// Renames a file in a given <paramref name="bucket"/>. Renaming consists of copying the file
         /// to the destination and then deleting the source, in this order. This will prevent loss of data.
         /// </summary>
         /// <param name="bucket">The bucket where the files reside.</param>
         /// <param name="sourceName">The source file to rename.</param>
         /// <param name="destName">The name to rename to.</param>
-        /// <returns></returns>
+        /// <returns>A <seealso cref="Task"/> instance that will be completed once the rename operation is finished.</returns>
         public async Task RenameFileAsync(string bucket, string sourceName, string destName)
         {
             try
@@ -191,7 +191,7 @@ namespace GoogleCloudExtension.DataSources
         /// <param name="bucket">The bucket that owns the files.</param>
         /// <param name="sourceName">The source file name to copy.</param>
         /// <param name="destName">The new file name.</param>
-        /// <returns></returns>
+        /// <returns>A <seealso cref="Task"/> instance that will be completed once the copy operation is completed.</returns>
         public async Task CopyFileAsync(string bucket, string sourceName, string destName)
         {
             try
@@ -210,7 +210,7 @@ namespace GoogleCloudExtension.DataSources
         /// </summary>
         /// <param name="bucket">The bucket that owns the files.</param>
         /// <param name="name">The name of the file.</param>
-        /// <returns></returns>
+        /// <returns>A <seealso cref="Task"/> instance that will be completed once the delete operation is completed.</returns>
         public async Task DeleteFileAsync(string bucket, string name)
         {
             try

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GcsDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GcsDataSource.cs
@@ -165,6 +165,66 @@ namespace GoogleCloudExtension.DataSources
         }
 
         /// <summary>
+        /// Renames a file in a given <paramref name="bucket"/>. Renaming consists on copying the file
+        /// to the destination and then deleting the source, in this order. This will prevent loss of data.
+        /// </summary>
+        /// <param name="bucket">The bucket where the files reside.</param>
+        /// <param name="sourceName">The source file to rename.</param>
+        /// <param name="destName">The name to rename to.</param>
+        /// <returns></returns>
+        public async Task RenameFileAsync(string bucket, string sourceName, string destName)
+        {
+            try
+            {
+                await CopyFileAsync(bucket, sourceName, destName);
+                await DeleteFileAsync(bucket, sourceName);
+            }
+            catch (GoogleApiException ex)
+            {
+                throw new DataSourceException(ex.Message, ex);
+            }
+        }
+
+        /// <summary>
+        /// Copies a file within a bucket.
+        /// </summary>
+        /// <param name="bucket">The bucket that owns the files.</param>
+        /// <param name="sourceName">The source file name to copy.</param>
+        /// <param name="destName">The new file name.</param>
+        /// <returns></returns>
+        public async Task CopyFileAsync(string bucket, string sourceName, string destName)
+        {
+            try
+            {
+                var request = Service.Objects.Copy(null, bucket, sourceName, bucket, destName);
+                await request.ExecuteAsync();
+            }
+            catch (GoogleApiException ex)
+            {
+                throw new DataSourceException(ex.Message, ex);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a file in a bucket.
+        /// </summary>
+        /// <param name="bucket">The bucket that owns the files.</param>
+        /// <param name="name">The name of the file.</param>
+        /// <returns></returns>
+        public async Task DeleteFileAsync(string bucket, string name)
+        {
+            try
+            {
+                var request = Service.Objects.Delete(bucket, name);
+                await request.ExecuteAsync();
+            }
+            catch (GoogleApiException ex)
+            {
+                throw new DataSourceException(ex.Message, ex);
+            }
+        }
+
+        /// <summary>
         /// Starts a file upload operation reporting the status and progress to the given <paramref name="operation"/>.
         /// </summary>
         /// <param name="sourcePath">The path to the file to open, should be a full path.</param>

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsBrowserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsBrowserViewModel.cs
@@ -210,8 +210,7 @@ namespace GoogleCloudExtension.GcsFileBrowser
 
             if (SelectedItems != null && SelectedItems.Count == 1)
             {
-                var row = (GcsRow)SelectedItem;
-                if (row.IsFile)
+                if (SelectedItem.IsFile)
                 {
                     menuItems.Add(new MenuItem
                     {
@@ -226,8 +225,7 @@ namespace GoogleCloudExtension.GcsFileBrowser
 
         private async void OnRenameFileCommand()
         {
-            var row = (GcsRow)SelectedItem;
-            var choosenName = NamePromptWindow.PromptUser(row.LeafName);
+            var choosenName = NamePromptWindow.PromptUser(SelectedItem.LeafName);
             if (choosenName == null)
             {
                 return;
@@ -238,11 +236,11 @@ namespace GoogleCloudExtension.GcsFileBrowser
                 IsLoading = true;
 
                 var newName = GcsPathUtils.Combine(CurrentState.CurrentPath, choosenName);
-                Debug.WriteLine($"Renaming {row.BlobName} to {newName}");
+                Debug.WriteLine($"Renaming {SelectedItem.BlobName} to {newName}");
                 await ProgressDialogWindow.PromptUser(
                     _dataSource.RenameFileAsync(
                         bucket: Bucket.Name,
-                        sourceName: row.BlobName,
+                        sourceName: SelectedItem.BlobName,
                         destName: newName),
                     new ProgressDialogWindow.Options
                     {
@@ -253,11 +251,12 @@ namespace GoogleCloudExtension.GcsFileBrowser
 
                 UpdateCurrentState();
             }
-            catch (DataSourceException)
+            catch (DataSourceException ex)
             {
                 UserPromptUtils.ErrorPrompt(
-                    message: string.Format(Resources.GcsFileBrowserRenameFailedMessage, row.LeafName),
-                    title: Resources.UiErrorCaption);
+                    message: string.Format(Resources.GcsFileBrowserRenameFailedMessage, SelectedItem.LeafName),
+                    title: Resources.UiErrorCaption,
+                    errorDetails: ex.Message);
             }
             finally
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsBrowserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsBrowserViewModel.cs
@@ -18,6 +18,7 @@ using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.GcsFileProgressDialog;
 using GoogleCloudExtension.GcsUtils;
 using GoogleCloudExtension.NamePrompt;
+using GoogleCloudExtension.ProgressDialog;
 using GoogleCloudExtension.Utils;
 using System;
 using System.Collections.Generic;
@@ -226,7 +227,7 @@ namespace GoogleCloudExtension.GcsFileBrowser
         private async void OnRenameFileCommand()
         {
             var row = (GcsRow)SelectedItem;
-            var choosenName = NamePromptWindow.PromptUser();
+            var choosenName = NamePromptWindow.PromptUser(row.LeafName);
             if (choosenName == null)
             {
                 return;
@@ -238,10 +239,17 @@ namespace GoogleCloudExtension.GcsFileBrowser
 
                 var newName = GcsPathUtils.Combine(CurrentState.CurrentPath, choosenName);
                 Debug.WriteLine($"Renaming {row.BlobName} to {newName}");
-                await _dataSource.RenameFileAsync(
-                    bucket: Bucket.Name,
-                    sourceName: row.BlobName,
-                    destName: newName);
+                await ProgressDialogWindow.PromptUser(
+                    _dataSource.RenameFileAsync(
+                        bucket: Bucket.Name,
+                        sourceName: row.BlobName,
+                        destName: newName),
+                    new ProgressDialogWindow.Options
+                    {
+                        Message = "Renaming file",
+                        Title = Resources.UiDefaultPromptTitle,
+                        IsCancellable = false
+                    });
 
                 UpdateCurrentState();
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsBrowserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsBrowserViewModel.cs
@@ -215,7 +215,7 @@ namespace GoogleCloudExtension.GcsFileBrowser
                 {
                     menuItems.Add(new MenuItem
                     {
-                        Header = "Rename...",
+                        Header = Resources.GcsFileBrowserRenameFileHeader,
                         Command = new ProtectedCommand(OnRenameFileCommand)
                     });
                 }
@@ -246,7 +246,7 @@ namespace GoogleCloudExtension.GcsFileBrowser
                         destName: newName),
                     new ProgressDialogWindow.Options
                     {
-                        Message = "Renaming file",
+                        Message = Resources.GcsFileBrowserRenamingProgressMessage,
                         Title = Resources.UiDefaultPromptTitle,
                         IsCancellable = false
                     });
@@ -256,7 +256,7 @@ namespace GoogleCloudExtension.GcsFileBrowser
             catch (DataSourceException)
             {
                 UserPromptUtils.ErrorPrompt(
-                    message: $"Failed to rename file {row.LeafName}",
+                    message: string.Format(Resources.GcsFileBrowserRenameFailedMessage, row.LeafName),
                     title: Resources.UiErrorCaption);
             }
             finally

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml
@@ -27,6 +27,7 @@
                                       Command="{Binding OkCommand}"
                                       IsDefault="True" />
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCancelButtonCaption}"
+                                      Command="{Binding CancelCommand}"
                                       IsCancel="True" />
         </theming:CommonDialogWindowBaseContent.Buttons>
         

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml.cs
@@ -28,10 +28,7 @@ namespace GoogleCloudExtension.NamePrompt
             InitializeComponent();
 
             _nameBox.Focus();
-        }
 
-        public void SelectAll()
-        {
             Loaded += OnLoaded;
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace GoogleCloudExtension.NamePrompt
@@ -26,6 +29,22 @@ namespace GoogleCloudExtension.NamePrompt
             InitializeComponent();
 
             _nameBox.Focus();
+        }
+
+        public void SelectAll()
+        {
+            Loaded += OnLoaded;
+        }
+
+        /// <summary>
+        /// This method selects all the current text stored in the textbox. The Task.Yield method is
+        /// used to ensure that the code runs on the **next** tick of the UI. This way the SelectAll() call
+        /// will happen **after** the bindings are evaluated.
+        /// </summary>
+        private async void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            await Task.Yield();
+            _nameBox.SelectAll();
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptContent.xaml.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptViewModel.cs
@@ -41,10 +41,11 @@ namespace GoogleCloudExtension.NamePrompt
         /// </summary>
         public ICommand OkCommand { get; }
 
-        public NamePromptViewModel(NamePromptWindow owner)
+        public NamePromptViewModel(NamePromptWindow owner, string initialName)
         {
             _owner = owner;
 
+            Name = initialName;
             OkCommand = new ProtectedCommand(OnOkCommand);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptViewModel.cs
@@ -41,12 +41,23 @@ namespace GoogleCloudExtension.NamePrompt
         /// </summary>
         public ICommand OkCommand { get; }
 
-        public NamePromptViewModel(NamePromptWindow owner, string initialName)
+        /// <summary>
+        /// The command for the cancel button.
+        /// </summary>
+        public ICommand CancelCommand { get; }
+
+        public NamePromptViewModel(NamePromptWindow owner)
         {
             _owner = owner;
 
-            Name = initialName;
             OkCommand = new ProtectedCommand(OnOkCommand);
+            CancelCommand = new ProtectedCommand(OnCancelCommand);
+        }
+
+        private void OnCancelCommand()
+        {
+            Name = null;
+            _owner.Close();
         }
 
         private void OnOkCommand()

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptViewModel.cs
@@ -46,9 +46,11 @@ namespace GoogleCloudExtension.NamePrompt
         /// </summary>
         public ICommand CancelCommand { get; }
 
-        public NamePromptViewModel(NamePromptWindow owner)
+        public NamePromptViewModel(NamePromptWindow owner, string initialName)
         {
             _owner = owner;
+
+            Name = initialName;
 
             OkCommand = new ProtectedCommand(OnOkCommand);
             CancelCommand = new ProtectedCommand(OnCancelCommand);

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptWindow.cs
@@ -23,9 +23,9 @@ namespace GoogleCloudExtension.NamePrompt
     {
         private NamePromptViewModel ViewModel { get; }
 
-        private NamePromptWindow() : base(GoogleCloudExtension.Resources.NamePromptCaption)
+        private NamePromptWindow(string initialName) : base(GoogleCloudExtension.Resources.NamePromptCaption)
         {
-            ViewModel = new NamePromptViewModel(this);
+            ViewModel = new NamePromptViewModel(this, initialName);
             Content = new NamePromptContent
             {
                 DataContext = ViewModel
@@ -36,9 +36,9 @@ namespace GoogleCloudExtension.NamePrompt
         /// Prompts the user for a name.
         /// </summary>
         /// <returns>The name chosen by the user.</returns>
-        public static string PromptUser()
+        public static string PromptUser(string initialName = "")
         {
-            var dialog = new NamePromptWindow();
+            var dialog = new NamePromptWindow(initialName);
             dialog.ShowModal();
             return dialog.ViewModel.Name;
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptWindow.cs
@@ -26,10 +26,16 @@ namespace GoogleCloudExtension.NamePrompt
         private NamePromptWindow(string initialName) : base(GoogleCloudExtension.Resources.NamePromptCaption)
         {
             ViewModel = new NamePromptViewModel(this, initialName);
-            Content = new NamePromptContent
+            var namePromptContent = new NamePromptContent
             {
                 DataContext = ViewModel
             };
+            Content = namePromptContent;
+
+            if (!string.IsNullOrEmpty(initialName))
+            {
+                namePromptContent.SelectAll();
+            }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/NamePrompt/NamePromptWindow.cs
@@ -26,16 +26,10 @@ namespace GoogleCloudExtension.NamePrompt
         private NamePromptWindow(string initialName) : base(GoogleCloudExtension.Resources.NamePromptCaption)
         {
             ViewModel = new NamePromptViewModel(this, initialName);
-            var namePromptContent = new NamePromptContent
+            Content = new NamePromptContent()
             {
                 DataContext = ViewModel
             };
-            Content = namePromptContent;
-
-            if (!string.IsNullOrEmpty(initialName))
-            {
-                namePromptContent.SelectAll();
-            }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -2802,6 +2802,33 @@ namespace GoogleCloudExtension
         public static string GcsFileBrowserNewFolderHeader {
             get {
                 return ResourceManager.GetString("GcsFileBrowserNewFolderHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to rename file {0}..
+        /// </summary>
+        public static string GcsFileBrowserRenameFailedMessage {
+            get {
+                return ResourceManager.GetString("GcsFileBrowserRenameFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename file....
+        /// </summary>
+        public static string GcsFileBrowserRenameFileHeader {
+            get {
+                return ResourceManager.GetString("GcsFileBrowserRenameFileHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Renaming file..
+        /// </summary>
+        public static string GcsFileBrowserRenamingProgressMessage {
+            get {
+                return ResourceManager.GetString("GcsFileBrowserRenamingProgressMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2325,7 +2325,7 @@
   </data>
   <data name="GcsFileBrowserRenameFailedMessage" xml:space="preserve">
     <value>Failed to rename file {0}.</value>
-    <comment>Message shown when the rename operation fails.</comment>
+    <comment>Message shown when the rename operation fails. {0} is the name of the file.</comment>
   </data>
   <data name="GcsFileBrowserRenameFileHeader" xml:space="preserve">
     <value>Rename file...</value>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2323,4 +2323,16 @@
     <value>Operation starting</value>
     <comment>Message shown when the operation is started.</comment>
   </data>
+  <data name="GcsFileBrowserRenameFailedMessage" xml:space="preserve">
+    <value>Failed to rename file {0}.</value>
+    <comment>Message shown when the rename operation fails.</comment>
+  </data>
+  <data name="GcsFileBrowserRenameFileHeader" xml:space="preserve">
+    <value>Rename file...</value>
+    <comment>Header for the Rename File menu entry.</comment>
+  </data>
+  <data name="GcsFileBrowserRenamingProgressMessage" xml:space="preserve">
+    <value>Renaming file.</value>
+    <comment>Message shown while the rename operation is in flight.</comment>
+  </data>
 </root>


### PR DESCRIPTION
This PR adds the rename single files feature to the extension. The user can righ-click on a file and rename it. This is translated into a copy operation and a delete operation by the underlying data source.

This extension will show the `Task` progress dialog while the operation is flight.

The implementation for renaming a directory, which will consist on renaming each file inside of the directory recursively, will be coming next.