### PR TITLE
Use the font to show up/down chevrons.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindowContent.xaml
@@ -49,12 +49,25 @@
                          IsIndeterminate="{Binding OperationsPending}"
                          Style="{StaticResource CommonProgressBarStyle}"/>
 
+
             <TextBlock Grid.Row="2">
                 <Hyperlink Command="{Binding ExpandCollapseDetailsCommand}"
                            Style="{StaticResource CommonHyperlinkStyle}">
                     <TextBlock Text="{Binding ExpandCollapseMessage}"/>
+                    
+                    <!-- Show the arrow down to expand the details. -->
+                    <TextBlock Text="&#xE0A0;"
+                               FontFamily="Segoe UI Symbol"
+                               Visibility="{Binding DetailsExpanded, Converter={utils:VisibilityConverter}}" />
+                    
+                    <!-- Show the arrow up to collapse the details. -->
+                    <TextBlock Text="&#xE0A1;"
+                               FontFamily="Segoe UI Symbol"
+                               Visibility="{Binding DetailsExpanded, Converter={utils:VisibilityConverter IsNegated=True}}" />
                 </Hyperlink>
             </TextBlock>
+
+           
 
             <!-- Details for the copy operation. -->
             <StackPanel Grid.Row="3"


### PR DESCRIPTION
This commit uses the "Segoe UI Symbol" font to add an up/down chevron to the show/collapse details hyperlink in the progress dialog.

The collapsed dialogs now looks like this:
<img width="416" alt="screen shot 2017-06-01 at 1 32 56 pm" src="https://cloud.githubusercontent.com/assets/9807532/26680054/ac5b59fe-46cf-11e7-838c-3fb44838816e.png">

While the expanded dialog will now look like this:
<img width="417" alt="screen shot 2017-06-01 at 1 33 03 pm" src="https://cloud.githubusercontent.com/assets/9807532/26680060/b5c20b32-46cf-11e7-9a0b-00d62888b2e4.png">

Using the font has the advantage that the symbol aligns with the text naturally, and participates on every behavior in the hyperlink, including changing color and underline.

Fixes #648 