### PR TITLE
Reverting out to ref.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/Model.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/Model.cs
@@ -33,7 +33,7 @@ namespace GoogleCloudExtension.Utils
         /// <param name="storage">Typically a ref to a field where the value is stored.</param>
         /// <param name="value">The new value.</param>
         /// <param name="propertyName">The name of the property that is changing, do not specify let the compiler determine it.</param>
-        protected void SetValueAndRaise<T>(out T storage, T value, [CallerMemberName] string propertyName = "")
+        protected void SetValueAndRaise<T>(ref T storage, T value, [CallerMemberName] string propertyName = "")
         {
             storage = value;
             RaisePropertyChanged(propertyName);

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/PlaceholderMessage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/PlaceholderMessage.cs
@@ -21,7 +21,7 @@ namespace GoogleCloudExtension.Utils
         public string Message
         {
             get { return _message; }
-            set { SetValueAndRaise(out _message, value); }
+            set { SetValueAndRaise(ref _message, value); }
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/AddTrafficSplit/AddTrafficSplitViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AddTrafficSplit/AddTrafficSplitViewModel.cs
@@ -35,7 +35,7 @@ namespace GoogleCloudExtension.AddTrafficSplit
         public string SelectedVersion
         {
             get { return _selectedVersion; }
-            set { SetValueAndRaise(out _selectedVersion, value); }
+            set { SetValueAndRaise(ref _selectedVersion, value); }
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace GoogleCloudExtension.AddTrafficSplit
         public string Allocation
         {
             get { return _allocation; }
-            set { SetValueAndRaise(out _allocation, value); }
+            set { SetValueAndRaise(ref _allocation, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddWindowsCredentialViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AddWindowsCredential/AddWindowsCredentialViewModel.cs
@@ -45,7 +45,7 @@ namespace GoogleCloudExtension.AddWindowsCredential
             get { return _userName; }
             set
             {
-                SetValueAndRaise(out _userName, value);
+                SetValueAndRaise(ref _userName, value);
                 RaisePropertyChanged(nameof(HasUserName));
             }
         }
@@ -58,7 +58,7 @@ namespace GoogleCloudExtension.AddWindowsCredential
             get { return _password; }
             set
             {
-                SetValueAndRaise(out _password, value);
+                SetValueAndRaise(ref _password, value);
                 RaisePropertyChanged(nameof(HasPassword));
             }
         }
@@ -71,7 +71,7 @@ namespace GoogleCloudExtension.AddWindowsCredential
             get { return _generatePassword; }
             set
             {
-                SetValueAndRaise(out _generatePassword, value);
+                SetValueAndRaise(ref _generatePassword, value);
             }
         }
 
@@ -83,7 +83,7 @@ namespace GoogleCloudExtension.AddWindowsCredential
             get { return _manualPassword; }
             set
             {
-                SetValueAndRaise(out _manualPassword, value);
+                SetValueAndRaise(ref _manualPassword, value);
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworkModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworkModel.cs
@@ -57,7 +57,7 @@ namespace GoogleCloudExtension.AuthorizedNetworkManagement
             get { return _toBeDeleted; }
             set
             {
-                SetValueAndRaise(out _toBeDeleted, value);
+                SetValueAndRaise(ref _toBeDeleted, value);
                 RaisePropertyChanged(nameof(NotDeleted));
                 RaisePropertyChanged(nameof(NewOrUpdated));
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AuthorizedNetworkManagement/AuthorizedNetworksViewModel.cs
@@ -72,7 +72,7 @@ namespace GoogleCloudExtension.AuthorizedNetworkManagement
         public string NetworkName
         {
             get { return _networkName; }
-            set { SetValueAndRaise(out _networkName, value); }
+            set { SetValueAndRaise(ref _networkName, value); }
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace GoogleCloudExtension.AuthorizedNetworkManagement
         public string NetworkValue
         {
             get { return _networkValue; }
-            set { SetValueAndRaise(out _networkValue, value); }
+            set { SetValueAndRaise(ref _networkValue, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/ButtonDefinition.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/ButtonDefinition.cs
@@ -35,7 +35,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public string ToolTip
         {
             get { return _toolTip; }
-            set { SetValueAndRaise(out _toolTip, value); }
+            set { SetValueAndRaise(ref _toolTip, value); }
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public ImageSource Icon
         {
             get { return _icon; }
-            set { SetValueAndRaise(out _icon, value); }
+            set { SetValueAndRaise(ref _icon, value); }
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public ICommand Command
         {
             get { return _command; }
-            set { SetValueAndRaise(out _command, value); }
+            set { SetValueAndRaise(ref _command, value); }
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public bool IsChecked
         {
             get { return _isChecked; }
-            set { SetValueAndRaise(out _isChecked, value); }
+            set { SetValueAndRaise(ref _isChecked, value); }
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public bool IsEnabled
         {
             get { return _isEnabled; }
-            set { SetValueAndRaise(out _isEnabled, value); }
+            set { SetValueAndRaise(ref _isEnabled, value); }
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.CloudExplorer
             get { return _isBusy; }
             private set
             {
-                SetValueAndRaise(out _isBusy, value);
+                SetValueAndRaise(ref _isBusy, value);
                 RaisePropertyChanged(nameof(IsReady));
                 RaisePropertyChanged(nameof(IsEmptyState));
             }
@@ -98,7 +98,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public AsyncPropertyValue<string> ProfilePictureAsync
         {
             get { return _profilePictureAsync; }
-            private set { SetValueAndRaise(out _profilePictureAsync, value); }
+            private set { SetValueAndRaise(ref _profilePictureAsync, value); }
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public AsyncPropertyValue<string> ProfileNameAsync
         {
             get { return _profileNameAsync; }
-            private set { SetValueAndRaise(out _profileNameAsync, value); }
+            private set { SetValueAndRaise(ref _profileNameAsync, value); }
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace GoogleCloudExtension.CloudExplorer
             get { return _currentProject; }
             set
             {
-                SetValueAndRaise(out _currentProject, value);
+                SetValueAndRaise(ref _currentProject, value);
                 if (value == null || value is Project)
                 {
                     var project = (Project)value;
@@ -158,19 +158,19 @@ namespace GoogleCloudExtension.CloudExplorer
         public string EmptyStateMessage
         {
             get { return _emptyStateMessage; }
-            set { SetValueAndRaise(out _emptyStateMessage, value); }
+            set { SetValueAndRaise(ref _emptyStateMessage, value); }
         }
 
         public string EmptyStateButtonCaption
         {
             get { return _emptyStateButtonCaption; }
-            set { SetValueAndRaise(out _emptyStateButtonCaption, value); }
+            set { SetValueAndRaise(ref _emptyStateButtonCaption, value); }
         }
 
         public ICommand EmptyStateCommand
         {
             get { return _emptyStateCommand; }
-            set { SetValueAndRaise(out _emptyStateCommand, value); }
+            set { SetValueAndRaise(ref _emptyStateCommand, value); }
         }
 
         #region ICloudSourceContext implementation.

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/TreeHierarchy.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/TreeHierarchy.cs
@@ -38,7 +38,7 @@ namespace GoogleCloudExtension.CloudExplorer
             {
                 if (value != _isExpanded)
                 {
-                    SetValueAndRaise(out _isExpanded, value);
+                    SetValueAndRaise(ref _isExpanded, value);
                     OnIsExpandedChanged(value);
                 }
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/TreeNode.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/TreeNode.cs
@@ -55,7 +55,7 @@ namespace GoogleCloudExtension.CloudExplorer
             get { return _isLoading; }
             set
             {
-                SetValueAndRaise(out _isLoading, value);
+                SetValueAndRaise(ref _isLoading, value);
                 RaisePropertyChanged(nameof(IconIsVisible));
             }
         }
@@ -68,7 +68,7 @@ namespace GoogleCloudExtension.CloudExplorer
             get { return _isError; }
             set
             {
-                SetValueAndRaise(out _isError, value);
+                SetValueAndRaise(ref _isError, value);
                 RaisePropertyChanged(nameof(IconIsVisible));
             }
         }
@@ -81,7 +81,7 @@ namespace GoogleCloudExtension.CloudExplorer
             get { return _isWarning; }
             set
             {
-                SetValueAndRaise(out _isWarning, value);
+                SetValueAndRaise(ref _isWarning, value);
                 RaisePropertyChanged(nameof(IconIsVisible));
             }
         }
@@ -97,7 +97,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public ImageSource Icon
         {
             get { return _icon; }
-            set { SetValueAndRaise(out _icon, value); }
+            set { SetValueAndRaise(ref _icon, value); }
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public string Caption
         {
             get { return _caption; }
-            set { SetValueAndRaise(out _caption, value); }
+            set { SetValueAndRaise(ref _caption, value); }
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace GoogleCloudExtension.CloudExplorer
         public ContextMenu ContextMenu
         {
             get { return _contextMenu; }
-            set { SetValueAndRaise(out _contextMenu, value); }
+            set { SetValueAndRaise(ref _contextMenu, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/FirewallManagement/PortModel.cs
@@ -42,7 +42,7 @@ namespace GoogleCloudExtension.FirewallManagement
         public bool IsEnabled
         {
             get { return _isEnabled; }
-            set { SetValueAndRaise(out _isEnabled, value); }
+            set { SetValueAndRaise(ref _isEnabled, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/ManageAccountsViewModel.cs
@@ -34,13 +34,13 @@ namespace GoogleCloudExtension.ManageAccounts
         public IEnumerable<UserAccountViewModel> UserAccountsList
         {
             get { return _userAccountsList; }
-            set { SetValueAndRaise(out _userAccountsList, value); }
+            set { SetValueAndRaise(ref _userAccountsList, value); }
         }
 
         public string CurrentAccountName
         {
             get { return _currentAccountName; }
-            set { SetValueAndRaise(out _currentAccountName, value); }
+            set { SetValueAndRaise(ref _currentAccountName, value); }
         }
 
         public UserAccountViewModel CurrentUserAccount
@@ -48,7 +48,7 @@ namespace GoogleCloudExtension.ManageAccounts
             get { return _currentUserAccount; }
             set
             {
-                SetValueAndRaise(out _currentUserAccount, value);
+                SetValueAndRaise(ref _currentUserAccount, value);
 
                 if (CredentialsStore.Default.CurrentAccount == null)
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
@@ -68,7 +68,7 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
             get { return _selectedCredentials; }
             set
             {
-                SetValueAndRaise(out _selectedCredentials, value);
+                SetValueAndRaise(ref _selectedCredentials, value);
                 UpdateCommands();
             }
         }
@@ -79,7 +79,7 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
         public IEnumerable<WindowsInstanceCredentials> CredentialsList
         {
             get { return _credentials; }
-            set { SetValueAndRaise(out _credentials, value); }
+            set { SetValueAndRaise(ref _credentials, value); }
         }
 
         public ManageWindowsCredentialsViewModel(Instance instance, ManageWindowsCredentialsWindow owner)

--- a/GoogleCloudExtension/GoogleCloudExtension/OauthLoginFlow/OauthLoginFlowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/OauthLoginFlow/OauthLoginFlowViewModel.cs
@@ -25,7 +25,7 @@ namespace GoogleCloudExtension.OauthLoginFlow
         public string Message
         {
             get { return _message; }
-            set { SetValueAndRaise(out _message, value); }
+            set { SetValueAndRaise(ref _message, value); }
         }
 
         public ICommand CloseCommand { get; }

--- a/GoogleCloudExtension/GoogleCloudExtension/PickFileDialog/PickFileWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PickFileDialog/PickFileWindowViewModel.cs
@@ -39,7 +39,7 @@ namespace GoogleCloudExtension.PickFileDialog
         public int SelectedIndex
         {
             get { return _selectedIndex; }
-            set { SetValueAndRaise(out _selectedIndex, value); }
+            set { SetValueAndRaise(ref _selectedIndex, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/PubSubWindows/NewTopicViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PubSubWindows/NewTopicViewModel.cs
@@ -44,7 +44,7 @@ namespace GoogleCloudExtension.PubSubWindows
             {
                 IEnumerable<StringValidationResult> validations =
                     PubSubNameValidationRule.Validate(value, Resources.NewTopicWindowNameFieldName);
-                SetAndRaiseWithValidation(out _topicName, value, validations);
+                SetAndRaiseWithValidation(ref _topicName, value, validations);
             }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
@@ -41,7 +41,7 @@ namespace GoogleCloudExtension.PublishDialog
         public FrameworkElement Content
         {
             get { return _content; }
-            set { SetValueAndRaise(out _content, value); }
+            set { SetValueAndRaise(ref _content, value); }
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.PublishDialog
         public bool IsReady
         {
             get { return _isReady; }
-            set { SetValueAndRaise(out _isReady, value); }
+            set { SetValueAndRaise(ref _isReady, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -50,7 +50,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         public IEnumerable<Choice> Choices
         {
             get { return _choices; }
-            set { SetValueAndRaise(out _choices, value); }
+            set { SetValueAndRaise(ref _choices, value); }
         }
 
         private ChoiceStepViewModel(ChoiceStepContent content)

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -49,7 +49,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             {
                 IEnumerable<ValidationResult> validations =
                     GcpPublishStepsUtils.ValidateName(value, Resources.PublishDialogFlexVersionNameFieldName);
-                SetAndRaiseWithValidation(out _version, value, validations);
+                SetAndRaiseWithValidation(ref _version, value, validations);
             }
         }
 
@@ -59,7 +59,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
         public bool Promote
         {
             get { return _promote; }
-            set { SetValueAndRaise(out _promote, value); }
+            set { SetValueAndRaise(ref _promote, value); }
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
         public bool OpenWebsite
         {
             get { return _openWebsite; }
-            set { SetValueAndRaise(out _openWebsite, value); }
+            set { SetValueAndRaise(ref _openWebsite, value); }
         }
 
         private FlexStepViewModel(FlexStepContent content)

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
@@ -58,7 +58,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
             get { return _selectedInstance; }
             set
             {
-                SetValueAndRaise(out _selectedInstance, value);
+                SetValueAndRaise(ref _selectedInstance, value);
                 UpdateCredentials();
                 ManageCredentialsCommand.CanExecuteCommand = value != null;
             }
@@ -70,7 +70,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
         public IEnumerable<WindowsInstanceCredentials> Credentials
         {
             get { return _credentials; }
-            private set { SetValueAndRaise(out _credentials, value); }
+            private set { SetValueAndRaise(ref _credentials, value); }
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
             get { return _selectedCredentials; }
             set
             {
-                SetValueAndRaise(out _selectedCredentials, value);
+                SetValueAndRaise(ref _selectedCredentials, value);
                 RaisePropertyChanged(nameof(HasSelectedCredentials));
                 CanPublish = value != null;
             }
@@ -103,7 +103,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
         public bool OpenWebsite
         {
             get { return _openWebsite; }
-            set { SetValueAndRaise(out _openWebsite, value); }
+            set { SetValueAndRaise(ref _openWebsite, value); }
         }
 
         private GceStepViewModel(GceStepContent content)

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -59,7 +59,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         public AsyncPropertyValue<IList<Cluster>> Clusters
         {
             get { return _clusters; }
-            private set { SetValueAndRaise(out _clusters, value); }
+            private set { SetValueAndRaise(ref _clusters, value); }
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             get { return _selectedCluster; }
             set
             {
-                SetValueAndRaise(out _selectedCluster, value);
+                SetValueAndRaise(ref _selectedCluster, value);
                 UpdateCanPublish();
             }
         }
@@ -85,7 +85,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             {
                 IEnumerable<ValidationResult> validations =
                     GcpPublishStepsUtils.ValidateName(value, Resources.GkePublishDeploymentNameFieldName);
-                SetAndRaiseWithValidation(out _deploymentName, value, validations);
+                SetAndRaiseWithValidation(ref _deploymentName, value, validations);
             }
         }
 
@@ -100,7 +100,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             {
                 IEnumerable<ValidationResult> validations =
                     GcpPublishStepsUtils.ValidateName(value, Resources.GkePublishDeploymentVersionFieldName);
-                SetAndRaiseWithValidation(out _deploymentVersion, value, validations);
+                SetAndRaiseWithValidation(ref _deploymentVersion, value, validations);
             }
         }
 
@@ -114,7 +114,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             {
                 IEnumerable<ValidationResult> validations =
                     GcpPublishStepsUtils.ValidateInteger(value, Resources.GkePublishReplicasFieldName);
-                SetAndRaiseWithValidation(out _replicas, value, validations);
+                SetAndRaiseWithValidation(ref _replicas, value, validations);
             }
         }
 
@@ -124,7 +124,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         public bool DontExposeService
         {
             get { return _dontExposeService; }
-            set { SetValueAndRaise(out _dontExposeService, value); }
+            set { SetValueAndRaise(ref _dontExposeService, value); }
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             get { return _exposeService; }
             set
             {
-                SetValueAndRaise(out _exposeService, value);
+                SetValueAndRaise(ref _exposeService, value);
                 InvalidateExposeService();
             }
         }
@@ -146,7 +146,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         public bool ExposePublicService
         {
             get { return _exposePublicService; }
-            set { SetValueAndRaise(out _exposePublicService, value); }
+            set { SetValueAndRaise(ref _exposePublicService, value); }
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         public bool OpenWebsite
         {
             get { return _openWebsite; }
-            set { SetValueAndRaise(out _openWebsite, value); }
+            set { SetValueAndRaise(ref _openWebsite, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/ShowPassword/ShowPasswordViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ShowPassword/ShowPasswordViewModel.cs
@@ -49,7 +49,7 @@ namespace GoogleCloudExtension.ShowPassword
         public bool ShowCopyFeedback
         {
             get { return _showCopyFeedback; }
-            set { SetValueAndRaise(out _showCopyFeedback, value); }
+            set { SetValueAndRaise(ref _showCopyFeedback, value); }
         }
 
         public ShowPasswordViewModel(ShowPasswordWindow.Options options)

--- a/GoogleCloudExtension/GoogleCloudExtension/SplitTrafficManagement/SplitTrafficModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/SplitTrafficManagement/SplitTrafficModel.cs
@@ -30,7 +30,7 @@ namespace GoogleCloudExtension.SplitTrafficManagement
         public string VersionId
         {
             get { return _versionId; }
-            set { SetValueAndRaise(out _versionId, value); }
+            set { SetValueAndRaise(ref _versionId, value); }
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace GoogleCloudExtension.SplitTrafficManagement
         public int TrafficAllocation
         {
             get { return _trafficAllocation; }
-            set { SetValueAndRaise(out _trafficAllocation, value); }
+            set { SetValueAndRaise(ref _trafficAllocation, value); }
         }
 
         public SplitTrafficModel(string versionId, int trafficAllocation)

--- a/GoogleCloudExtension/GoogleCloudExtension/SplitTrafficManagement/SplitTrafficViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/SplitTrafficManagement/SplitTrafficViewModel.cs
@@ -66,7 +66,7 @@ namespace GoogleCloudExtension.SplitTrafficManagement
         public bool IsIpChecked
         {
             get { return _isIpChecked; }
-            set { SetValueAndRaise(out _isIpChecked, value); }
+            set { SetValueAndRaise(ref _isIpChecked, value); }
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace GoogleCloudExtension.SplitTrafficManagement
         public bool IsCookieChecked
         {
             get { return _isCookieChecked; }
-            set { SetValueAndRaise(out _isCookieChecked, value); }
+            set { SetValueAndRaise(ref _isCookieChecked, value); }
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace GoogleCloudExtension.SplitTrafficManagement
             get { return _selectedSplit; }
             set
             {
-                SetValueAndRaise(out _selectedSplit, value);
+                SetValueAndRaise(ref _selectedSplit, value);
                 UpdateCommands();
             }
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingDetailViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingDetailViewModel.cs
@@ -47,7 +47,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsAccountChanged
         {
             get { return _isAccountChanged; }
-            set { SetValueAndRaise(out _isAccountChanged, value); }
+            set { SetValueAndRaise(ref _isAccountChanged, value); }
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public string ErrorString
         {
             get { return _errorString; }
-            set { SetValueAndRaise(out _errorString, value); }
+            set { SetValueAndRaise(ref _errorString, value); }
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool ShowError
         {
             get { return _showError; }
-            set { SetValueAndRaise(out _showError, value); }
+            set { SetValueAndRaise(ref _showError, value); }
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsControlEnabled
         {
             get { return _isControlEnabled; }
-            set { SetValueAndRaise(out _isControlEnabled, value); }
+            set { SetValueAndRaise(ref _isControlEnabled, value); }
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsGroupLoading
         {
             get { return _isGroupLoading; }
-            set { SetValueAndRaise(out _isGroupLoading, value); }
+            set { SetValueAndRaise(ref _isGroupLoading, value); }
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsEventLoading
         {
             get { return _isEventLoading; }
-            set { SetValueAndRaise(out _isEventLoading, value); }
+            set { SetValueAndRaise(ref _isEventLoading, value); }
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public ErrorGroupItem GroupItem
         {
             get { return _groupItem; }
-            private set { SetValueAndRaise(out _groupItem, value); }
+            private set { SetValueAndRaise(ref _groupItem, value); }
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public CollectionView EventItemCollection
         {
             get { return _eventItemCollection; }
-            private set { SetValueAndRaise(out _eventItemCollection, value); }
+            private set { SetValueAndRaise(ref _eventItemCollection, value); }
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
             get { return _selectedTimeRange; }
             set
             {
-                SetValueAndRaise(out _selectedTimeRange, value);
+                SetValueAndRaise(ref _selectedTimeRange, value);
                 if (value != null)
                 {
                     ErrorHandlerUtils.HandleAsyncExceptions(UpdateGroupAndEventAsync);

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingViewModel.cs
@@ -51,7 +51,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public string ErrorString
         {
             get { return _exceptionString; }
-            set { SetValueAndRaise(out _exceptionString, value); }
+            set { SetValueAndRaise(ref _exceptionString, value); }
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool ShowError
         {
             get { return _showException; }
-            set { SetValueAndRaise(out _showException, value); }
+            set { SetValueAndRaise(ref _showException, value); }
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsLoadingComplete
         {
             get { return !_isLoading; }
-            set { SetValueAndRaise(out _isLoading, !value); }
+            set { SetValueAndRaise(ref _isLoading, !value); }
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsRefreshing
         {
             get { return _isRefreshing; }
-            set { SetValueAndRaise(out _isRefreshing, value); }
+            set { SetValueAndRaise(ref _isRefreshing, value); }
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsLoadingNextPage
         {
             get { return _isLoadingNextPage; }
-            set { SetValueAndRaise(out _isLoadingNextPage, value); }
+            set { SetValueAndRaise(ref _isLoadingNextPage, value); }
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
             get { return _selectedTimeRange; }
             set
             {
-                SetValueAndRaise(out _selectedTimeRange, value);
+                SetValueAndRaise(ref _selectedTimeRange, value);
                 if (_selectedTimeRange != null)
                 {
                     Reload();

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/TimeRangeButtons/TimeRangeItem.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/TimeRangeButtons/TimeRangeItem.cs
@@ -32,7 +32,7 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public bool IsCurrentSelection
         {
             get { return _isSelected; }
-            set { SetValueAndRaise(out _isSelected, value); }
+            set { SetValueAndRaise(ref _isSelected, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/DateTimePickerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/DateTimePickerViewModel.cs
@@ -74,7 +74,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public TimeSpan UiElementTime
         {
             get { return _uiElementTime; }
-            set { SetValueAndRaise(out _uiElementTime, value); }
+            set { SetValueAndRaise(ref _uiElementTime, value); }
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public int SelectedOrderIndex
         {
             get { return _uiSelectedOrderIndex; }
-            set { SetValueAndRaise(out _uiSelectedOrderIndex, value); }
+            set { SetValueAndRaise(ref _uiSelectedOrderIndex, value); }
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             get { return _isDropDownOpen; }
             set
             {
-                SetValueAndRaise(out _isDropDownOpen, value);
+                SetValueAndRaise(ref _isDropDownOpen, value);
 
                 Debug.WriteLine($"Set IsDropDownOpen {value}");
                 if (_isDropDownOpen)

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogIdsList.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogIdsList.cs
@@ -56,7 +56,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public string SelectedLogId
         {
             get { return _selectedLogIDShortName; }
-            set { SetValueAndRaise(out _selectedLogIDShortName, value); }
+            set { SetValueAndRaise(ref _selectedLogIDShortName, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerViewModel.cs
@@ -87,7 +87,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public LogIdsList LogIdList
         {
             get { return _logIdList; }
-            private set { SetValueAndRaise(out _logIdList, value); }
+            private set { SetValueAndRaise(ref _logIdList, value); }
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public string AdvancedFilterText
         {
             get { return _advacedFilterText; }
-            set { SetValueAndRaise(out _advacedFilterText, value); }
+            set { SetValueAndRaise(ref _advacedFilterText, value); }
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool ShowAdvancedFilter
         {
             get { return _showAdvancedFilter; }
-            private set { SetValueAndRaise(out _showAdvancedFilter, value); }
+            private set { SetValueAndRaise(ref _showAdvancedFilter, value); }
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public string SimpleSearchText
         {
             get { return _simpleSearchText; }
-            set { SetValueAndRaise(out _simpleSearchText, value); }
+            set { SetValueAndRaise(ref _simpleSearchText, value); }
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public LogSeverityItem SelectedLogSeverity
         {
             get { return _selectedLogSeverity; }
-            set { SetValueAndRaise(out _selectedLogSeverity, value); }
+            set { SetValueAndRaise(ref _selectedLogSeverity, value); }
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public TimeZoneInfo SelectedTimeZone
         {
             get { return _selectedTimeZone; }
-            set { SetValueAndRaise(out _selectedTimeZone, value); }
+            set { SetValueAndRaise(ref _selectedTimeZone, value); }
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             get { return _toggleExpandAllExpanded; }
             set
             {
-                SetValueAndRaise(out _toggleExpandAllExpanded, value);
+                SetValueAndRaise(ref _toggleExpandAllExpanded, value);
                 RaisePropertyChanged(nameof(ToggleExapandAllToolTip));
             }
         }
@@ -230,7 +230,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool ShowCancelRequestButton
         {
             get { return _showCancelRequestButton; }
-            private set { SetValueAndRaise(out _showCancelRequestButton, value); }
+            private set { SetValueAndRaise(ref _showCancelRequestButton, value); }
         }
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool ShowRequestErrorMessage
         {
             get { return _showRequestErrorMessage; }
-            private set { SetValueAndRaise(out _showRequestErrorMessage, value); }
+            private set { SetValueAndRaise(ref _showRequestErrorMessage, value); }
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public string RequestErrorMessage
         {
             get { return _requestErrorMessage; }
-            private set { SetValueAndRaise(out _requestErrorMessage, value); }
+            private set { SetValueAndRaise(ref _requestErrorMessage, value); }
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public string RequestStatusText
         {
             get { return _requestStatusText; }
-            private set { SetValueAndRaise(out _requestStatusText, value); }
+            private set { SetValueAndRaise(ref _requestStatusText, value); }
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool ShowRequestStatus
         {
             get { return _showRequestStatus; }
-            private set { SetValueAndRaise(out _showRequestStatus, value); }
+            private set { SetValueAndRaise(ref _showRequestStatus, value); }
         }
 
         /// <summary>
@@ -276,7 +276,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool IsControlEnabled
         {
             get { return _isControlEnabled; }
-            private set { SetValueAndRaise(out _isControlEnabled, value); }
+            private set { SetValueAndRaise(ref _isControlEnabled, value); }
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool IsAutoReloadChecked
         {
             get { return _isAutoReloadChecked; }
-            set { SetValueAndRaise(out _isAutoReloadChecked, value); }
+            set { SetValueAndRaise(ref _isAutoReloadChecked, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/MenuItemViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/MenuItemViewModel.cs
@@ -48,7 +48,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public string Header
         {
             get { return _header; }
-            set { SetValueAndRaise(out _header, value); }
+            set { SetValueAndRaise(ref _header, value); }
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool IsSubmenuPopulated
         {
             get { return _isSubmenuPopulated; }
-            set { SetValueAndRaise(out _isSubmenuPopulated, value); }
+            set { SetValueAndRaise(ref _isSubmenuPopulated, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeMenuViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeMenuViewModel.cs
@@ -62,7 +62,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public MenuItemViewModel SelectedMenuItem
         {
             get { return _selectedMenuItem; }
-            set { SetValueAndRaise(out _selectedMenuItem, value); }
+            set { SetValueAndRaise(ref _selectedMenuItem, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SourceNavigation/LoggerTooltipViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SourceNavigation/LoggerTooltipViewModel.cs
@@ -41,7 +41,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public bool FilterLogsOfSourceLine
         {
             get { return _filterLogsOfSourceLine; }
-            set { SetValueAndRaise(out _filterLogsOfSourceLine, value); }
+            set { SetValueAndRaise(ref _filterLogsOfSourceLine, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/TitleBar/TitleBarViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TitleBar/TitleBarViewModel.cs
@@ -46,7 +46,7 @@ namespace GoogleCloudExtension.TitleBar
         public bool ShowAccountManagementLink
         {
             get { return _showAccountManagementLink; }
-            set { SetValueAndRaise(out _showAccountManagementLink, value); }
+            set { SetValueAndRaise(ref _showAccountManagementLink, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/Validation/ValidatingViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/Validation/ValidatingViewModelBase.cs
@@ -79,12 +79,12 @@ namespace GoogleCloudExtension.Utils.Validation
         }
 
         protected void SetAndRaiseWithValidation<T>(
-            out T storage,
+            ref T storage,
             T value,
             IEnumerable<ValidationResult> validations,
             [CallerMemberName] string propertyName = "")
         {
-            SetValueAndRaise(out storage, value, propertyName);
+            SetValueAndRaise(ref storage, value, propertyName);
             SetValidationResults(validations, propertyName);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/ViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/ViewModelBase.cs
@@ -28,13 +28,13 @@ namespace GoogleCloudExtension.Utils
         public bool Loading
         {
             get { return _loading; }
-            set { SetValueAndRaise(out _loading, value); }
+            set { SetValueAndRaise(ref _loading, value); }
         }
 
         public string LoadingMessage
         {
             get { return _loadingMessage; }
-            set { SetValueAndRaise(out _loadingMessage, value); }
+            set { SetValueAndRaise(ref _loadingMessage, value); }
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/WindowsCredentialsChooser/WindowsCredentialsChooserViewModel.cs
@@ -56,7 +56,7 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
         public IEnumerable<WindowsInstanceCredentials> InstanceCredentials
         {
             get { return _instanceCredentials; }
-            set { SetValueAndRaise(out _instanceCredentials, value); }
+            set { SetValueAndRaise(ref _instanceCredentials, value); }
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
         public WindowsInstanceCredentials CurrentCredentials
         {
             get { return _currentCredentials; }
-            set { SetValueAndRaise(out _currentCredentials, value); }
+            set { SetValueAndRaise(ref _currentCredentials, value); }
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace GoogleCloudExtension.WindowsCredentialsChooser
         public bool HasCredentials
         {
             get { return _hasCredentials; }
-            set { SetValueAndRaise(out _hasCredentials, value); }
+            set { SetValueAndRaise(ref _hasCredentials, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/Validation/ValidatingViewModelBaseTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/Validation/ValidatingViewModelBaseTests.cs
@@ -249,7 +249,7 @@ namespace GoogleCloudExtensionUnitTests.Utils.Validation
             public int SomeIntProperty
             {
                 get { return _someIntProperty; }
-                set { SetAndRaiseWithValidation(out _someIntProperty, value, s_setTestValidations); }
+                set { SetAndRaiseWithValidation(ref _someIntProperty, value, s_setTestValidations); }
             }
 
             public int HasErrorChangedCount { get; private set; } = 0;


### PR DESCRIPTION
The parameter to the `SetValueAndRaise()` method is a **ref** parameter. We are passing the _pointer_ to the variable. The method does **not** produce a value into its parameter. We need to use the right semantics for C# here.

I have reverted the change, and I am ashamed to say that I didn't see this on the review. I will be more careful in the future.