### PR TITLE
Fix code coverage by adding filters to the OpenCover comand.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -41,7 +41,7 @@
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This will make the tools use the v3 version of the .vsix format. Without this the extension won't load on VS 2017. -->
@@ -38,7 +38,7 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
-    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,11 @@ artifacts:
 test_script:
   - ps: $testDllNames = "GoogleAnalyticsUtilsTests.dll", "GoogleCloudExtensionUnitTests.dll", "GoogleCloudExtension.Utils.UnitTests.dll"
   - ps: $testDlls = ls -r -include $testDllNames | ? FullName -Like *\bin\*
-  - ps: $vsTestPath = (Get-Command vstest.console).Source
   - ps: $testContainerArgs = $testDlls.FullName -join " "
   - ps: $testArgs = "/logger:Appveyor $testContainerArgs"
-  - ps: OpenCover.Console.exe -register:user -target:$vsTestPath -targetargs:$testContainerArgs -output:codecoverage.xml
+  - ps: $testFilters = ($testDlls.BaseName | % { "-[$_]*"}) -join " "
+  - ps: $filter = "+[GoogleCloudExtension*]* +[GoogleAnalyticsUtils*]* -[*]XamlGeneratedNamespace* $testFilters"
+  - ps: OpenCover.Console.exe -register:user -target:vstest.console.exe -targetargs:$testArgs -output:codecoverage.xml -filter:$filter
 
 # Upload to codecov.io
 after_test:


### PR DESCRIPTION
Fix code coverage report by including GoogleCloudExtension.dll and excluding the unit test dlls.