### PR TITLE
Master support netcore 1 1

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -26,7 +26,7 @@ namespace GoogleCloudExtension.Deployment
     /// </summary>
     internal static class CommonUtils
     {
-        // This pattern is to be used to find al of  the .deps.json in the stage directory.
+        // This pattern is to be used to find all of  the .deps.json in the stage directory.
         private const string DepsFilePattern = "*.deps.json";
 
         // This is the extension for the .deps.json file that determines the name of the entrypoint assembly.
@@ -37,7 +37,6 @@ namespace GoogleCloudExtension.Deployment
         /// is determined by looking for the .deps.json that defines the app's structure.
         /// </summary>
         /// <param name="stageDirectory">The directory where the app is being staged.</param>
-        /// <returns></returns>
         internal static string GetEntrypointName(string stageDirectory)
         {
             var depsFile = Directory.GetFiles(stageDirectory, DepsFilePattern).FirstOrDefault();

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace GoogleCloudExtension.Deployment
 {
@@ -25,33 +26,28 @@ namespace GoogleCloudExtension.Deployment
     /// </summary>
     internal static class CommonUtils
     {
+        // This pattern is to be used to find al of  the .deps.json in the stage directory.
+        private const string DepsFilePattern = "*.deps.json";
+
+        // This is the extension for the .deps.json file that determines the name of the entrypoint assembly.
+        private const string DepsFileExtension = ".deps.json";
+
         /// <summary>
-        /// Returns the project name given the path to the project.json. If the project.json file defines a
-        /// "name" property then it is used as the name for the final assembly, otherwise the name of the directory
-        /// is used as the name of the final assembly.
+        /// Returns the entrypoint .dll for the .NET Core project given it's stage directory.
         /// </summary>
-        /// <param name="projectPath">The full path to the project.json of the project.</param>
-        internal static string GetProjectName(string projectPath)
+        /// <param name="stageDirectory">The directory where the app is being staged.</param>
+        /// <returns></returns>
+        internal static string GetEntrypointName(string stageDirectory)
         {
-            try
+            var depsFile = Directory.GetFiles(stageDirectory, DepsFilePattern).FirstOrDefault();
+            if (depsFile == null)
             {
-                var contents = File.ReadAllText(projectPath);
-                var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(contents);
-                object name = null;
-                if (parsed.TryGetValue("name", out name))
-                {
-                    return (string)name;
-                }
-                else
-                {
-                    var directory = Path.GetDirectoryName(projectPath);
-                    return Path.GetFileName(directory);
-                }
+                Debug.WriteLine($"Cannot find .deps.file in {stageDirectory}");
+                return null;
             }
-            catch (Exception ex) when (ex is IOException || ex is JsonException)
-            {
-                throw new DeploymentException(ex.Message, ex);
-            }
+
+            var name = Path.GetFileName(depsFile);
+            return name.Substring(0, name.Length - DepsFileExtension.Length);
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CommonUtils.cs
@@ -33,7 +33,8 @@ namespace GoogleCloudExtension.Deployment
         private const string DepsFileExtension = ".deps.json";
 
         /// <summary>
-        /// Returns the entrypoint .dll for the .NET Core project given it's stage directory.
+        /// Returns the name of the entrypoint assembly for the .NET Core project given it's stage directory. The name
+        /// is determined by looking for the .deps.json that defines the app's structure.
         /// </summary>
         /// <param name="stageDirectory">The directory where the app is being staged.</param>
         /// <returns></returns>

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GoogleCloudExtension.Deployment.csproj.user
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GoogleCloudExtension.Deployment.csproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
 </Project>

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -29,6 +29,7 @@ namespace GoogleCloudExtension.Deployment
     {
         internal const string DockerfileName = "Dockerfile";
 
+        // The mapping of supported .NET Core versions to the base images to use for the Docker image.
         private static readonly Dictionary<KnownProjectTypes, string> s_knownRuntimeImages = new Dictionary<KnownProjectTypes, string>
         {
             [ KnownProjectTypes.NetCoreWebApplication1_0 ] = "gcr.io/google-appengine/aspnetcore:1.0",

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindow.cs
@@ -53,7 +53,9 @@ namespace GoogleCloudExtension.PublishDialog
         public static bool CanPublish(IParsedProject project)
         {
             var projectType = project.ProjectType;
-            return projectType == KnownProjectTypes.WebApplication || projectType == KnownProjectTypes.NetCoreWebApplication1_0;
+            return projectType == KnownProjectTypes.WebApplication ||
+                projectType == KnownProjectTypes.NetCoreWebApplication1_0 ||
+                projectType == KnownProjectTypes.NetCoreWebApplication1_1;
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -69,7 +69,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepAppEngineFlexName,
                     Command = new ProtectedCommand(
                         OnAppEngineChoiceCommand,
-                        canExecuteCommand: projectType == KnownProjectTypes.NetCoreWebApplication1_0),
+                        canExecuteCommand: IsSupportedNetCoreProject(_dialog.Project)),
                     Icon = s_appEngineIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepAppEngineToolTip
                 },
@@ -78,7 +78,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepGkeName,
                     Command = new ProtectedCommand(
                         OnGkeChoiceCommand,
-                        canExecuteCommand: projectType == KnownProjectTypes.NetCoreWebApplication1_0),
+                        canExecuteCommand:IsSupportedNetCoreProject(_dialog.Project)),
                     Icon = s_gkeIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepGkeToolTip
                 },
@@ -133,5 +133,8 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
             return viewModel;
         }
+
+        private static bool IsSupportedNetCoreProject(IParsedProject project)
+            => project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_0 || project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_1;
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -135,6 +135,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         }
 
         private static bool IsSupportedNetCoreProject(IParsedProject project)
-            => project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_0 || project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_1;
+            => project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_0 ||
+               project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_1;
     }
 }


### PR DESCRIPTION
This PR adds support for .NET Core 1.1 apps. This PR also adds support for determining the name of the entrypoint assembly based on the published app, instead of just looking at the project name.

The project name will still be used for the case where the user wants us to generate a Dockerfile, the user can update the Dockerfile as needed should the name of the project change.

Fixes #675 