### PR TITLE
Use the GA command for resetting windows password.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -57,7 +57,7 @@ namespace GoogleCloudExtension.GCloud
             string userName,
             GCloudContext context) =>
             GetJsonOutputAsync<WindowsInstanceCredentials>(
-                $"beta compute reset-windows-password {instanceName} --zone={zoneName} --user=\"{userName}\" --quiet ",
+                $"compute reset-windows-password {instanceName} --zone={zoneName} --user=\"{userName}\" --quiet ",
                 context);
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageWindowsCredentials/ManageWindowsCredentialsViewModel.cs
@@ -192,13 +192,6 @@ namespace GoogleCloudExtension.ManageWindowsCredentials
 
                 Debug.WriteLine($"Resetting the password for the user {user}");
 
-                // Check that gcloud is in the right state to invoke the reset credentials method.
-                if (!await GCloudWrapperUtils.VerifyGCloudDependencies("beta"))
-                {
-                    Debug.WriteLine("Missing gcloud dependencies for resetting password.");
-                    return null;
-                }
-
                 var context = new GCloudContext
                 {
                     CredentialsPath = CredentialsStore.Default.CurrentAccountPath,


### PR DESCRIPTION
This PR updates the reset Windows credentials functionality to use the GA command for resetting the password.

Fixes #590 