### PR TITLE
create repo dialog

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneCreateViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneCreateViewModelBase.cs
@@ -15,14 +15,12 @@
 using Google.Apis.CloudResourceManager.v1.Data;
 using Google.Apis.CloudSourceRepositories.v1.Data;
 using GoogleCloudExtension.Accounts;
-using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.GitUtils;
 using GoogleCloudExtension.Theming;
 using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Validation;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneCreateViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneCreateViewModelBase.cs
@@ -1,0 +1,226 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.CloudResourceManager.v1.Data;
+using Google.Apis.CloudSourceRepositories.v1.Data;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.DataSources;
+using GoogleCloudExtension.GitUtils;
+using GoogleCloudExtension.Theming;
+using GoogleCloudExtension.Utils;
+using GoogleCloudExtension.Utils.Validation;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace GoogleCloudExtension.CloudSourceRepositories
+{
+    /// <summary>
+    /// View model for user control CsrCloneWindowContent.xaml.
+    /// </summary>
+    public abstract class CsrCloneCreateViewModelBase : ValidatingViewModelBase
+    {
+        protected readonly CommonDialogWindowBase _owner;
+        private string _localPath;
+        private IEnumerable<Project> _projects;
+        private Project _selectedProject;
+        private bool _isReady = true;
+
+        /// <summary>
+        /// Get the repository name
+        /// </summary>
+        protected virtual string RepoName { get; }
+
+
+        /// <summary>
+        /// The projects list
+        /// </summary>
+        public IEnumerable<Project> Projects
+        {
+            get { return _projects; }
+            private set { SetValueAndRaise(ref _projects, value); }
+        }
+
+        /// <summary>
+        /// Selected project
+        /// </summary>
+        public Project SelectedProject
+        {
+            get { return _selectedProject; }
+            set
+            {
+                var oldValue = _selectedProject;
+                SetValueAndRaise(ref _selectedProject, value);
+                if (_selectedProject != null && _isReady && oldValue != _selectedProject)
+                {
+                    OnSelectedProjectChanged(_selectedProject.ProjectId);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The local path to clone the repository to 
+        /// </summary>
+        public string LocalPath
+        {
+            get { return _localPath; }
+            set
+            {
+                SetValueAndRaise(ref _localPath, value);
+                ValidateInputs();
+            }
+        }
+
+        /// <summary>
+        /// Indicates if there is async task running that UI should be disabled.
+        /// </summary>
+        public bool IsReady
+        {
+            get { return _isReady; }
+            set { SetValueAndRaise(ref _isReady, value); }
+        }
+
+        /// <summary>
+        /// Responds to choose a folder command
+        /// </summary>
+        public ICommand PickFolderCommand { get; }
+
+        /// <summary>
+        /// Responds to OK button click event
+        /// </summary>
+        virtual public ProtectedCommand OkCommand { get; }
+
+        /// <summary>
+        /// Final cloned repository
+        /// </summary>
+        public RepoItemViewModel Result { get; protected set; }
+
+        public CsrCloneCreateViewModelBase(CommonDialogWindowBase owner, IList<Project> projects)
+        {
+            _owner = owner.ThrowIfNull(nameof(owner));
+            Projects = projects.ThrowIfNull(nameof(projects));
+            if (!Projects.Any())
+            {
+                throw new ArgumentException($"{nameof(projects)} must not be empty");
+            }
+            PickFolderCommand = new ProtectedCommand(PickFoloder);
+            var projectId = CredentialsStore.Default.CurrentProjectId;
+            // If projectId is null, choose first project. Otherwise, choose the project.
+            SelectedProject = Projects.FirstOrDefault(x => projectId == null || x.ProjectId == projectId);
+        }
+
+        protected async Task ExecuteAsync(Func<Task> task)
+        {
+            IsReady = false;
+            try
+            {
+                await task();
+            }
+            finally
+            {
+                IsReady = true;
+            }
+        }
+
+        protected async Task CloneAsync(Repo CloudRepo)
+        {
+            if (CloudRepo == null)
+            {
+                return;
+            }
+
+            // If OkCommand is enabled, SelectedRepository and LocalPath is valid
+            string destPath = Path.Combine(LocalPath, RepoName);
+
+            if (!CsrGitUtils.StoreCredential(
+                CloudRepo.Url,
+                CredentialsStore.Default.CurrentAccount.RefreshToken,
+                CsrGitUtils.StoreCredentialPathOption.UrlPath))
+            {
+                UserPromptUtils.ErrorPrompt(
+                    message: Resources.CsrCloneFailedToSetCredentialMessage,
+                    title: Resources.UiDefaultPromptTitle);
+                return;
+            }
+
+            try
+            {
+                GitRepository localRepo = await CsrGitUtils.CloneAsync(CloudRepo.Url, destPath);
+                Result = new RepoItemViewModel(CloudRepo, localRepo.Root);
+                _owner.Close();
+            }
+            catch (GitCommandException)
+            {
+                UserPromptUtils.ErrorPrompt(
+                    message: Resources.CsrCloneFailedMessage,
+                    title: Resources.UiDefaultPromptTitle);
+                return;
+            }
+        }
+
+        protected virtual void OnSelectedProjectChanged(string projectId) { }
+
+        protected virtual void ValidateInputs()
+        {
+            SetValidationResults(ValidateLocalPath(), nameof(LocalPath));
+            OkCommand.CanExecuteCommand = RepoName != null && !HasErrors;
+        }
+
+        private void PickFoloder()
+        {
+            using (var dialog = new System.Windows.Forms.FolderBrowserDialog())
+            {
+                dialog.Description = Resources.CsrCloneLocalPathLabel;
+                dialog.SelectedPath = LocalPath;
+                dialog.ShowNewFolderButton = true;
+                var result = dialog.ShowDialog();
+                if (result == System.Windows.Forms.DialogResult.OK)
+                {
+                    LocalPath = dialog.SelectedPath;
+                }
+            }
+        }
+
+        private IEnumerable<ValidationResult> ValidateLocalPath()
+        {
+            string fieldName = Resources.CsrCloneLocalPathFieldName;
+            if (String.IsNullOrEmpty(LocalPath))
+            {
+                yield return StringValidationResult.FromResource(
+                    nameof(Resources.ValdiationNotEmptyMessage), fieldName);
+                yield break;
+            }
+            if (!Directory.Exists(LocalPath))
+            {
+                yield return StringValidationResult.FromResource(nameof(Resources.CsrClonePathNotExistMessage));
+                yield break;
+            }
+            if (RepoName != null)
+            {
+                string destPath = Path.Combine(LocalPath, RepoName);
+                if (Directory.Exists(destPath) && !PathUtils.IsDirectoryEmpty(destPath))
+                {
+                    yield return StringValidationResult.FromResource(
+                        nameof(Resources.CsrClonePathExistNotEmptyMessageFormat), destPath);
+                    yield break;
+                }
+            }
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneCreateViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneCreateViewModelBase.cs
@@ -184,7 +184,6 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         {
             using (var dialog = new System.Windows.Forms.FolderBrowserDialog())
             {
-                dialog.Description = Resources.CsrCloneLocalPathLabel;
                 dialog.SelectedPath = LocalPath;
                 dialog.ShowNewFolderButton = true;
                 var result = dialog.ShowDialog();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindowViewModel.cs
@@ -15,12 +15,15 @@
 using Google.Apis.CloudResourceManager.v1.Data;
 using Google.Apis.CloudSourceRepositories.v1.Data;
 using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.GitUtils;
+using GoogleCloudExtension.Theming;
 using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Validation;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,41 +35,9 @@ namespace GoogleCloudExtension.CloudSourceRepositories
     /// <summary>
     /// View model for user control CsrCloneWindowContent.xaml.
     /// </summary>
-    public class CsrCloneWindowViewModel : ValidatingViewModelBase
+    public class CsrCloneWindowViewModel : CsrCloneCreateViewModelBase
     {
-        private readonly CsrCloneWindow _owner;
-        private string _localPath;
         private Repo _selectedRepo;
-        private IEnumerable<Project> _projects;
-        private Project _selectedProject;
-        private bool _isReady = true;
-
-        /// <summary>
-        /// The projects list
-        /// </summary>
-        public IEnumerable<Project> Projects
-        {
-            get { return _projects; }
-            private set { SetValueAndRaise(ref _projects, value); }
-        }
-
-        /// <summary>
-        /// Selected project
-        /// </summary>
-        public Project SelectedProject
-        {
-            get { return _selectedProject; }
-            set
-            {
-                var oldValue = _selectedProject;
-                SetValueAndRaise(ref _selectedProject, value);
-                if (_selectedProject != null && IsReady && oldValue != _selectedProject)
-                {
-                    ErrorHandlerUtils.HandleAsyncExceptions(() =>
-                        RepositoriesAsync.StartListRepoTaskAsync(_selectedProject.ProjectId));
-                }
-            }
-        }
 
         /// <summary>
         /// The list of repositories that belong to the project
@@ -86,58 +57,22 @@ namespace GoogleCloudExtension.CloudSourceRepositories
             }
         }
 
-        /// <summary>
-        /// The local path to clone the repository to 
-        /// </summary>
-        public string LocalPath
+        public override ProtectedCommand OkCommand { get; }
+
+        protected override string RepoName => SelectedRepository?.GetRepoName();
+
+        public CsrCloneWindowViewModel(CsrCloneWindow owner, IList<Project> projects) : base(owner, projects)
         {
-            get { return _localPath; }
-            set
-            {
-                SetValueAndRaise(ref _localPath, value);
-                ValidateInputs();
-            }
-        }
-
-        /// <summary>
-        /// Indicates if there is async task running that UI should be disabled.
-        /// </summary>
-        public bool IsReady
-        {
-            get { return _isReady; }
-            set { SetValueAndRaise(ref _isReady, value); }
-        }
-
-        /// <summary>
-        /// Responds to choose a folder command
-        /// </summary>
-        public ICommand PickFolderCommand { get; }
-
-        /// <summary>
-        /// Responds to OK button click event
-        /// </summary>
-        public ProtectedCommand OkCommand { get; }
-
-        /// <summary>
-        /// Final cloned repository
-        /// </summary>
-        public RepoItemViewModel Result { get; private set; }
-
-        public CsrCloneWindowViewModel(CsrCloneWindow owner, IList<Project> projects)
-        {
-            _owner = owner.ThrowIfNull(nameof(owner));
-            Projects = projects.ThrowIfNull(nameof(projects));
-            if (!Projects.Any())
-            {
-                throw new ArgumentException($"{nameof(projects)} must not be empty");
-            }
-            PickFolderCommand = new ProtectedCommand(PickFoloder);
-            OkCommand = new ProtectedAsyncCommand(() => ExecuteAsync(CloneAsync), canExecuteCommand: false);
+            OkCommand = new ProtectedAsyncCommand(
+                () => ExecuteAsync(() => CloneAsync(SelectedRepository)), 
+                canExecuteCommand: false);
             RepositoriesAsync.PropertyChanged += RepositoriesAsyncPropertyChanged;
+        }
 
-            var projectId = CredentialsStore.Default.CurrentProjectId;
-            // If projectId is null, choose first project. Otherwise, choose the project.
-            SelectedProject = Projects.FirstOrDefault(x => projectId == null || x.ProjectId == projectId);
+        protected override void OnSelectedProjectChanged(string projectId)
+        {
+            ErrorHandlerUtils.HandleAsyncExceptions(() =>
+                RepositoriesAsync.StartListRepoTaskAsync(projectId));
         }
 
         private void RepositoriesAsyncPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -151,96 +86,6 @@ namespace GoogleCloudExtension.CloudSourceRepositories
                     break;
                 default:
                     break;
-            }
-        }
-
-        private async Task CloneAsync()
-        {
-            // If OkCommand is enabled, SelectedRepository and LocalPath is valid
-            string destPath = Path.Combine(LocalPath, SelectedRepository.GetRepoName());
-
-            if (!CsrGitUtils.StoreCredential(
-                SelectedRepository.Url,
-                CredentialsStore.Default.CurrentAccount.RefreshToken,
-                CsrGitUtils.StoreCredentialPathOption.UrlPath))
-            {
-                UserPromptUtils.ErrorPrompt(
-                    message: Resources.CsrCloneFailedToSetCredentialMessage,
-                    title: Resources.UiDefaultPromptTitle);
-                return;
-            }
-
-            try
-            {
-                GitRepository localRepo = await CsrGitUtils.CloneAsync(SelectedRepository.Url, destPath);
-                Result = new RepoItemViewModel(SelectedRepository, localRepo.Root);
-                _owner.Close();
-            }
-            catch (GitCommandException)
-            {
-                UserPromptUtils.ErrorPrompt(
-                    message: Resources.CsrCloneFailedMessage,
-                    title: Resources.UiDefaultPromptTitle);
-                return;
-            }
-        }
-
-        private void PickFoloder()
-        {
-            using (var dialog = new System.Windows.Forms.FolderBrowserDialog())
-            {
-                dialog.SelectedPath = LocalPath;
-                dialog.ShowNewFolderButton = true;
-                var result = dialog.ShowDialog();
-                if (result == System.Windows.Forms.DialogResult.OK)
-                {
-                    LocalPath = dialog.SelectedPath;
-                }
-            }
-        }
-
-        private async Task ExecuteAsync(Func<Task> task)
-        {
-            IsReady = false;
-            try
-            {
-                await task();
-            }
-            finally
-            {
-                IsReady = true;
-            }
-        }
-
-        private void ValidateInputs()
-        {
-            SetValidationResults(ValidateLocalPath(), nameof(LocalPath));
-            OkCommand.CanExecuteCommand = SelectedRepository != null && !HasErrors;
-        }
-
-        private IEnumerable<ValidationResult> ValidateLocalPath()
-        {
-            string fieldName = Resources.CsrCloneLocalPathFieldName;
-            if (String.IsNullOrEmpty(LocalPath))
-            {
-                yield return StringValidationResult.FromResource(
-                    nameof(Resources.ValdiationNotEmptyMessage), fieldName);
-                yield break;
-            }
-            if (!Directory.Exists(LocalPath))
-            {
-                yield return StringValidationResult.FromResource(nameof(Resources.CsrClonePathNotExistMessage));
-                yield break;
-            }
-            if (SelectedRepository != null)
-            {
-                string destPath = Path.Combine(LocalPath, SelectedRepository.GetRepoName());
-                if (Directory.Exists(destPath) && !PathUtils.IsDirectoryEmpty(destPath))
-                {
-                    yield return StringValidationResult.FromResource(
-                        nameof(Resources.CsrClonePathExistNotEmptyMessageFormat), destPath);
-                    yield break;
-                }
             }
         }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindowViewModel.cs
@@ -14,21 +14,10 @@
 
 using Google.Apis.CloudResourceManager.v1.Data;
 using Google.Apis.CloudSourceRepositories.v1.Data;
-using GoogleCloudExtension.Accounts;
-using GoogleCloudExtension.DataSources;
-using GoogleCloudExtension.GitUtils;
-using GoogleCloudExtension.Theming;
 using GoogleCloudExtension.Utils;
-using GoogleCloudExtension.Utils.Validation;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace GoogleCloudExtension.CloudSourceRepositories
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindow.cs
@@ -26,7 +26,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
     {
         private  CsrCreateWindowViewModel ViewModel { get; }
 
-        private CsrCreateWindow(IList<Project> projects): base("Create Google repository")
+        private CsrCreateWindow(IList<Project> projects): base(StringResources.CsrCreateWindowTitle)
         {
             ViewModel = new CsrCreateWindowViewModel(this, projects);
             Content = new CsrCreateWindowContent { DataContext = ViewModel };

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindow.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.CloudResourceManager.v1.Data;
+using StringResources = GoogleCloudExtension.Resources;
+using GoogleCloudExtension.Theming;
+using System.Collections.Generic;
+
+namespace GoogleCloudExtension.CloudSourceRepositories
+{
+    /// <summary>
+    /// Dialog to create a new Google Cloud Source Repository.
+    /// </summary>
+    public class CsrCreateWindow : CommonDialogWindowBase
+    {
+        private  CsrCreateWindowViewModel ViewModel { get; }
+
+        private CsrCreateWindow(IList<Project> projects): base("Create Google repository")
+        {
+            ViewModel = new CsrCreateWindowViewModel(this, projects);
+            Content = new CsrCreateWindowContent { DataContext = ViewModel };
+        }
+
+        /// <summary>
+        /// Show create a new repository dialog
+        /// </summary>
+        /// <param name="projects">A list of GCP <seealso cref="Project"/>.</param>
+        /// <returns>The created and cloned repo item</returns>
+        public static RepoItemViewModel PromptUser(IList<Project> projects)
+        {
+            var dialog = new CsrCreateWindow(projects);
+            dialog.ShowModal();
+            return dialog.ViewModel.Result;
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml
@@ -1,0 +1,116 @@
+﻿<UserControl x:Class="GoogleCloudExtension.CloudSourceRepositories.CsrCreateWindowContent"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:GoogleCloudExtension.CloudSourceRepositories"
+             xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
+             xmlns:ctrl="clr-namespace:GoogleCloudExtension.Controls"
+             xmlns:ext="clr-namespace:GoogleCloudExtension"
+             xmlns:utils="clr-namespace:GoogleCloudExtension.Utils;assembly=GoogleCloudExtension.Utils"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance IsDesignTimeCreatable=False, Type=local:CsrCreateWindowViewModel}"
+             d:DesignHeight="300" d:DesignWidth="300">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+                <ResourceDictionary Source="../Controls/DotsProgressIndicatorResources.xaml" />
+                <ResourceDictionary Source="./CsrResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleBase}" />
+    </UserControl.Style>
+
+    <theming:CommonDialogWindowBaseContent>
+        <theming:CommonDialogWindowBaseContent.Buttons>
+            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiOkButtonCaption}"
+                                      Command="{Binding OkCommand}"
+                                      IsDefault="True"/>
+            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCancelButtonCaption}" IsCancel="True" />
+        </theming:CommonDialogWindowBaseContent.Buttons>
+
+        <StackPanel IsEnabled="{Binding IsReady}">
+
+            <Label 
+                Content="{x:Static ext:Resources.CsrProjectSelectionLabel}"
+                Target="{Binding ElementName=_projectsComboBox}"
+                Style="{StaticResource CommonLabelStyle}" />
+
+            <ComboBox 
+                x:Name="_projectsComboBox"
+                ItemsSource="{Binding Projects}"
+                SelectedItem="{Binding SelectedProject}"
+                DisplayMemberPath="Name"        
+                IsSynchronizedWithCurrentItem="True"
+                IsTextSearchEnabled="True"
+                Style="{StaticResource CommonComboBoxStyle}"/>
+
+            <Label 
+                Content="{x:Static ext:Resources.CsrRepositorySelectionLabel}"
+                Target="{Binding ElementName=_repositoryTextBox}"
+                Style="{StaticResource CommonLabelStyle}"
+                Margin="0,5,0,0"/>
+
+            <TextBox 
+                x:Name="_repositoryTextBox"
+                Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged, 
+                    ValidatesOnNotifyDataErrors=True, Mode=TwoWay}"
+                Style="{StaticResource CommonTextBoxStyle}"
+                MaxLength="{Binding REPO_NAME_LEN}"
+                Margin="0,0,6,0" />
+
+            <Label 
+                Content="{x:Static ext:Resources.CsrCloneLocalPathLabel}"
+                Target="{Binding ElementName=_localPathTextBox}"
+                Style="{StaticResource CommonLabelStyle}" 
+                Margin="0,5,0,0" />
+
+            <DockPanel>
+                <Button 
+                    DockPanel.Dock="Right"
+                    Content="{x:Static ext:Resources.CsrClonePathBrowseButtonCaption}"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Right"
+                    Command="{Binding PickFolderCommand}"
+                    Style="{StaticResource CommonButtonDynamicStyle}" />
+
+                <TextBox 
+                    x:Name="_localPathTextBox"
+                    Text="{Binding LocalPath, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, Mode=TwoWay}"
+                    Style="{StaticResource CommonTextBoxStyle}"
+                    Margin="0,0,5,0">
+                    <TextBox.ToolTip>
+                        <ToolTip 
+                            Content="{x:Static ext:Resources.CsrCloneToTextBoxToolTip}"
+                            Style="{StaticResource CommonTooltipStyle}"/>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+            </DockPanel>
+
+            <CheckBox 
+                Margin="0,6,0,0"
+                VerticalAlignment="Center"
+                IsChecked="{Binding GotoCsrWebPage}" >
+                <TextBlock Text="{x:Static ext:Resources.CsrCreateMirrorAfterPublish}"
+                            TextWrapping="NoWrap"
+                            TextTrimming="CharacterEllipsis"
+                            Style="{StaticResource CommonTextStyle}"/>
+            </CheckBox>
+
+            <ctrl:DotsProgressIndicator 
+                Margin="0,12,0,0" 
+                Width="60" 
+                HorizontalAlignment="Left" 
+                Visibility="{Binding IsReady, Converter={utils:VisibilityConverter IsNegated=True}}"/>
+
+        </StackPanel>
+    </theming:CommonDialogWindowBaseContent>
+    
+</UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml
@@ -17,17 +17,16 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="../Theming/CommonResources.xaml" />
                 <ResourceDictionary Source="../Controls/DotsProgressIndicatorResources.xaml" />
-                <ResourceDictionary Source="./CsrResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
         </ResourceDictionary>
     </UserControl.Resources>
 
     <UserControl.Style>
-        <Binding Source="{StaticResource CommonDialogStyleBase}" />
+        <Binding Source="{StaticResource CommonDialogStyleDynamicSmall}" />
     </UserControl.Style>
 
-    <theming:CommonDialogWindowBaseContent>
+    <theming:CommonDialogWindowBaseContent HasBanner="True">
         <theming:CommonDialogWindowBaseContent.Buttons>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiOkButtonCaption}"
                                       Command="{Binding OkCommand}"
@@ -62,7 +61,7 @@
                 Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged, 
                     ValidatesOnNotifyDataErrors=True, Mode=TwoWay}"
                 Style="{StaticResource CommonTextBoxStyle}"
-                MaxLength="{Binding REPO_NAME_LEN}"
+                MaxLength="{Binding RepoNameMaxLength}"
                 Margin="0,0,6,0" />
 
             <Label 
@@ -82,7 +81,8 @@
 
                 <TextBox 
                     x:Name="_localPathTextBox"
-                    Text="{Binding LocalPath, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True, Mode=TwoWay}"
+                    Text="{Binding LocalPath, UpdateSourceTrigger=PropertyChanged, 
+                        ValidatesOnNotifyDataErrors=True, Mode=TwoWay}"
                     Style="{StaticResource CommonTextBoxStyle}"
                     Margin="0,0,5,0">
                     <TextBox.ToolTip>
@@ -99,7 +99,7 @@
                 VerticalAlignment="Center"
                 IsChecked="{Binding GotoCsrWebPage}" >
                 <TextBlock Text="{x:Static ext:Resources.CsrCreateMirrorAfterPublish}"
-                            TextWrapping="NoWrap"
+                            TextWrapping="Wrap"
                             TextTrimming="CharacterEllipsis"
                             Style="{StaticResource CommonTextStyle}"/>
             </CheckBox>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml
@@ -61,8 +61,7 @@
                 Text="{Binding RepositoryName, UpdateSourceTrigger=PropertyChanged, 
                     ValidatesOnNotifyDataErrors=True, Mode=TwoWay}"
                 Style="{StaticResource CommonTextBoxStyle}"
-                MaxLength="{Binding RepoNameMaxLength}"
-                Margin="0,0,6,0" />
+                MaxLength="{Binding RepoNameMaxLength}" />
 
             <Label 
                 Content="{x:Static ext:Resources.CsrCloneLocalPathLabel}"
@@ -95,7 +94,7 @@
             </DockPanel>
 
             <CheckBox 
-                Margin="0,6,0,0"
+                Margin="0,5,0,0"
                 VerticalAlignment="Center"
                 IsChecked="{Binding GotoCsrWebPage}" >
                 <TextBlock Text="{x:Static ext:Resources.CsrCreateMirrorAfterPublish}"

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowContent.xaml.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Windows.Controls;
+
+namespace GoogleCloudExtension.CloudSourceRepositories
+{
+    /// <summary>
+    /// Interaction logic for CsrCreateWindowContent.xaml
+    /// </summary>
+    public partial class CsrCreateWindowContent : UserControl
+    {
+        public CsrCreateWindowContent()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowViewModel.cs
@@ -36,7 +36,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         private static readonly Lazy<HashSet<char>> 
             s_repoNmaeCharSet = new Lazy<HashSet<char>>(CreateRepoNameCharSet);
 
-        private string _repoName;
+        private string _repositoryName;
         private bool _gotoCsrWebPage = true;
 
         protected override string RepoName => RepositoryName;
@@ -65,10 +65,10 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         /// </summary>
         public string RepositoryName
         {
-            get { return _repoName; }
+            get { return _repositoryName; }
             set
             {
-                SetValueAndRaise(ref _repoName, value);
+                SetValueAndRaise(ref _repositoryName, value);
                 ValidateInputs();
             }
         }
@@ -118,7 +118,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
             {
                 yield return StringValidationResult.FromResource(
                     nameof(Resources.ValdiationNotEmptyMessage), 
-                    Resources.CsrCreateRepoNameTextBoxLebel);
+                    Resources.CsrCreateRepoNameTextBoxLabel);
                 yield break;
             }
 
@@ -149,6 +149,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
             AddCharRange(set, 'a', 'z');
             AddCharRange(set, 'A', 'Z');
             AddCharRange(set, '0', '9');
+            set.Add('_');
             return set;
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCreateWindowViewModel.cs
@@ -1,0 +1,152 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.CloudResourceManager.v1.Data;
+using Google.Apis.CloudSourceRepositories.v1.Data;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.DataSources;
+using GoogleCloudExtension.GitUtils;
+using GoogleCloudExtension.Theming;
+using GoogleCloudExtension.Utils;
+using GoogleCloudExtension.Utils.Validation;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Controls;
+
+namespace GoogleCloudExtension.CloudSourceRepositories
+{
+    /// <summary>
+    /// View model for user control CsrCreateWindowContent.xaml.
+    /// </summary>
+    public class CsrCreateWindowViewModel : CsrCloneCreateViewModelBase
+    {
+        private string _repoName;
+        private bool _gotoCsrWebPage = true;
+
+        public bool GotoCsrWebPage
+        {
+            get { return _gotoCsrWebPage; }
+            set { SetValueAndRaise(ref _gotoCsrWebPage, value); }
+        }
+
+        public string RepositoryName
+        {
+            get { return _repoName; }
+            set
+            {
+                SetValueAndRaise(ref _repoName, value);
+                ValidateInputs();
+            }
+        }
+
+        protected override string RepoName => RepositoryName;
+
+        public override ProtectedCommand OkCommand { get; }
+
+        public int REPO_NAME_LEN => 128;
+
+        public CsrCreateWindowViewModel(CsrCreateWindow owner, IList<Project> projects) : base(owner, projects)
+        {
+            OkCommand = new ProtectedAsyncCommand(() => ExecuteAsync(CreateAsync), canExecuteCommand: false);
+        }
+
+        private async Task CreateAsync()
+        {
+            var csrDatasource = CsrUtils.CreateCsrDataSource(SelectedProject.ProjectId);
+
+            Repo cloudRepo = null;
+            try
+            {
+                cloudRepo = await csrDatasource.CreateRepoAsync(RepositoryName);
+            }
+            catch (DataSourceException ex)
+            {
+                UserPromptUtils.ErrorPrompt(
+                    message: ex.Message,
+                    title: "Create repository");
+                return;
+            }
+
+            // In success, CloneAsync set Result, close dialog.
+            await CloneAsync(cloudRepo);
+            if (base.Result != null && GotoCsrWebPage)
+            {
+                string fmt = "https://console.cloud.google.com/code/develop/browse/{0}?project={1}";
+                string url = String.Format(fmt, RepositoryName, SelectedProject.ProjectId);
+                Process.Start(url);
+            }
+        }
+
+        protected override void ValidateInputs()
+        {
+            SetValidationResults(ValidateRepoName(RepositoryName), nameof(RepositoryName));
+            // Note: Call the base ValidateInputs after ValidateRepoName.
+            base.ValidateInputs();
+        }
+
+        private static readonly HashSet<char> REPO_NAME_FIRST_CHAR = new HashSet<char>();
+        //    CharMatcher.inRange('A', 'Z')
+        //        .or(CharMatcher.inRange('a', 'z'))
+        //        .or(CharMatcher.inRange('0', '9'))
+        //        .or(CharMatcher.is('_'));
+        private static HashSet<char> REPO_NAME_MATCHER;
+
+        private static void AddCharRange(char low, char high)
+        {
+            for (char ch = low; ch <= high; ++ch)
+            {
+                REPO_NAME_FIRST_CHAR.Add(ch);
+            }
+        }
+
+        private IEnumerable<ValidationResult> ValidateRepoName(string name)
+        {
+            if (!REPO_NAME_FIRST_CHAR.Any())
+            {
+                AddCharRange('a', 'z');
+                AddCharRange('A', 'Z');
+                AddCharRange('0', '9');
+                REPO_NAME_FIRST_CHAR.Add('_');
+                REPO_NAME_MATCHER = new HashSet<char>(REPO_NAME_FIRST_CHAR);
+                REPO_NAME_MATCHER.Add('-');
+            }
+
+            if (String.IsNullOrWhiteSpace(name))
+            {
+                yield return StringValidationResult.FromResource(
+                    nameof(Resources.ValdiationNotEmptyMessage), 
+                    Resources.CsrCreateRepoNameTextBoxLebel);
+                yield break;
+            }
+
+            if (!REPO_NAME_FIRST_CHAR.Contains(name[0]))
+            { 
+                yield return StringValidationResult.FromResource(nameof(Resources.CsrRepoNameStartWithMessageFormat), name);
+                yield break;
+            }
+
+            if (name.Skip(1).Any(x => !REPO_NAME_MATCHER.Contains(x)))
+            {
+                yield return StringValidationResult.FromResource(nameof(Resources.CsrCreateRepoNameValidationMessage), name);
+                yield break;
+            }
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
@@ -184,24 +184,12 @@ namespace GoogleCloudExtension.CloudSourceRepositories
                 return;
             }
 
-            var resourceManager = DataSourceFactories.CreateResourceManagerDataSource();
-            if (resourceManager == null)
-            {
-                return;
-            }
-
             IsReady = false;
             Loading = true;
+
             Repositories = new ObservableCollection<RepoItemViewModel>();
-            
             try
             {
-                var projects = await resourceManager.GetSortedActiveProjectsAsync();
-                if (!projects.Any())
-                {
-                    return;
-                }
-
                 await AddLocalReposAsync(await GetLocalGitRepositories());
 
                 SetActiveRepo(_teamExplorer.GetActiveRepository());
@@ -289,152 +277,67 @@ namespace GoogleCloudExtension.CloudSourceRepositories
 
         private async Task CloneAsync()
         {
-            ResourceManagerDataSource resourceManager = DataSourceFactories.CreateResourceManagerDataSource();
-            if (resourceManager == null)
+            var projects = await GetProjectsAsync();
+            if (!projects.Any())
             {
                 return;
             }
 
-            IsReady = false;
-            Loading = true;
-
-            try
+            var repoItem = CsrCloneWindow.PromptUser(projects);
+            if (repoItem != null)
             {
-                var projects = await resourceManager.GetSortedActiveProjectsAsync();
-                Loading = false;
-
-                if (!projects.Any())
+                if (Repositories == null)
                 {
-                    // TODO: Disconnect and show error message "no project"
-                    UserPromptUtils.OkPrompt(
-                        message: Resources.CsrCloneNoProject,
-                        title: Resources.UiDefaultPromptTitle);
-                    return;
+                    Repositories = new ObservableCollection<RepoItemViewModel>();
                 }
-
-                var repoItem = CsrCloneWindow.PromptUser(projects);
-                if (repoItem != null)
-                {
-                    if (Repositories == null)
-                    {
-                        Repositories = new ObservableCollection<RepoItemViewModel>();
-                    }
-                    Repositories.Add(repoItem);
-                }
-            }
-            finally
-            {
-                IsReady = true;
-                Loading = false;
+                Repositories.Add(repoItem);
             }
         }
 
         private async Task CreateAsync()
         {
+            var projects = await GetProjectsAsync();
+            if (!projects.Any())
+            {
+                return;
+            }
+            var repoItem = CsrCreateWindow.PromptUser(projects);
+            if (repoItem != null)
+            {
+                SetCurrentRepo(repoItem.LocalPath);
+            }
+        }
+
+        /// <summary>
+        /// Return a list of projects. Returns empty list if no item is found.
+        /// </summary>
+        private async Task<IList<Project>> GetProjectsAsync()
+        {
             ResourceManagerDataSource resourceManager = DataSourceFactories.CreateResourceManagerDataSource();
             if (resourceManager == null)
             {
-                return;
+                return new List<Project>();
             }
 
             IsReady = false;
             Loading = true;
 
-            RepoItemViewModel repoItem = null;
             try
             {
                 var projects = await resourceManager.GetSortedActiveProjectsAsync();
-                Loading = false;
-                repoItem = CsrCreateWindow.PromptUser(projects);
-
                 if (!projects.Any())
                 {
-                    // TODO: Disconnect and show error message "no project"
                     UserPromptUtils.OkPrompt(
-                        message: Resources.CsrCloneNoProject,
-                        title: Resources.UiDefaultPromptTitle);
-                    return;
+                        message: Resources.CsrNoProjectMessage,
+                        title: Resources.CsrConnectSectionTitle);
                 }
+                return projects;
             }
             finally
             {
                 IsReady = true;
                 Loading = false;
             }
-
-            if (repoItem != null)
-            {
-                SetCurrentRepo(repoItem.LocalPath);
-
-                var msg = string.Format("The repository {0} has been created successfully.", repoItem.Name);
-                msg += " " + string.Format("[Create a new project or solution]({0}) now.", repoItem.LocalPath);
-
-                (Repositories ?? new ObservableCollection<RepoItemViewModel>()).Add(repoItem);
-                _teamExplorer.ShowMessage(msg,
-                    command: new ProtectedCommand(handler: () =>
-                    {
-                        SetDefaultProjectPath(repoItem.LocalPath);
-                        var serviceProvider = ShellUtils.GetGloblalServiceProvider();
-                        var solution = serviceProvider.GetService(typeof(SVsSolution)) as IVsSolution;
-                        solution?.CreateNewProjectViaDlg(null, null, 0);
-                        _teamExplorer.ShowHomeSection();
-                    }));
-            }
-        }
-
-        const string NewProjectDialogKeyPath = @"Software\Microsoft\VisualStudio\14.0\NewProjectDialog";
-        const string MRUKeyPath = "MRUSettingsLocalProjectLocationEntries";
-        internal static string SetDefaultProjectPath(string path)
-        {
-            var old = String.Empty;
-            try
-            {
-                var newProjectKey = Registry.CurrentUser.OpenSubKey(NewProjectDialogKeyPath, true) ??
-                    Registry.CurrentUser.CreateSubKey(NewProjectDialogKeyPath);
-                Debug.Assert(newProjectKey != null, string.Format(CultureInfo.CurrentCulture,
-                    "Could not open or create registry key '{0}'", NewProjectDialogKeyPath));
-
-                using (newProjectKey)
-                {
-                    var mruKey = newProjectKey.OpenSubKey(MRUKeyPath, true) ?? Registry.CurrentUser.CreateSubKey(MRUKeyPath);
-                    Debug.Assert(mruKey != null, string.Format(CultureInfo.CurrentCulture,
-                        "Could not open or create registry key '{0}'", MRUKeyPath));
-
-                    using (mruKey)
-                    {
-                        // is this already the default path? bail
-                        old = (string)mruKey.GetValue("Value0", string.Empty,
-                            RegistryValueOptions.DoNotExpandEnvironmentNames);
-                        if (String.Equals(path.TrimEnd('\\'), old.TrimEnd('\\'),
-                            StringComparison.CurrentCultureIgnoreCase))
-                            return old;
-
-                        // grab the existing list of recent paths, throwing away the last one
-                        var numEntries = (int)mruKey.GetValue("MaximumEntries", 5);
-                        var entries = new List<string>(numEntries);
-                        for (int i = 0; i < numEntries - 1; i++)
-                        {
-                            var val = (string)mruKey.GetValue("Value" + i, String.Empty,
-                                RegistryValueOptions.DoNotExpandEnvironmentNames);
-                            if (!String.IsNullOrEmpty(val))
-                                entries.Add(val);
-                        }
-
-                        newProjectKey.SetValue("LastUsedNewProjectPath", path);
-                        mruKey.SetValue("Value0", path);
-                        // bump list of recent paths one entry down
-                        for (int i = 0; i < entries.Count; i++)
-                            mruKey.SetValue("Value" + (i + 1), entries[i]);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                //VsOutputLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Error setting the create project path in the registry '{0}'", ex));
-                Debug.WriteLine(string.Format(CultureInfo.CurrentCulture,
-                    "Error setting the create project path in the registry '{0}'", ex));
-            }
-            return old;
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
@@ -14,19 +14,14 @@
 
 using Google.Apis.CloudResourceManager.v1.Data;
 using Google.Apis.CloudSourceRepositories.v1.Data;
-using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.GitUtils;
 using GoogleCloudExtension.TeamExplorerExtension;
 using GoogleCloudExtension.Utils;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -185,11 +185,15 @@
     <Compile Include="CloudExplorer\ISourceRootViewModelBase.cs" />
     <Compile Include="CloudExplorer\ITreeHierarchy.cs" />
     <Compile Include="CloudExplorer\ITreeNode.cs" />
+    <Compile Include="CloudSourceRepositories\CsrCloneCreateViewModelBase.cs" />
     <Compile Include="CloudSourceRepositories\CsrCloneWindow.cs" />
     <Compile Include="CloudSourceRepositories\CsrCloneWindowContent.xaml.cs">
       <DependentUpon>CsrCloneWindowContent.xaml</DependentUpon>
     </Compile>
     <Compile Include="CloudSourceRepositories\CsrCloneWindowViewModel.cs" />
+    <Compile Include="CloudSourceRepositories\CsrCreateWindow.cs" />
+    <Compile Include="CloudSourceRepositories\CsrCreateWindowContent.xaml.cs" />
+    <Compile Include="CloudSourceRepositories\CsrCreateWindowViewModel.cs" />
     <Compile Include="CloudSourceRepositories\CsrUtils.cs" />
     <Compile Include="CloudSourceRepositories\AsyncRepositories.cs" />
     <Compile Include="TemplateWizards\Dialogs\ProjectIdDialog\IPickProjectIdWindow.cs" />
@@ -920,6 +924,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="CloudSourceRepositories\CsrCloneWindowContent.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="CloudSourceRepositories\CsrCreateWindowContent.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -194,6 +194,7 @@
     <Compile Include="CloudSourceRepositories\CsrCreateWindow.cs" />
     <Compile Include="CloudSourceRepositories\CsrCreateWindowContent.xaml.cs" />
     <Compile Include="CloudSourceRepositories\CsrCreateWindowViewModel.cs" />
+    <Compile Include="CloudSourceRepositories\CsrReposViewModel.cs" />
     <Compile Include="CloudSourceRepositories\CsrUtils.cs" />
     <Compile Include="CloudSourceRepositories\AsyncRepositories.cs" />
     <Compile Include="TemplateWizards\Dialogs\ProjectIdDialog\IPickProjectIdWindow.cs" />
@@ -237,7 +238,6 @@
     <Compile Include="CloudSourceRepositories\CsrReposContent.xaml.cs">
       <DependentUpon>CsrReposContent.xaml</DependentUpon>
     </Compile>
-    <Compile Include="CloudSourceRepositories\CsrReposViewModel.cs" />
     <Compile Include="CloudSourceRepositories\CsrSectionControl.xaml.cs">
       <DependentUpon>CsrSectionControl.xaml</DependentUpon>
     </Compile>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -2383,7 +2383,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to After creation, goto Google CSR page to mirror repository from GitHub or Gitbuckets (git only)..
+        ///   Looks up a localized string similar to After creation, goto GCP console to mirror repository from GitHub or Gitbuckets (git only)..
         /// </summary>
         public static string CsrCreateMirrorAfterPublish {
             get {
@@ -2394,9 +2394,9 @@ namespace GoogleCloudExtension {
         /// <summary>
         ///   Looks up a localized string similar to Repository name.
         /// </summary>
-        public static string CsrCreateRepoNameTextBoxLebel {
+        public static string CsrCreateRepoNameTextBoxLabel {
             get {
-                return ResourceManager.GetString("CsrCreateRepoNameTextBoxLebel", resourceCulture);
+                return ResourceManager.GetString("CsrCreateRepoNameTextBoxLabel", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -2392,6 +2392,33 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Goto Google CSR page to mirror repo from GitHub or Gitbuckets (git only).
+        /// </summary>
+        public static string CsrCreateMirrorAfterPublish {
+            get {
+                return ResourceManager.GetString("CsrCreateMirrorAfterPublish", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repository name.
+        /// </summary>
+        public static string CsrCreateRepoNameTextBoxLebel {
+            get {
+                return ResourceManager.GetString("CsrCreateRepoNameTextBoxLebel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Supported characters are A-Z, a-z, 0-9, -, and _.
+        /// </summary>
+        public static string CsrCreateRepoNameValidationMessage {
+            get {
+                return ResourceManager.GetString("CsrCreateRepoNameValidationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fully-featured private Git repositories hosted on Cloud Platform on highly-replicated backend storage systems distributed geographically across multiple data centers and run on infrastructure proven for reliability..
         /// </summary>
         public static string CsrDescription {
@@ -2446,11 +2473,29 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The repository name already exists.
+        /// </summary>
+        public static string CsrRepoNameAlreadyExitstsMessage {
+            get {
+                return ResourceManager.GetString("CsrRepoNameAlreadyExitstsMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Repo Name.
         /// </summary>
         public static string CsrRepoNameLabel {
             get {
                 return ResourceManager.GetString("CsrRepoNameLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repo name must start with A-Z, a-z, 0-9 or _.
+        /// </summary>
+        public static string CsrRepoNameStartWithMessageFormat {
+            get {
+                return ResourceManager.GetString("CsrRepoNameStartWithMessageFormat", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -2473,15 +2473,6 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The repository name already exists.
-        /// </summary>
-        public static string CsrRepoNameAlreadyExitstsMessage {
-            get {
-                return ResourceManager.GetString("CsrRepoNameAlreadyExitstsMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Repo Name.
         /// </summary>
         public static string CsrRepoNameLabel {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -2392,7 +2392,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Goto Google CSR page to mirror repo from GitHub or Gitbuckets (git only).
+        ///   Looks up a localized string similar to After creation, goto Google CSR page to mirror repository from GitHub or Gitbuckets (git only)..
         /// </summary>
         public static string CsrCreateMirrorAfterPublish {
             get {
@@ -2410,11 +2410,11 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Supported characters are A-Z, a-z, 0-9, -, and _.
+        ///   Looks up a localized string similar to Create Google Cloud Source Repositories.
         /// </summary>
-        public static string CsrCreateRepoNameValidationMessage {
+        public static string CsrCreateWindowTitle {
             get {
-                return ResourceManager.GetString("CsrCreateRepoNameValidationMessage", resourceCulture);
+                return ResourceManager.GetString("CsrCreateWindowTitle", resourceCulture);
             }
         }
         
@@ -2496,6 +2496,15 @@ namespace GoogleCloudExtension {
         public static string CsrRepoNameStartWithMessageFormat {
             get {
                 return ResourceManager.GetString("CsrRepoNameStartWithMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Supported characters are A-Z, a-z, 0-9, -, and _.
+        /// </summary>
+        public static string CsrRepoNameValidationMessage {
+            get {
+                return ResourceManager.GetString("CsrRepoNameValidationMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -2311,15 +2311,6 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is no project..
-        /// </summary>
-        public static string CsrCloneNoProject {
-            get {
-                return ResourceManager.GetString("CsrCloneNoProject", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Browse.
         /// </summary>
         public static string CsrClonePathBrowseButtonCaption {
@@ -2442,6 +2433,15 @@ namespace GoogleCloudExtension {
         public static string CsrLoadingRepoMessage {
             get {
                 return ResourceManager.GetString("CsrLoadingRepoMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current GCP account has no project..
+        /// </summary>
+        public static string CsrNoProjectMessage {
+            get {
+                return ResourceManager.GetString("CsrNoProjectMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2727,4 +2727,24 @@
     <value>Loading repositories ...</value>
     <comment>Message when loading repositories</comment>
   </data>
+  <data name="CsrCreateMirrorAfterPublish" xml:space="preserve">
+    <value>Goto Google CSR page to mirror repo from GitHub or Gitbuckets (git only)</value>
+    <comment>Caption for checkbox that asks to goto CSR page after repo is created</comment>
+  </data>
+  <data name="CsrCreateRepoNameValidationMessage" xml:space="preserve">
+    <value>Supported characters are A-Z, a-z, 0-9, -, and _</value>
+    <comment>Repo name validation error message</comment>
+  </data>
+  <data name="CsrCreateRepoNameTextBoxLebel" xml:space="preserve">
+    <value>Repository name</value>
+    <comment>Label to repository name input text box</comment>
+  </data>
+  <data name="CsrRepoNameAlreadyExitstsMessage" xml:space="preserve">
+    <value>The repository name already exists</value>
+    <comment>Validation message tells that the input repository name already exists.</comment>
+  </data>
+  <data name="CsrRepoNameStartWithMessageFormat" xml:space="preserve">
+    <value>Repo name must start with A-Z, a-z, 0-9 or _</value>
+    <comment>Repository name first charactor validation message.</comment>
+  </data>  
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2687,8 +2687,8 @@
     <value>_Clone to:</value>
     <comment>Label to the input local path text box</comment>
   </data>
-  <data name="CsrCloneNoProject" xml:space="preserve">
-    <value>There is no project.</value>
+  <data name="CsrNoProjectMessage" xml:space="preserve">
+    <value>Current GCP account has no project.</value>
     <comment>Error message if the user account has no any project</comment>
   </data>
   <data name="CsrClonePathBrowseButtonCaption" xml:space="preserve">

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2728,10 +2728,10 @@
     <comment>Message when loading repositories</comment>
   </data>
   <data name="CsrCreateMirrorAfterPublish" xml:space="preserve">
-    <value>Goto Google CSR page to mirror repo from GitHub or Gitbuckets (git only)</value>
+    <value>After creation, goto Google CSR page to mirror repository from GitHub or Gitbuckets (git only).</value>
     <comment>Caption for checkbox that asks to goto CSR page after repo is created</comment>
   </data>
-  <data name="CsrCreateRepoNameValidationMessage" xml:space="preserve">
+  <data name="CsrRepoNameValidationMessage" xml:space="preserve">
     <value>Supported characters are A-Z, a-z, 0-9, -, and _</value>
     <comment>Repo name validation error message</comment>
   </data>
@@ -2746,5 +2746,9 @@
   <data name="CsrRepoNameStartWithMessageFormat" xml:space="preserve">
     <value>Repo name must start with A-Z, a-z, 0-9 or _</value>
     <comment>Repository name first charactor validation message.</comment>
-  </data>  
+  </data>
+  <data name="CsrCreateWindowTitle" xml:space="preserve">
+    <value>Create Google Cloud Source Repositories</value>
+    <comment>The title to create CSR Repository window</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2728,14 +2728,14 @@
     <comment>Message when loading repositories</comment>
   </data>
   <data name="CsrCreateMirrorAfterPublish" xml:space="preserve">
-    <value>After creation, goto Google CSR page to mirror repository from GitHub or Gitbuckets (git only).</value>
+    <value>After creation, goto GCP console to mirror repository from GitHub or Gitbuckets (git only).</value>
     <comment>Caption for checkbox that asks to goto CSR page after repo is created</comment>
   </data>
   <data name="CsrRepoNameValidationMessage" xml:space="preserve">
     <value>Supported characters are A-Z, a-z, 0-9, -, and _</value>
     <comment>Repo name validation error message</comment>
   </data>
-  <data name="CsrCreateRepoNameTextBoxLebel" xml:space="preserve">
+  <data name="CsrCreateRepoNameTextBoxLabel" xml:space="preserve">
     <value>Repository name</value>
     <comment>Label to repository name input text box</comment>
   </data>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2739,10 +2739,6 @@
     <value>Repository name</value>
     <comment>Label to repository name input text box</comment>
   </data>
-  <data name="CsrRepoNameAlreadyExitstsMessage" xml:space="preserve">
-    <value>The repository name already exists</value>
-    <comment>Validation message tells that the input repository name already exists.</comment>
-  </data>
   <data name="CsrRepoNameStartWithMessageFormat" xml:space="preserve">
     <value>Repo name must start with A-Z, a-z, 0-9 or _</value>
     <comment>Repository name first charactor validation message.</comment>


### PR DESCRIPTION
![create-dialog](https://user-images.githubusercontent.com/22829476/27468069-5903e158-579c-11e7-874d-07e7f828854c.png)

CsrCloneWindowViewModel.cs logic is not changed.  Majority code is moved to CsrCloneCreateViewModelBase.cs  so that CsrCreateWindowViewModel.cs share some common code.
