### PR TITLE
Master gcs browser ui feedback

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
@@ -8,6 +8,7 @@
              xmlns:utils="clr-namespace:GoogleCloudExtension.Utils;assembly=GoogleCloudExtension.Utils"
              xmlns:mb="clr-namespace:GoogleCloudExtension.Extensions"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
              Background="{DynamicResource VsBrush.Window}"
              Foreground="{DynamicResource VsBrush.WindowText}"
              Padding="5"
@@ -27,6 +28,53 @@
             <CollectionViewSource x:Key="cvs" Source="{Binding CurrentState.Items}" />
 
             <utils:VisibilityConverter x:Key="commonVisibilityConverter" />
+
+            <!-- Custom style for the row to customize selection code and behavior. -->
+            <Style x:Key="HighlightRowStyle" TargetType="{x:Type DataGridRow}">
+                <EventSetter Event="FrameworkElement.ContextMenuOpening" Handler="DataGrid_RowContextMenuOpening" />
+                <EventSetter Event="UIElement.PreviewMouseRightButtonDown" Handler="DataGrid_RowRightClickPreview" />
+
+                <Style.Triggers>
+                    <!-- The Alternation Background must be set here when IsMouseOver trigger is defined. -->
+                    <Trigger Property="AlternationIndex" Value="1">
+                        <Setter Property="Background" Value="#F5F5F5"/>
+                    </Trigger>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="#FFFFD6" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            
+            <!-- Cell style to modify the selection colors. -->
+            <Style x:Key="HighlightCellStyle" TargetType="{x:Type DataGridCell}">
+                <Style.Triggers>
+                    <!-- Focussed on the cell. -->
+                    <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static DataGrid.FocusBorderBrushKey}}"/>
+                    </Trigger>
+
+                    <!-- Selected and focused. -->
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.StartPageSelectedItemBackgroundKey}}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.StartPageSelectedItemBackgroundKey}}"/>
+                    </Trigger>
+
+                    <!-- Trigger for the case the row is selected but not foccused. -->
+                    <MultiTrigger>
+                        <MultiTrigger.Conditions>
+                            <Condition Property="IsSelected" Value="true"/>
+                            <Condition Property="Selector.IsSelectionActive" Value="false"/>
+                        </MultiTrigger.Conditions>
+                        <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.FileTabInactiveDocumentBorderBackgroundKey}}"/>
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.FileTabInactiveDocumentBorderBackgroundKey}}"/>
+                    </MultiTrigger>
+
+                    <!-- Disabled. -->
+                    <Trigger Property="IsEnabled" Value="false">
+                        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -99,7 +147,7 @@
                 </Button.ToolTip>
                 <Image Source="{mb:ImageResource GcsFileBrowser/Resources/file_upload.png}" />
             </Button>
-            
+
             <!-- The create new folder button. -->
             <Button Command="{Binding NewFolderCommand}"
                     Margin="10,0,0,0"
@@ -149,23 +197,10 @@
                   AlternationCount="2"
                   utils:ControlBehaviors.DoubleClickCommand="{Binding DoubleClickCommand}"
                   utils:ControlBehaviors.DoubleClickCommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource Self}}"
-                  SelectionChanged="OnDataGridSelectionChanged">
-            <DataGrid.RowStyle>
-                <Style TargetType="{x:Type DataGridRow}">
-                    <EventSetter Event="DataGridRow.ContextMenuOpening" Handler="DataGrid_RowContextMenuOpening" />
-                    <EventSetter Event="DataGridRow.PreviewMouseRightButtonDown" Handler="DataGrid_RowRightClickPreview" />
-                    <Style.Triggers>
-                        <!-- The Alternation Background must be set here when IsMouseOver trigger is defined. -->
-                        <Trigger Property="AlternationIndex" Value="1">
-                            <Setter Property="Background" Value="#F5F5F5"/>
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#FFFFD6" />
-                        </Trigger>
-                    </Style.Triggers>
-                </Style>
-            </DataGrid.RowStyle>            
-            
+                  SelectionChanged="OnDataGridSelectionChanged"
+                  RowStyle="{StaticResource HighlightRowStyle}"
+                  CellStyle="{StaticResource HighlightCellStyle}">
+
             <DataGrid.Columns>
                 <DataGridTemplateColumn Header="{x:Static ext:Resources.GcsFileBrowserNameHeader}"
                                         SortMemberPath="LeafName"

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
@@ -129,7 +129,7 @@
                                 </Hyperlink>
                             </TextBlock>
                             <TextBlock Text="/"
-                                       Style="{StaticResource CommonTextStyle}"
+                                       Style="{StaticResource DynamicColorTextStyle}"
                                        Margin="10,0,0,0"/>
                         </StackPanel>
                     </DataTemplate>
@@ -223,7 +223,7 @@
                                 <TextBlock Text="{Binding LeafName}"
                                            TextTrimming="CharacterEllipsis"
                                            TextWrapping="NoWrap"
-                                           Style="{StaticResource CommonTextStyle}" />
+                                           Style="{StaticResource DynamicColorTextStyle}" />
                             </StackPanel>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -237,7 +237,7 @@
                             <TextBlock Text="{Binding FormattedSize}"
                                        TextTrimming="CharacterEllipsis"
                                        TextWrapping="NoWrap"
-                                       Style="{StaticResource CommonTextStyle}" />
+                                       Style="{StaticResource DynamicColorTextStyle}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
@@ -250,7 +250,7 @@
                             <TextBlock Text="{Binding LastModified}"
                                        TextTrimming="CharacterEllipsis"
                                        TextWrapping="NoWrap"
-                                       Style="{StaticResource CommonTextStyle}" />
+                                       Style="{StaticResource DynamicColorTextStyle}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
@@ -263,7 +263,7 @@
                             <TextBlock Text="{Binding ContentType}"
                                        TextTrimming="CharacterEllipsis"
                                        TextWrapping="NoWrap"
-                                       Style="{StaticResource CommonTextStyle}" />
+                                       Style="{StaticResource DynamicColorTextStyle}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
@@ -57,6 +57,7 @@
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.StartPageSelectedItemBackgroundKey}}"/>
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.StartPageSelectedItemBackgroundKey}}"/>
+                        <Setter Property="Foreground" Value="White" />
                     </Trigger>
 
                     <!-- Trigger for the case the row is selected but not foccused. -->
@@ -67,6 +68,7 @@
                         </MultiTrigger.Conditions>
                         <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.FileTabInactiveDocumentBorderBackgroundKey}}"/>
                         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.FileTabInactiveDocumentBorderBackgroundKey}}"/>
+                        <Setter Property="Foreground" Value="White" />
                     </MultiTrigger>
 
                     <!-- Disabled. -->

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
@@ -145,6 +145,8 @@
                   ContextMenu="{Binding ContextMenu}"
                   ContextMenuOpening="DataGrid_ContextMenuOpening"
                   ItemsSource="{Binding Source={StaticResource cvs}}"
+                  GridLinesVisibility="None"
+                  AlternationCount="2"
                   utils:ControlBehaviors.DoubleClickCommand="{Binding DoubleClickCommand}"
                   utils:ControlBehaviors.DoubleClickCommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource Self}}"
                   SelectionChanged="OnDataGridSelectionChanged">
@@ -152,6 +154,15 @@
                 <Style TargetType="{x:Type DataGridRow}">
                     <EventSetter Event="DataGridRow.ContextMenuOpening" Handler="DataGrid_RowContextMenuOpening" />
                     <EventSetter Event="DataGridRow.PreviewMouseRightButtonDown" Handler="DataGrid_RowRightClickPreview" />
+                    <Style.Triggers>
+                        <!-- The Alternation Background must be set here when IsMouseOver trigger is defined. -->
+                        <Trigger Property="AlternationIndex" Value="1">
+                            <Setter Property="Background" Value="#F5F5F5"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#FFFFD6" />
+                        </Trigger>
+                    </Style.Triggers>
                 </Style>
             </DataGrid.RowStyle>            
             

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileBrowser/GcsFileBrowserWindowControl.xaml
@@ -35,10 +35,10 @@
                 <EventSetter Event="UIElement.PreviewMouseRightButtonDown" Handler="DataGrid_RowRightClickPreview" />
 
                 <Style.Triggers>
-                    <!-- The Alternation Background must be set here when IsMouseOver trigger is defined. -->
                     <Trigger Property="AlternationIndex" Value="1">
                         <Setter Property="Background" Value="#F5F5F5"/>
                     </Trigger>
+                    
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Background" Value="#FFFFD6" />
                     </Trigger>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -12,7 +12,6 @@
 
     <!-- Text style. -->
     <Style x:Key="CommonTextStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type TextBlock}">
-        <Setter Property="Foreground" Value="Black" />
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
     

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -12,9 +12,15 @@
 
     <!-- Text style. -->
     <Style x:Key="CommonTextStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type TextBlock}">
+        <Setter Property="Foreground" Value="Black" />
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
-    
+
+    <!-- This style is to be used on TextBlocks that are to have dynamic colors. -->
+    <Style x:Key="DynamicColorTextStyle" BasedOn="{StaticResource CommonTextStyleBase}" TargetType="{x:Type TextBlock}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+
     <!-- Large text style. -->
     <Style x:Key="CommonTextStyleLarge" BasedOn="{StaticResource CommonTextStyle}" TargetType="{x:Type TextBlock}">
         <Setter Property="TextElement.FontSize" Value="20px" />


### PR DESCRIPTION
Updated the UI to better mach the feedback given recently about grids. This PR brings the `DataGrid` used in the GCS browser more inline with how the `DataGrid` is used in other parts of the UI.

In particular this PR adds alternating columns, removes borders and updates the selection (active and inactive) to better match the UI.

<img width="956" alt="screen shot 2017-07-06 at 2 00 13 pm" src="https://user-images.githubusercontent.com/9807532/27932695-8f46fba8-6253-11e7-83f5-50dbc656e267.png">
