### PR TITLE
Master fixing bug 773 and 776

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using GoogleCloudExtension.Deployment;
+using GoogleCloudExtension.PublishDialog;
 using GoogleCloudExtension.SolutionUtils;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Shell;
@@ -161,7 +162,7 @@ namespace GoogleCloudExtension.GenerateConfigurationCommand
 
             // Ensure that the menu entry is only available for ASP.NET Core projects.
             var selectedProject = SolutionHelper.CurrentSolution.SelectedProject;
-            if (selectedProject == null || selectedProject.ProjectType != KnownProjectTypes.NetCoreWebApplication1_0)
+            if (selectedProject == null || PublishDialogWindow.CanPublish(selectedProject))
             {
                 menuCommand.Visible = false;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
@@ -162,7 +162,7 @@ namespace GoogleCloudExtension.GenerateConfigurationCommand
 
             // Ensure that the menu entry is only available for ASP.NET Core projects.
             var selectedProject = SolutionHelper.CurrentSolution.SelectedProject;
-            if (selectedProject == null || PublishDialogWindow.CanPublish(selectedProject))
+            if (selectedProject == null || !PublishDialogWindow.CanPublish(selectedProject))
             {
                 menuCommand.Visible = false;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Properties/AssemblyInfo.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 
 // This version number matches the version in the .vsixmanifest. Please update both versions at the
 // same time.
-[assembly: AssemblyVersion("1.2.7.0")]
+[assembly: AssemblyVersion("1.2.8.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo(
     "GoogleCloudExtensionUnitTests," +

--- a/GoogleCloudExtension/GoogleCloudExtension/VsVersion/VS15/ToolsPathProvider.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/VsVersion/VS15/ToolsPathProvider.cs
@@ -41,7 +41,10 @@ namespace GoogleCloudExtension.VsVersion.VS15
 
         public string GetExternalToolsPath()
         {
-            return "";
+            var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            var result = Path.Combine(programFilesPath, $@"Microsoft Visual Studio\2017\{_edition}\Web\External");
+            GcpOutputWindow.OutputDebugLine($"External tools path: {result}");
+            return result;
         }
 
         public string GetMsbuildPath()

--- a/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
+++ b/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     The Version attribute of the Identity element *must* match the version number in Properties\AssemblyInfo.cs, to ensure 
     accurate metrics.
     -->
-    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="1.2.7.0" Language="en-US" Publisher="Google Inc." />
+    <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="1.2.8.0" Language="en-US" Publisher="Google Inc." />
     <DisplayName>Google Cloud Tools for Visual Studio</DisplayName>
     <Description xml:space="preserve">Tools to develop applications for Google Cloud Platform.</Description>
     <MoreInfo>https://cloud.google.com/visual-studio/</MoreInfo>


### PR DESCRIPTION
This PR fixes #773 by ensuring that the "Generate app.yaml and Dockerfile" context menu option checks the same set of .NET Core versions as the publish dialog.

This PR fixes #776 by adding code to provide the external tool paths for VS 2017.

This PR also increments the version of the extension to v1.2.7.0.