### PR TITLE
Use .NET Core SDK version 1.0.0-preview2-003131.

### DIFF
--- a/GoogleCloudExtension/ProjectTemplates/GoogleAspNetCoreMvc/global.json
+++ b/GoogleCloudExtension/ProjectTemplates/GoogleAspNetCoreMvc/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "1.0.0-preview2-003156"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/GoogleCloudExtension/ProjectTemplates/GoogleAspNetCoreWebApi/global.json
+++ b/GoogleCloudExtension/ProjectTemplates/GoogleAspNetCoreWebApi/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "1.0.0-preview2-003156"
+    "version": "1.0.0-preview2-003131"
   }
 }


### PR DESCRIPTION
For issue #762:
Move back .NET Core SDK version in *global.json* to `1.0.0-preview2-003131`, the version installed by the **.NET Core SDK for Visual Studio 2015**.