### PR TITLE
Remove the creation of a complex cloudbuild.yaml when a simpler Dockerfile suffices.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CloudBuilderUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CloudBuilderUtils.cs
@@ -24,36 +24,13 @@ namespace GoogleCloudExtension.Deployment
     internal static class CloudBuilderUtils
     {
         /// <summary>
-        /// The template to produce a cloudbuild.yaml file to build an image using the the container builder.
-        /// </summary>
-        private const string CloudBuildFileContent =
-           "steps:\n" +
-            "- name: gcr.io/cloud-builders/docker\n" +
-            "  args: [ 'build', '-t', '{0}', '--no-cache', '--pull', '.' ]\n" +
-            "images:\n" +
-            "  ['{0}']\n";
-
-        /// <summary>
-        /// Creates a cloudbuild.yaml for the given <paramref name="imageName"/> in the given <paramref name="project"/>.
+        /// Creates the Docker image tag with the given parameters.
         /// </summary>
         /// <param name="project">The project on which the image should be built.</param>
         /// <param name="imageName">The name of the image to build.</param>
         /// <param name="imageVersion">The version tag to use.</param>
-        /// <param name="buildFilePath">Where to store the produced build file.</param>
         /// <returns>The tag to identify the image to be built.</returns>
-        internal static string CreateBuildFile(string project, string imageName, string imageVersion, string buildFilePath)
-        {
-            var tag = GetDeploymentTag(
-                project: project,
-                imageName: imageName,
-                imageVersion: imageVersion);
-            Debug.WriteLine($"Creating build file for tag {tag} at {buildFilePath}");
-            var content = String.Format(CloudBuildFileContent, tag);
-            File.WriteAllText(buildFilePath, content);
-            return tag;
-        }
-
-        private static string GetDeploymentTag(string project, string imageName, string imageVersion)
+        internal static string GetImageTag(string project, string imageName, string imageVersion)
             => $"gcr.io/{project}/{imageName}:{imageVersion}";
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GkeDeployment.cs
@@ -114,11 +114,8 @@ namespace GoogleCloudExtension.Deployment
 
             using (var cleanup = new Disposable(() => CommonUtils.Cleanup(stageDirectory)))
             {
-                var appRootPath = Path.Combine(stageDirectory, "app");
-                var buildFilePath = Path.Combine(stageDirectory, "cloudbuild.yaml");
-
                 if (!await ProgressHelper.UpdateProgress(
-                        NetCoreAppUtils.CreateAppBundleAsync(project, appRootPath, toolsPathProvider, outputAction),
+                        NetCoreAppUtils.CreateAppBundleAsync(project, stageDirectory, toolsPathProvider, outputAction),
                         progress,
                         from: 0.1, to: 0.3))
                 {
@@ -126,7 +123,7 @@ namespace GoogleCloudExtension.Deployment
                     return null;
                 }
 
-                NetCoreAppUtils.CopyOrCreateDockerfile(project, appRootPath);
+                NetCoreAppUtils.CopyOrCreateDockerfile(project, stageDirectory);
                 var imageTag = CloudBuilderUtils.GetImageTag(
                     project: options.GCloudContext.ProjectId,
                     imageName: options.DeploymentName,
@@ -135,7 +132,7 @@ namespace GoogleCloudExtension.Deployment
                 if (!await ProgressHelper.UpdateProgress(
                     GCloudWrapper.BuildContainerAsync(
                         imageTag: imageTag,
-                        contentsPath: appRootPath,
+                        contentsPath: stageDirectory,
                         outputAction: outputAction,
                         context: options.GCloudContext),
                     progress,

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -134,14 +134,14 @@ namespace GoogleCloudExtension.GCloud
         /// <summary>
         /// Builds a container using the Container Builder service.
         /// </summary>
-        /// <param name="buildFilePath">The path to the cloudbuild.yaml file.</param>
-        /// <param name="contentsPath">The contents of the container.</param>
+        /// <param name="imageTag">The name of the image to build.</param>
+        /// <param name="contentsPath">The contents of the container, including the Dockerfile.</param>
         /// <param name="outputAction">The action to perform on each line of output.</param>
         /// <param name="context">The context under which the command is executed.</param>
-        public static Task<bool> BuildContainerAsync(string buildFilePath, string contentsPath, Action<string> outputAction, GCloudContext context)
+        public static Task<bool> BuildContainerAsync(string imageTag, string contentsPath, Action<string> outputAction, GCloudContext context)
         {
             return RunCommandAsync(
-                $"container builds submit --config=\"{buildFilePath}\" \"{contentsPath}\"",
+                $"container builds submit --tag=\"{imageTag}\" \"{contentsPath}\"",
                 outputAction,
                 context);
         }


### PR DESCRIPTION
When we build a Docker image to be deployed to GKE we create a `cloudbuild.yaml` file that only builds the image by invoking `docker build` on the existing `Dockerfile`. As it turns out `gcloud` already supports this directly. Instead of generating the `cloudbuild.yaml` we can invoke `gcloud` like this:
```bash
gcloud container builds submit --tag={name of the tag} {path to the published app}
```
This will accomplish the same, building the Docker image for the app, with less complexity.

Fixes #591 