### PR TITLE
Master removing beta dependency

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GoogleCloudExtension.GCloud
+﻿namespace GoogleCloudExtension.GCloud
 {
     /// <summary>
     /// This enum describe the well known components for gcloud.

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
@@ -28,7 +28,6 @@ namespace GoogleCloudExtension.GCloud
         /// The beta component, contains the beta features for gcloud, only depend on this if
         /// absolutely necessary as things change rapidly.
         /// </summary>
-
         Beta,
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
@@ -1,4 +1,18 @@
-﻿namespace GoogleCloudExtension.GCloud
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GoogleCloudExtension.GCloud
 {
     /// <summary>
     /// This enum describe the well known components for gcloud.

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudComponent.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.GCloud
+{
+    /// <summary>
+    /// This enum describe the well known components for gcloud.
+    /// </summary>
+    public enum GCloudComponent
+    {
+        /// <summary>
+        /// Placeholder for no component.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The beta component, contains the beta features for gcloud, only depend on this if
+        /// absolutely necessary as things change rapidly.
+        /// </summary>
+
+        Beta,
+
+        /// <summary>
+        /// The kubectl component, which installs the necessary tools to work with Kubernetes clusters.
+        /// </summary>
+        Kubectl,
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -41,6 +41,7 @@ namespace GoogleCloudExtension.GCloud
         // Minimum version of Cloud SDK that is acceptable.
         private static readonly Version s_minimumVersion = new Version(GCloudSdkMinimumVersion);
 
+        // Mapping between the enum and the actual gcloud component.
         private static readonly Dictionary<GCloudComponent, string> s_componentNames = new Dictionary<GCloudComponent, string>
         {
             [ GCloudComponent.Beta ] = "beta",

--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GoogleCloudExtension.GCloud.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GoogleCloudExtension.GCloud.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommonEnvironmentVariables.cs" />
+    <Compile Include="GCloudComponent.cs" />
     <Compile Include="GCloudValidationResult.cs" />
     <Compile Include="Models\CloudSdkVersions.cs" />
     <Compile Include="Models\GkeDeployment.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -102,7 +102,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             var project = _publishDialog.Project;
             try
             {
-                var verifyGcloudTask = GCloudWrapperUtils.VerifyGCloudDependencies("beta");
+                var verifyGcloudTask = GCloudWrapperUtils.VerifyGCloudDependencies();
                 _publishDialog.TrackTask(verifyGcloudTask);
                 if (!await verifyGcloudTask)
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -231,7 +231,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             {
                 ShellUtils.SaveAllFiles();
 
-                var verifyGCloudTask = GCloudWrapperUtils.VerifyGCloudDependencies("kubectl");
+                var verifyGCloudTask = GCloudWrapperUtils.VerifyGCloudDependencies(GCloudComponent.Kubectl);
                 _publishDialog.TrackTask(verifyGCloudTask);
                 if (!await verifyGCloudTask)
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GCloudWrapperUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GCloudWrapperUtils.cs
@@ -25,9 +25,9 @@ namespace GoogleCloudExtension.Utils
         /// Verify that the Cloud SDK is installed and at the right version. Optionally also verify that the given
         /// component is installed.
         /// </summary>
-        /// <param name="component">The name of the component to check, optional.</param>
+        /// <param name="component">The component to check, optional.</param>
         /// <returns>True if the Cloud SDK installation is valid.</returns>
-        public static async Task<bool> VerifyGCloudDependencies(string component = null)
+        public static async Task<bool> VerifyGCloudDependencies(GCloudComponent component = GCloudComponent.None)
         {
             var result = await GCloudWrapper.ValidateGCloudAsync(component);
             if (result.IsValid)


### PR DESCRIPTION
Removing the dependency on the `beta` component from `gcloud`. This PR also refactors a bit how the check for components is done, instead of using the string with the name we will now use an `enum` which will check that we're using a valid component name.
