### PR TITLE
Automatic code cleanup.

### DIFF
--- a/GoogleCloudExtension/GoogleAnalyticsUtils/HitSender.cs
+++ b/GoogleCloudExtension/GoogleAnalyticsUtils/HitSender.cs
@@ -59,7 +59,7 @@ namespace GoogleAnalyticsUtils
             }
             catch (Exception ex) when (
                 ex is HttpRequestException ||
-                ex is TaskCanceledException )   // timeout
+                ex is TaskCanceledException)   // timeout
             { }
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/DataSourceUnitTestsBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/DataSourceUnitTestsBase.cs
@@ -102,7 +102,6 @@ namespace GoogleCloudExtension.DataSources.UnitTests
             where TResource : class
             where TRequest : ClientServiceRequest<TResponse>
         {
-
             IClientService clientService = GetMockedClientService<TRequest, TResponse>(responses);
             TRequest request = GetMockedRequest<TRequest, TResponse>(requestExpression, clientService);
 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,18 @@
-﻿using System.Reflection;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("GoogleCloudExtension.DataSources.UnitTests")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyCopyright("Copyright \u00A9  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/CsrDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/CsrDataSource.cs
@@ -52,7 +52,7 @@ namespace GoogleCloudExtension.DataSources
                 },
                 x => x.Repos,
                 x => x.NextPageToken);
-        }           
+        }
 
         /// <summary>
         /// Creates a cloud source repository.

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ResourceManagerDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ResourceManagerDataSource.cs
@@ -56,7 +56,8 @@ namespace GoogleCloudExtension.DataSources
         internal ResourceManagerDataSource(
             GoogleCredential credential,
             Func<BaseClientService.Initializer, CloudResourceManagerService> factory,
-            string appName) : base(credential, factory, appName) { }
+            string appName) : base(credential, factory, appName)
+        { }
 
         /// <summary>
         /// Returns the complete list of projects for the current credentials.

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/CloudBuilderUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/CloudBuilderUtils.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Diagnostics;
-using System.IO;
 
 namespace GoogleCloudExtension.Deployment
 {

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -32,9 +32,9 @@ namespace GoogleCloudExtension.Deployment
         // The mapping of supported .NET Core versions to the base images to use for the Docker image.
         private static readonly Dictionary<KnownProjectTypes, string> s_knownRuntimeImages = new Dictionary<KnownProjectTypes, string>
         {
-            [ KnownProjectTypes.NetCoreWebApplication1_0 ] = "gcr.io/google-appengine/aspnetcore:1.0",
-            [ KnownProjectTypes.NetCoreWebApplication1_1 ] = "gcr.io/google-appengine/aspnetcore:1.1",
-            [ KnownProjectTypes.NetCoreWebApplication2_0 ] = "gcr.io/google-appengine/aspnetcore:2.0"
+            [KnownProjectTypes.NetCoreWebApplication1_0] = "gcr.io/google-appengine/aspnetcore:1.0",
+            [KnownProjectTypes.NetCoreWebApplication1_1] = "gcr.io/google-appengine/aspnetcore:1.1",
+            [KnownProjectTypes.NetCoreWebApplication2_0] = "gcr.io/google-appengine/aspnetcore:2.0"
         };
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.GitUtils/CsrGitUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GitUtils/CsrGitUtils.cs
@@ -15,8 +15,8 @@
 using GoogleCloudExtension.Utils;
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.GitUtils

--- a/GoogleCloudExtension/GoogleCloudExtension.GitUtils/CsrGitUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GitUtils/CsrGitUtils.cs
@@ -72,8 +72,8 @@ namespace GoogleCloudExtension.GitUtils
         /// Otherwise false.
         /// </returns>
         public static bool StoreCredential(
-            string url, 
-            string refreshToken, 
+            string url,
+            string refreshToken,
             StoreCredentialPathOption pathOption)
         {
             url.ThrowIfNullOrEmpty(nameof(url));
@@ -81,7 +81,7 @@ namespace GoogleCloudExtension.GitUtils
 
             Uri uri = new Uri(url);
             UriPartial uriPartial;
-            switch(pathOption)
+            switch (pathOption)
             {
                 case StoreCredentialPathOption.UrlPath:
                     uriPartial = UriPartial.Path;
@@ -90,7 +90,7 @@ namespace GoogleCloudExtension.GitUtils
                     uriPartial = UriPartial.Authority;
                     break;
                 default:
-                    throw new  ArgumentException(nameof(pathOption));
+                    throw new ArgumentException(nameof(pathOption));
             }
             return WindowsCredentialManager.Write(
                 $"git:{uri.GetLeftPart(uriPartial)}",

--- a/GoogleCloudExtension/GoogleCloudExtension.GitUtils/GitRepository.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GitUtils/GitRepository.cs
@@ -99,7 +99,7 @@ namespace GoogleCloudExtension.GitUtils
         /// Returns true if the git repository contains the git SHA revision.
         /// </summary>
         /// <param name="sha">The Git SHA.</param>
-        public async Task<bool> ContainsCommitAsync(string sha) => 
+        public async Task<bool> ContainsCommitAsync(string sha) =>
             (await ExecCommandAsync($"cat-file -t {sha}"))?.FirstOrDefault() == "commit";
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace GoogleCloudExtension.GitUtils
         /// </returns>
         public static async Task<bool> IsGitCredentialManagerInstalledAsync() =>
             (await GitRepository.RunGitCommandAsync(
-                "credential-manager version", 
+                "credential-manager version",
                 Directory.GetCurrentDirectory(),
                 throwOnError: false)) != null;
 

--- a/GoogleCloudExtension/GoogleCloudExtension.Interop/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Interop/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("GoogleCloudExtension.Interop")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyCopyright("Copyright \u00A9  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/PowerShellFailedToConnectException.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/PowerShellFailedToConnectException.cs
@@ -21,10 +21,10 @@ namespace GoogleCloudExtension.PowerShellUtils
         /// <summary>
         /// This error message indicates it fails to establish connection.
         /// </summary>
-        public const string SessionEmptyErrorMessage = 
+        public const string SessionEmptyErrorMessage =
             @"Cannot validate argument on parameter 'Session'. The argument is null or empty.";
 
-        public PowerShellFailedToConnectException(Exception innerException) : 
+        public PowerShellFailedToConnectException(Exception innerException) :
             base(innerException.Message, innerException)
         { }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/Properties/AssemblyInfo.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/RemoteToolInstaller.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/RemoteToolInstaller.cs
@@ -81,7 +81,7 @@ namespace GoogleCloudExtension.PowerShellUtils
                 return await target.ExecuteAsync(AddInstallCommands, cancelToken);
             }
             catch (Exception ex) when (
-                ex is ParameterBindingException && 
+                ex is ParameterBindingException &&
                 ex.Message.Contains(PowerShellFailedToConnectException.SessionEmptyErrorMessage))
             {
                 throw new PowerShellFailedToConnectException(ex);

--- a/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension.v14/Section.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension.v14/Section.cs
@@ -30,7 +30,7 @@ namespace GoogleCloudExtension.TeamExplorerExtension
     {
         private const string Guid = "2625FA1D-22DD-440E-87C0-1EB42DB7C5A4";
 
-        private ISectionViewModel _viewModel;
+        private readonly ISectionViewModel _viewModel;
         private IServiceProvider _serviceProvider;
         private TeamExplorerUtils _teamExploerServices;
         private bool _isBusy;

--- a/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension.v14/Section.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension.v14/Section.cs
@@ -15,8 +15,8 @@
 using GoogleCloudExtension.Utils;
 using Microsoft.TeamFoundation.Controls;
 using System;
-using System.Diagnostics;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 
 namespace GoogleCloudExtension.TeamExplorerExtension
 {

--- a/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension.v14/TeamExplorerUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension.v14/TeamExplorerUtils.cs
@@ -71,10 +71,10 @@ namespace GoogleCloudExtension.TeamExplorerExtension
 
         public void ShowError(string message) =>
             NotificationManager?.ShowNotification(
-                message, 
-                NotificationType.Error, 
-                NotificationFlags.RequiresConfirmation, 
-                null, 
+                message,
+                NotificationType.Error,
+                NotificationFlags.RequiresConfirmation,
+                null,
                 default(Guid));
 
         #endregion

--- a/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension/ISectionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TeamExplorerExtension/ISectionViewModel.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 
 namespace GoogleCloudExtension.TeamExplorerExtension
 {

--- a/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/GoogleProjectTemplateSelectorWizard.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/GoogleProjectTemplateSelectorWizard.cs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 namespace GoogleCloudExtension.TemplateWizards
 {
     /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/GoogleProjectTemplateWizard.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/GoogleProjectTemplateWizard.cs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 namespace GoogleCloudExtension.TemplateWizards
 {
     /// <summary>
@@ -19,5 +20,5 @@ namespace GoogleCloudExtension.TemplateWizards
     /// of problems loading wizards from MEF component assemblies.
     /// </summary>
     public class GoogleProjectTemplateWizard : DelegatingTemplateWizard<IGoogleProjectTemplateWizard>
-    {}
+    { }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Google Inc.")]
 [assembly: AssemblyProduct("TemplateWizards")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyCopyright("Copyright \u00A9  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils.UnitTests/ProcessUtilsTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils.UnitTests/ProcessUtilsTests.cs
@@ -1,4 +1,18 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/Async/AsyncPropertyUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/Async/AsyncPropertyUtils.cs
@@ -33,7 +33,7 @@ namespace GoogleCloudExtension.Utils.Async
             Task<TIn> valueSource, Func<TIn, T> func, T defaultValue = default(T))
         {
             return new AsyncProperty<T>(
-                valueSource.ContinueWith(t => func(GetTaskResultSafe(t))), 
+                valueSource.ContinueWith(t => func(GetTaskResultSafe(t))),
                 defaultValue);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension.Utils/WindowsCredentialManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Utils/WindowsCredentialManager.cs
@@ -72,7 +72,6 @@ namespace GoogleCloudExtension.Utils
                 Marshal.FreeCoTaskMem(credential.CredentialBlob);
                 Marshal.FreeCoTaskMem(credential.UserName);
             }
-
         }
 
         [DllImport("Advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/CurrentAccountProjectSettings.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/CurrentAccountProjectSettings.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using GoogleCloudExtension.SolutionUtils;
 using System;
 using System.Diagnostics;
-using GoogleCloudExtension.SolutionUtils;
 
 namespace GoogleCloudExtension.Accounts
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/GcsFileBrowserNewFolderEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/GcsFileBrowserNewFolderEvent.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace GoogleCloudExtension.Analytics.Events
 {
-    class GcsFileBrowserNewFolderEvent
+    internal class GcsFileBrowserNewFolderEvent
     {
         private const string GcsFileGcsFileBrowserNewFolderEventName = "gcsFileBrowserNewFolder";
         private const string DeploymentDurationProperty = "duration";

--- a/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/PubSubSubscriptionCreatedEvent.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Analytics/Events/PubSubSubscriptionCreatedEvent.cs
@@ -24,6 +24,5 @@ namespace GoogleCloudExtension.Analytics.Events
                 PubSubSubscriptionCreatedEventName,
                 CommandStatusUtils.StatusProperty, CommandStatusUtils.GetStatusString(status));
         }
-
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerFirewallPort.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerFirewallPort.cs
@@ -31,7 +31,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
     /// </summary>
     public class AttachDebuggerFirewallPort
     {
-        private static readonly TimeSpan ConnectivityTestTimeout = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan s_connectivityTestTimeout = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan s_firewallRuleWaitMaxTime = TimeSpan.FromMinutes(5);
         private readonly Lazy<GceDataSource> _lazyDataSource;
         private Instance _gceInstance;
@@ -122,7 +122,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
                 .SelectMany(x => x.Allowed)
                 // x is now FireWall.AllowedData
                 // Check if the allowed protocol is tcp
-                .Where(x => x?.IPProtocol == "tcp" && x.Ports != null)  
+                .Where(x => x?.IPProtocol == "tcp" && x.Ports != null)
                 .SelectMany(x => x.Ports)
                 // x is now port number in string type
                 // Check if the allowed port number matches
@@ -148,7 +148,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
                 try
                 {
                     var connectTask = client.ConnectAsync(_gceInstance.GetPublicIpAddress(), PortInfo.Port);
-                    if (connectTask == await Task.WhenAny(connectTask, Task.Delay(ConnectivityTestTimeout, cancelToken)))
+                    if (connectTask == await Task.WhenAny(connectTask, Task.Delay(s_connectivityTestTimeout, cancelToken)))
                     {
                         await connectTask;
                         Debug.WriteLine("ConnectivityTest, Succeeded");

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerSettings.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerSettings.cs
@@ -60,9 +60,9 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
     {
         private const int InstancesDefaultUserMaxLength = 10;
         private static readonly Lazy<AttachDebuggerSettings> s_instance = new Lazy<AttachDebuggerSettings>();
-        private static readonly Lazy<List<InstanceDefaultUser>> _lazyDefaultUsersList = 
+        private static readonly Lazy<List<InstanceDefaultUser>> s_lazyDefaultUsersList =
             new Lazy<List<InstanceDefaultUser>>(AttachDebuggerSettingsStore.ReadGceInstanceDefaultUsers);
-        private static List<InstanceDefaultUser> _defaultUsersList => _lazyDefaultUsersList.Value;
+        private static List<InstanceDefaultUser> _defaultUsersList => s_lazyDefaultUsersList.Value;
 
         /// <summary>
         /// Singleton instance.

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerSettingsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerSettingsStore.cs
@@ -27,7 +27,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
     {
         private const string SettingsPath = @"googlecloudvsextension\attach_debugger_dialog";
         private const string DefaultUsersSettingFile = @"gceinstace_default_user.cfg";
-        private static readonly string DefaultUsersSettingsFullPath 
+        private static readonly string s_defaultUsersSettingsFullPath
             = Path.Combine(GetStoragePath(), DefaultUsersSettingFile);
 
         /// <summary>
@@ -36,9 +36,9 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
         public static List<InstanceDefaultUser> ReadGceInstanceDefaultUsers()
         {
             List<InstanceDefaultUser> results = null;
-            if (File.Exists(DefaultUsersSettingsFullPath))
+            if (File.Exists(s_defaultUsersSettingsFullPath))
             {
-                string jsonText = File.ReadAllText(DefaultUsersSettingsFullPath);
+                string jsonText = File.ReadAllText(s_defaultUsersSettingsFullPath);
                 if (!string.IsNullOrWhiteSpace(jsonText))
                 {
                     try
@@ -62,7 +62,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
             {
                 Directory.CreateDirectory(GetStoragePath());
             }
-            File.WriteAllText(DefaultUsersSettingsFullPath, JsonConvert.SerializeObject(defaultUsers));
+            File.WriteAllText(s_defaultUsersSettingsFullPath, JsonConvert.SerializeObject(defaultUsers));
         }
 
         private static string GetStoragePath()

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerSettingsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerSettingsStore.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Newtonsoft.Json;
 using GoogleCloudExtension.Utils;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerStepBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerStepBase.cs
@@ -24,7 +24,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
     /// </summary>
     public abstract class AttachDebuggerStepBase : ViewModelBase, IAttachDebuggerStep
     {
-        private CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _cancellationTokenSource;
         private bool _isCancelButtonEnabled;
         private bool _isOKButtonEnabled;
         private bool _isCancelButtonVisible = true;

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/AttachDebuggerWindow.cs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Compute.v1.Data;
 using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.Analytics.Events;
 using GoogleCloudExtension.DataSources;
-using GoogleCloudExtension.Utils;
-using StringResources = GoogleCloudExtension.Resources;
-using Google.Apis.Compute.v1.Data;
 using GoogleCloudExtension.Theming;
+using GoogleCloudExtension.Utils;
 using System;
+using StringResources = GoogleCloudExtension.Resources;
 
 namespace GoogleCloudExtension.AttachDebuggerDialog
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/EnablePowerShellPortStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/EnablePowerShellPortStepViewModel.cs
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
                 // This is the second time, check connectivity with a longer wait time.
                 await ConnectivityTestUntillTimeout(waitTime) :
                 // This is the first time, we don't check "waitTime", test connectivity anyhow.
-                await port.ConnectivityTest(CancelToken);   
+                await port.ConnectivityTest(CancelToken);
             if (connected)
             {
                 return InstallStartRemoteToolStepViewModel.CreateStep(Context);

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/ListProcessStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/ListProcessStepViewModel.cs
@@ -17,7 +17,6 @@ using EnvDTE80;
 using GoogleCloudExtension.Analytics;
 using GoogleCloudExtension.Analytics.Events;
 using GoogleCloudExtension.Utils;
-using Shell = Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -25,6 +24,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Controls;
+using Shell = Microsoft.VisualStudio.Shell;
 
 namespace GoogleCloudExtension.AttachDebuggerDialog
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
@@ -22,6 +22,7 @@ using GoogleCloudExtension.CloudExplorerSources.PubSub;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.ManageAccounts;
 using GoogleCloudExtension.Utils;
+using GoogleCloudExtension.Utils.Async;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -30,7 +31,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Media;
-using GoogleCloudExtension.Utils.Async;
 
 namespace GoogleCloudExtension.CloudExplorer
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -147,7 +147,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 IsLoading = true;
                 Caption = String.Format(Resources.CloudExplorerGaeMigratingAllTrafficCaption, _version.Id);
 
-                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> { [_version.Id] = 1.0 } };
+                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> {[_version.Id] = 1.0 } };
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, _service.Id);
                 await _owner.DataSource.AwaitOperationAsync(operation);
                 _owner.InvalidateService(_service.Id);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/VersionViewModel.cs
@@ -147,7 +147,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 IsLoading = true;
                 Caption = String.Format(Resources.CloudExplorerGaeMigratingAllTrafficCaption, _version.Id);
 
-                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> {[_version.Id] = 1.0 } };
+                var split = new TrafficSplit { Allocations = new Dictionary<string, double?> { [_version.Id] = 1.0 } };
                 var operation = await _owner.DataSource.UpdateServiceTrafficSplitAsync(split, _service.Id);
                 await _owner.DataSource.AwaitOperationAsync(operation);
                 _owner.InvalidateService(_service.Id);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceInstanceViewModel.cs
@@ -99,7 +99,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             // To be safe and in case the constructor/initiailzation code could be modified in the future.
             if (_attachDebuggerCommand != null)
             {
-                _attachDebuggerCommand.CanExecuteCommand = 
+                _attachDebuggerCommand.CanExecuteCommand =
                     Instance.IsWindowsInstance() && Instance.IsRunning() && !ShellUtils.IsBusy();
             }
             base.OnMenuItemOpen();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/SubscriptionViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/SubscriptionViewModel.cs
@@ -116,7 +116,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
                             Resources.PubSubDeleteSubscriptionErrorMessage,
                             Resources.PubSubDeleteSubscriptionErrorHeader,
                             e.Message);
-
                     }
                     await _owner.Refresh();
                 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/AsyncRepositories.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/AsyncRepositories.cs
@@ -14,7 +14,6 @@
 
 using Google.Apis.CloudSourceRepositories.v1.Data;
 using GoogleCloudExtension.Utils;
-using GoogleCloudExtension.Utils.Async;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsAddRepoWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsAddRepoWindow.cs
@@ -14,9 +14,9 @@
 
 using Google.Apis.CloudResourceManager.v1.Data;
 using Google.Apis.CloudSourceRepositories.v1.Data;
-using StringResources = GoogleCloudExtension.Resources;
 using GoogleCloudExtension.Theming;
 using System.Collections.Generic;
+using StringResources = GoogleCloudExtension.Resources;
 
 namespace GoogleCloudExtension.CloudSourceRepositories
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrAddRepoWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrAddRepoWindowViewModel.cs
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         /// <summary>
         /// Add repo for the project message
         /// </summary>
-        public string AddRepoForProjectMessage => 
+        public string AddRepoForProjectMessage =>
             String.Format(Resources.CsrAddRepoForProjectMessageFormat, _project.Name);
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindow.cs
@@ -40,7 +40,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
     /// </summary>
     public class CsrCloneWindow : CommonDialogWindowBase
     {
-        private  CsrCloneWindowViewModel ViewModel { get; }
+        private CsrCloneWindowViewModel ViewModel { get; }
 
         private CsrCloneWindow(IList<Project> projects) : base(StringResources.CsrCloneWindowTitle)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindow.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using Google.Apis.CloudResourceManager.v1.Data;
-using StringResources = GoogleCloudExtension.Resources;
 using GoogleCloudExtension.Theming;
 using System.Collections.Generic;
+using StringResources = GoogleCloudExtension.Resources;
 
 namespace GoogleCloudExtension.CloudSourceRepositories
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrCloneWindowViewModel.cs
@@ -127,7 +127,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         /// Responds to create repo button click event
         /// </summary>
         public ProtectedCommand CreateRepoCommand { get; }
-        
+
         /// <summary>
         /// Gets a result of type <seealso cref="CloneDialogResult"/>.
         /// null inidcates no result is created, user cancelled the operation.
@@ -169,7 +169,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
                             .FirstOrDefault(x => x.Name == _latestCreatedRepo.Name);
                         if (SelectedRepository != null)
                         {
-                            break;  
+                            break;
                         }
                         // else if it is null, user may have changed project, continue to select first repo.
                     }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrGitSetupWarningViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrGitSetupWarningViewModel.cs
@@ -41,7 +41,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         public bool IsEnabled
         {
             get { return _isEnabled; }
-            private set { SetValueAndRaise(ref _isEnabled, value);  }
+            private set { SetValueAndRaise(ref _isEnabled, value); }
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
@@ -41,7 +41,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         /// This is to preserve the list when a new user control is created.
         /// Without doing so, user constantly sees the list of repos are loading without reasons.
         /// </summary>
-        private readonly static ObservableCollection<RepoItemViewModel> s_repoList 
+        private readonly static ObservableCollection<RepoItemViewModel> s_repoList
             = new ObservableCollection<RepoItemViewModel>();
         private static RepoItemViewModel s_activeRepo;
 
@@ -270,8 +270,8 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         }
 
         private async Task<Repo> TryGetCloudRepoAsync(
-            string url, 
-            string projectId, 
+            string url,
+            string projectId,
             Dictionary<string, IList<Repo>> projectReposMap)
         {
             IList<Repo> cloudRepos;

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrSectionControlViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrSectionControlViewModel.cs
@@ -184,7 +184,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         #endregion
 
         private async Task CheckGitInstallationAsync()
-        {            
+        {
             if (await _gitSetupViewModel.CheckInstallationAsync())
             {
                 OnGitInstallationCheckSuccess();

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
@@ -150,11 +150,11 @@ namespace GoogleCloudExtension
             if (_closingEvent != null)
             {
                 var tasks = new List<SystemTasks.Task>();
-                foreach(var handler in _closingEvent.GetInvocationList().OfType<EventHandler>())
+                foreach (var handler in _closingEvent.GetInvocationList().OfType<EventHandler>())
                 {
                     tasks.Add(SystemTasks.Task.Run(() => handler(this, EventArgs.Empty)));
                 };
- 
+
                 SystemTasks.Task.WaitAll(tasks.ToArray(), TimeSpan.FromMilliseconds(1000));
             }
             return base.QueryClose(out canClose);

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
@@ -22,6 +22,7 @@ using GoogleCloudExtension.GCloud;
 using GoogleCloudExtension.ManageWindowsCredentials;
 using GoogleCloudExtension.PublishDialog;
 using GoogleCloudExtension.Utils;
+using GoogleCloudExtension.Utils.Async;
 using GoogleCloudExtension.VsVersion;
 using System;
 using System.Collections.Generic;
@@ -29,7 +30,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
-using GoogleCloudExtension.Utils.Async;
 
 namespace GoogleCloudExtension.PublishDialogSteps.GceStep
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowCommand.cs
@@ -58,7 +58,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             {
                 var menuCommandID = new CommandID(CommandSet, CommandId);
                 var menuItem = new OleMenuCommand(
-                    (sender, e) => ToolWindowCommandUtils.ShowToolWindow<LogsViewerToolWindow>(),  menuCommandID);
+                    (sender, e) => ToolWindowCommandUtils.ShowToolWindow<LogsViewerToolWindow>(), menuCommandID);
                 menuItem.BeforeQueryStatus += ToolWindowCommandUtils.EnableMenuItemOnValidProjectId;
                 commandService.AddCommand(menuItem);
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdViewModel.cs
@@ -108,7 +108,8 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
         }
 
         public PickProjectIdViewModel(IPickProjectIdWindow owner)
-            : this(owner, DataSourceFactories.CreateResourceManagerDataSource, ManageAccountsWindow.PromptUser) { }
+            : this(owner, DataSourceFactories.CreateResourceManagerDataSource, ManageAccountsWindow.PromptUser)
+        { }
 
         /// <summary>
         /// For Testing.

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdWindowContent.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdWindowContent.xaml.cs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
 {
     /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/AspNetVersion.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/AspNetVersion.cs
@@ -111,7 +111,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
             switch (framework)
             {
                 case FrameworkType.NetFramework:
-                    return new List<AspNetVersion> {AspNet4};
+                    return new List<AspNetVersion> { AspNet4 };
                 case FrameworkType.NetCore:
                     switch (vsVersion)
                     {
@@ -129,6 +129,5 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
                     throw new InvalidOperationException($"Unknown Famework type: {framework}");
             }
         }
-
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
@@ -25,7 +25,6 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
     /// </summary>
     public class TemplateChooserViewModel : ViewModelBase
     {
-
         private string _gcpProjectId;
         private FrameworkType _selectedFramework;
         private AspNetVersion _selectedVersion;

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/ReplacementsKeys.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/ReplacementsKeys.cs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 namespace GoogleCloudExtension.TemplateWizards
 {
     /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/StringUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/StringUtils.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/AssemblyInitialize.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/AssemblyInitialize.cs
@@ -1,4 +1,17 @@
-﻿
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using GoogleCloudExtension.Analytics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CloudExplorerSources/PubSub/TopicViewModelBaseTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CloudExplorerSources/PubSub/TopicViewModelBaseTests.cs
@@ -186,7 +186,8 @@ namespace GoogleCloudExtensionUnitTests.CloudExplorerSources.PubSub
             public TestTopicViewModelBase(
                 IPubsubSourceRootViewModel owner,
                 ITopicItem item,
-                IEnumerable<Subscription> subscriptions) : base(owner, item, subscriptions) { }
+                IEnumerable<Subscription> subscriptions) : base(owner, item, subscriptions)
+            { }
 
             public void AssetOwnerEquals(IPubsubSourceRootViewModel ownerMockObject)
             {
@@ -194,5 +195,4 @@ namespace GoogleCloudExtensionUnitTests.CloudExplorerSources.PubSub
             }
         }
     }
-
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CloudSourceRepository/CsrAddRepoWindowViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CloudSourceRepository/CsrAddRepoWindowViewModelTests.cs
@@ -85,11 +85,10 @@ namespace GoogleCloudExtensionUnitTests.CloudSourceRepository
             TestRepoNameValidRange('A', 'Z');
             TestRepoNameValidRange('0', '9');
             TestValidRepoName("_This-is_valid");    // _ and - character
-
         }
 
         public void InvalidRepoNameTest()
-        { 
+        {
             TestRepoNameInvalidRange(Convert.ToChar(0), Convert.ToChar(44));    // 45 is -
             TestRepoNameInvalidRange(Convert.ToChar(46), Convert.ToChar(47));   // 48 is 0
             TestRepoNameInvalidRange(Convert.ToChar(58), Convert.ToChar(64));   // 57 is 9, 66 is A

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CloudSourceRepository/CsrAddRepoWindowViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CloudSourceRepository/CsrAddRepoWindowViewModelTests.cs
@@ -19,8 +19,8 @@ using GoogleCloudExtension.CloudSourceRepositories;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GoogleCloudExtensionUnitTests.CloudSourceRepository
 {

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/SolutionUserOptionsTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/SolutionUserOptionsTests.cs
@@ -28,7 +28,7 @@ namespace GoogleCloudExtensionUnitTests
         [SolutionSettingKey("google_string_1")]
         public string StringOption { get; set; } = "string option 1";
 
-        [SolutionSettingKey("google_string_2")] 
+        [SolutionSettingKey("google_string_2")]
         public string StringOption2 { get; set; } = "string option 2";
 
         public string NonOption { get; set; }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/GoogleProjectSelectorTemplateWizardTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/GoogleProjectSelectorTemplateWizardTests.cs
@@ -74,7 +74,6 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards
         [TestInitialize]
         public void BeforeEach()
         {
-
             _replacements = new Dictionary<string, string>
             {
                 {ReplacementsKeys.ProjectNameKey, DefaultProjectName},

--- a/GoogleCloudExtension/GoogleCloudExtensions.TeamExplorerExtension.v15/GitExtentionWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensions.TeamExplorerExtension.v15/GitExtentionWrapper.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Linq;
-using static System.Diagnostics.Debug;
 
 namespace GoogleCloudExtension.TeamExplorerExtension
 {

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/VisualStudioWrapper.cs
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/VisualStudioWrapper.cs
@@ -14,12 +14,12 @@
 
 using EnvDTE;
 using EnvDTE80;
+using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
-using Microsoft.Win32;
 using Process = System.Diagnostics.Process;
 using Thread = System.Threading.Thread;
 

--- a/GoogleCloudExtension/TestProjects/EchoApp/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/TestProjects/EchoApp/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
This PR includes the result of running the following tools on the code:
* The PowerTools "Organize and Sort Usings" to make sure that we only have usings in our source code for what we actually use.
* The `./tools/ensure_license.py` script, which will make sure that all .cs files have the license header.
* The `./tools/format_files.cmd` script, which will use the [codeformatter]( https://github.com/dotnet/codeformatter) tool to format the source code with pre-defined set of formatting rules.