### PR TITLE
Correctly check for .NET Core before creating config files.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/GoogleCloudExtension.Deployment.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/GoogleCloudExtension.Deployment.csproj
@@ -94,6 +94,7 @@
     <Compile Include="GkeDeployment.cs" />
     <Compile Include="GkeDeploymentResult.cs" />
     <Compile Include="IParsedProject.cs" />
+    <Compile Include="IParsedProjectExtensions.cs" />
     <Compile Include="IToolsPathProvider.cs" />
     <Compile Include="KnownProjectTypes.cs" />
     <Compile Include="NetCoreAppUtils.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/IParsedProjectExtensions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/IParsedProjectExtensions.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/IParsedProjectExtensions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/IParsedProjectExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.Deployment
+{
+    /// <summary>
+    /// Useful checks for projects.
+    /// </summary>
+    public static class IParsedProjectExtensions
+    {
+        /// <summary>
+        /// Determines if the given project is a .NET Core project or not.
+        /// </summary>
+        /// <param name="project">The project to check.</param>
+        /// <returns>Returns true if the project is a .NET Core project, false otherwise.</returns>
+        public static bool IsAspNetCoreProject(this IParsedProject project)
+            => project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_0 ||
+               project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_1 ||
+               project.ProjectType == KnownProjectTypes.NetCoreWebApplication2_0;
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
@@ -162,7 +162,7 @@ namespace GoogleCloudExtension.GenerateConfigurationCommand
 
             // Ensure that the menu entry is only available for ASP.NET Core projects.
             var selectedProject = SolutionHelper.CurrentSolution.SelectedProject;
-            if (selectedProject == null || !PublishDialogWindow.CanPublish(selectedProject))
+            if (selectedProject == null || !selectedProject.IsAspNetCoreProject())
             {
                 menuCommand.Visible = false;
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -69,7 +69,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepAppEngineFlexName,
                     Command = new ProtectedCommand(
                         OnAppEngineChoiceCommand,
-                        canExecuteCommand: IsSupportedNetCoreProject(_dialog.Project)),
+                        canExecuteCommand: _dialog.Project.IsAspNetCoreProject()),
                     Icon = s_appEngineIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepAppEngineToolTip
                 },
@@ -78,7 +78,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepGkeName,
                     Command = new ProtectedCommand(
                         OnGkeChoiceCommand,
-                        canExecuteCommand:IsSupportedNetCoreProject(_dialog.Project)),
+                        canExecuteCommand:_dialog.Project.IsAspNetCoreProject()),
                     Icon = s_gkeIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepGkeToolTip
                 },
@@ -133,10 +133,5 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
             return viewModel;
         }
-
-        private static bool IsSupportedNetCoreProject(IParsedProject project)
-            => project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_0 ||
-               project.ProjectType == KnownProjectTypes.NetCoreWebApplication1_1 ||
-               project.ProjectType == KnownProjectTypes.NetCoreWebApplication2_0;
     }
 }


### PR DESCRIPTION
This PR uses the right check to enable/disable the menu item for creating config files to ASP.NET Core apps. The check has been centralized into an extension method so it can be used anywhere we need to check for the ASP.NET Core framework, like the publishing wizard.

Fixed #816 