### PR TITLE
Add GCP Project Id Text to publish dialogs.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using GoogleCloudExtension.Accounts;
-using GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog;
-using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Validation;
 using System;
 using System.Windows;
@@ -29,8 +27,6 @@ namespace GoogleCloudExtension.PublishDialog
     {
         private bool _canGoNext;
         private bool _canPublish;
-        internal Func<string, string> PickProjectPrompt = PickProjectIdWindow.PromptUser;
-        public IPublishDialog PublishDialog { get; private set; }
 
         public bool CanGoNext
         {
@@ -60,17 +56,10 @@ namespace GoogleCloudExtension.PublishDialog
 
         public abstract FrameworkElement Content { get; }
         public string GcpProjectId => CredentialsStore.Default.CurrentProjectId;
-        public ProtectedCommand SelectProjectCommand { get; }
 
         public event EventHandler CanGoNextChanged;
 
         public event EventHandler CanPublishChanged;
-
-        /// <inheritdoc />
-        protected PublishDialogStepBase()
-        {
-            SelectProjectCommand = new ProtectedCommand(OnSelectProjectCommand);
-        }
 
         public virtual IPublishDialogStep Next()
         {
@@ -83,23 +72,6 @@ namespace GoogleCloudExtension.PublishDialog
         }
 
         public virtual void OnPushedToDialog(IPublishDialog dialog)
-        {
-            PublishDialog = dialog;
-        }
-
-        private void OnSelectProjectCommand()
-        {
-            string pickProjectDialogTitle = string.Format(
-                Resources.PublishDialogSelectGcpProjectTitle, PublishDialog.Project.Name);
-            if (PickProjectPrompt(pickProjectDialogTitle) != null)
-            {
-                OnGcpProjectIdUpdated();
-                RaisePropertyChanged(nameof(GcpProjectId));
-            }
-        }
-
-        protected virtual void OnGcpProjectIdUpdated()
-        {
-        }
+        { }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
@@ -94,10 +94,15 @@ namespace GoogleCloudExtension.PublishDialog
             };
         }
 
-        public virtual IPublishDialogStep Next() => throw new NotImplementedException();
+        public virtual IPublishDialogStep Next()
+        {
+            throw new NotImplementedException();
+        }
 
-        public virtual void Publish() => throw new NotImplementedException();
-
+        public virtual void Publish()
+        {
+            throw new NotImplementedException();
+        }
         public virtual void OnPushedToDialog(IPublishDialog dialog)
         {
             PublishDialog = dialog;

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.CloudResourceManager.v1.Data;
 using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog;
+using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Validation;
 using System;
 using System.Windows;
@@ -27,7 +30,12 @@ namespace GoogleCloudExtension.PublishDialog
     {
         private bool _canGoNext;
         private bool _canPublish;
+        internal Func<string, Project> PickProjectPrompt = PickProjectIdWindow.PromptUser;
+        protected internal IPublishDialog PublishDialog { get; private set; }
 
+        /// <summary>
+        /// Indicates whether the next button is active.
+        /// </summary>
         public bool CanGoNext
         {
             get { return _canGoNext; }
@@ -41,6 +49,9 @@ namespace GoogleCloudExtension.PublishDialog
             }
         }
 
+        /// <summary>
+        /// Indicates whether the publish button is active.
+        /// </summary>
         public bool CanPublish
         {
             get { return _canPublish; }
@@ -54,24 +65,53 @@ namespace GoogleCloudExtension.PublishDialog
             }
         }
 
+        /// <summary>
+        /// The content of the step.
+        /// </summary>
         public abstract FrameworkElement Content { get; }
+
+        /// <summary>
+        /// The ID of the current Google Cloud Project.
+        /// </summary>
         public string GcpProjectId => CredentialsStore.Default.CurrentProjectId;
+
+        /// <summary>
+        /// The command used to select the Google Cloud Project.
+        /// </summary>
+        public ProtectedCommand SelectProjectCommand { get; }
 
         public event EventHandler CanGoNextChanged;
 
         public event EventHandler CanPublishChanged;
 
-        public virtual IPublishDialogStep Next()
+        /// <inheritdoc />
+        protected PublishDialogStepBase()
         {
-            throw new NotImplementedException();
+            SelectProjectCommand = new ProtectedCommand(OnSelectProjectCommand);
+            CredentialsStore.Default.CurrentProjectIdChanged += (sender, args) =>
+            {
+                RaisePropertyChanged(nameof(GcpProjectId));
+            };
         }
 
-        public virtual void Publish()
-        {
-            throw new NotImplementedException();
-        }
+        public virtual IPublishDialogStep Next() => throw new NotImplementedException();
+
+        public virtual void Publish() => throw new NotImplementedException();
 
         public virtual void OnPushedToDialog(IPublishDialog dialog)
-        { }
+        {
+            PublishDialog = dialog;
+        }
+
+        private void OnSelectProjectCommand()
+        {
+            string pickProjectDialogTitle = string.Format(
+                Resources.PublishDialogSelectGcpProjectTitle, PublishDialog.Project.Name);
+            Project selectedProject = PickProjectPrompt(pickProjectDialogTitle);
+            if (selectedProject?.ProjectId != null)
+            {
+                CredentialsStore.Default.UpdateCurrentProject(selectedProject);
+            }
+        }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogStepBase.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog;
+using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Validation;
 using System;
 using System.Windows;
@@ -26,6 +29,8 @@ namespace GoogleCloudExtension.PublishDialog
     {
         private bool _canGoNext;
         private bool _canPublish;
+        internal Func<string, string> PickProjectPrompt = PickProjectIdWindow.PromptUser;
+        public IPublishDialog PublishDialog { get; private set; }
 
         public bool CanGoNext
         {
@@ -54,10 +59,18 @@ namespace GoogleCloudExtension.PublishDialog
         }
 
         public abstract FrameworkElement Content { get; }
+        public string GcpProjectId => CredentialsStore.Default.CurrentProjectId;
+        public ProtectedCommand SelectProjectCommand { get; }
 
         public event EventHandler CanGoNextChanged;
 
         public event EventHandler CanPublishChanged;
+
+        /// <inheritdoc />
+        protected PublishDialogStepBase()
+        {
+            SelectProjectCommand = new ProtectedCommand(OnSelectProjectCommand);
+        }
 
         public virtual IPublishDialogStep Next()
         {
@@ -70,6 +83,23 @@ namespace GoogleCloudExtension.PublishDialog
         }
 
         public virtual void OnPushedToDialog(IPublishDialog dialog)
-        { }
+        {
+            PublishDialog = dialog;
+        }
+
+        private void OnSelectProjectCommand()
+        {
+            string pickProjectDialogTitle = string.Format(
+                Resources.PublishDialogSelectGcpProjectTitle, PublishDialog.Project.Name);
+            if (PickProjectPrompt(pickProjectDialogTitle) != null)
+            {
+                OnGcpProjectIdUpdated();
+                RaisePropertyChanged(nameof(GcpProjectId));
+            }
+        }
+
+        protected virtual void OnGcpProjectIdUpdated()
+        {
+        }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -41,7 +41,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private static readonly Lazy<ImageSource> s_gkeIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(GkeIconPath));
 
         private readonly ChoiceStepContent _content;
-        private IPublishDialog _dialog;
         private IEnumerable<Choice> _choices;
 
         /// <summary>
@@ -60,7 +59,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         private IEnumerable<Choice> GetChoicesForCurrentProject()
         {
-            var projectType = _dialog.Project.ProjectType;
+            KnownProjectTypes projectType = PublishDialog.Project.ProjectType;
 
             return new List<Choice>
             {
@@ -69,7 +68,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepAppEngineFlexName,
                     Command = new ProtectedCommand(
                         OnAppEngineChoiceCommand,
-                        canExecuteCommand: _dialog.Project.IsAspNetCoreProject()),
+                        canExecuteCommand: PublishDialog.Project.IsAspNetCoreProject()),
                     Icon = s_appEngineIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepAppEngineToolTip
                 },
@@ -78,7 +77,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepGkeName,
                     Command = new ProtectedCommand(
                         OnGkeChoiceCommand,
-                        canExecuteCommand:_dialog.Project.IsAspNetCoreProject()),
+                        canExecuteCommand: PublishDialog.Project.IsAspNetCoreProject()),
                     Icon = s_gkeIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepGkeToolTip
                 },
@@ -97,19 +96,19 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private void OnGkeChoiceCommand()
         {
             var nextStep = GkeStepViewModel.CreateStep();
-            _dialog.NavigateToStep(nextStep);
+            PublishDialog.NavigateToStep(nextStep);
         }
 
         private void OnAppEngineChoiceCommand()
         {
             var nextStep = FlexStepViewModel.CreateStep();
-            _dialog.NavigateToStep(nextStep);
+            PublishDialog.NavigateToStep(nextStep);
         }
 
         private void OnGceChoiceCommand()
         {
             var nextStep = GceStepViewModel.CreateStep();
-            _dialog.NavigateToStep(nextStep);
+            PublishDialog.NavigateToStep(nextStep);
         }
 
         #region IPublishDialogStep
@@ -118,7 +117,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         public override void OnPushedToDialog(IPublishDialog dialog)
         {
-            _dialog = dialog;
+            base.OnPushedToDialog(dialog);
 
             Choices = GetChoicesForCurrentProject();
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -41,7 +41,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private static readonly Lazy<ImageSource> s_gkeIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(GkeIconPath));
 
         private readonly ChoiceStepContent _content;
-        private IPublishDialog _dialog;
         private IEnumerable<Choice> _choices;
 
         /// <summary>
@@ -60,7 +59,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         private IEnumerable<Choice> GetChoicesForCurrentProject()
         {
-            var projectType = _dialog.Project.ProjectType;
+            var projectType = PublishDialog.Project.ProjectType;
 
             return new List<Choice>
             {
@@ -69,7 +68,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepAppEngineFlexName,
                     Command = new ProtectedCommand(
                         OnAppEngineChoiceCommand,
-                        canExecuteCommand: IsSupportedNetCoreProject(_dialog.Project)),
+                        canExecuteCommand: IsSupportedNetCoreProject(PublishDialog.Project)),
                     Icon = s_appEngineIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepAppEngineToolTip
                 },
@@ -78,7 +77,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepGkeName,
                     Command = new ProtectedCommand(
                         OnGkeChoiceCommand,
-                        canExecuteCommand:IsSupportedNetCoreProject(_dialog.Project)),
+                        canExecuteCommand:IsSupportedNetCoreProject(PublishDialog.Project)),
                     Icon = s_gkeIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepGkeToolTip
                 },
@@ -97,19 +96,19 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private void OnGkeChoiceCommand()
         {
             var nextStep = GkeStepViewModel.CreateStep();
-            _dialog.NavigateToStep(nextStep);
+            PublishDialog.NavigateToStep(nextStep);
         }
 
         private void OnAppEngineChoiceCommand()
         {
-            var nextStep = FlexStepViewModel.CreateStep(_dialog.Project.Name);
-            _dialog.NavigateToStep(nextStep);
+            var nextStep = FlexStepViewModel.CreateStep();
+            PublishDialog.NavigateToStep(nextStep);
         }
 
         private void OnGceChoiceCommand()
         {
             var nextStep = GceStepViewModel.CreateStep();
-            _dialog.NavigateToStep(nextStep);
+            PublishDialog.NavigateToStep(nextStep);
         }
 
         #region IPublishDialogStep
@@ -118,7 +117,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         public override void OnPushedToDialog(IPublishDialog dialog)
         {
-            _dialog = dialog;
+            base.OnPushedToDialog(dialog);
 
             Choices = GetChoicesForCurrentProject();
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -41,6 +41,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private static readonly Lazy<ImageSource> s_gkeIcon = new Lazy<ImageSource>(() => ResourceUtils.LoadImage(GkeIconPath));
 
         private readonly ChoiceStepContent _content;
+        private IPublishDialog _dialog;
         private IEnumerable<Choice> _choices;
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         private IEnumerable<Choice> GetChoicesForCurrentProject()
         {
-            var projectType = PublishDialog.Project.ProjectType;
+            var projectType = _dialog.Project.ProjectType;
 
             return new List<Choice>
             {
@@ -68,7 +69,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepAppEngineFlexName,
                     Command = new ProtectedCommand(
                         OnAppEngineChoiceCommand,
-                        canExecuteCommand: PublishDialog.Project.IsAspNetCoreProject()),
+                        canExecuteCommand: _dialog.Project.IsAspNetCoreProject()),
                     Icon = s_appEngineIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepAppEngineToolTip
                 },
@@ -77,7 +78,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
                     Name = Resources.PublishDialogChoiceStepGkeName,
                     Command = new ProtectedCommand(
                         OnGkeChoiceCommand,
-                        canExecuteCommand: PublishDialog.Project.IsAspNetCoreProject()),
+                        canExecuteCommand:_dialog.Project.IsAspNetCoreProject()),
                     Icon = s_gkeIcon.Value,
                     ToolTip = Resources.PublishDialogChoiceStepGkeToolTip
                 },
@@ -96,19 +97,19 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private void OnGkeChoiceCommand()
         {
             var nextStep = GkeStepViewModel.CreateStep();
-            PublishDialog.NavigateToStep(nextStep);
+            _dialog.NavigateToStep(nextStep);
         }
 
         private void OnAppEngineChoiceCommand()
         {
             var nextStep = FlexStepViewModel.CreateStep();
-            PublishDialog.NavigateToStep(nextStep);
+            _dialog.NavigateToStep(nextStep);
         }
 
         private void OnGceChoiceCommand()
         {
             var nextStep = GceStepViewModel.CreateStep();
-            PublishDialog.NavigateToStep(nextStep);
+            _dialog.NavigateToStep(nextStep);
         }
 
         #region IPublishDialogStep
@@ -117,7 +118,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         public override void OnPushedToDialog(IPublishDialog dialog)
         {
-            base.OnPushedToDialog(dialog);
+            _dialog = dialog;
 
             Choices = GetChoicesForCurrentProject();
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -102,7 +102,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
 
         private void OnAppEngineChoiceCommand()
         {
-            var nextStep = FlexStepViewModel.CreateStep();
+            var nextStep = FlexStepViewModel.CreateStep(_dialog.Project.Name);
             _dialog.NavigateToStep(nextStep);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
@@ -21,11 +21,11 @@
         <DockPanel HorizontalAlignment="Left">
             <Label
                 DockPanel.Dock="Top"
-                Content="{x:Static ext:Resources.PublishDialogFlexGcpProjectIdLabel}"
+                Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
                 Style="{StaticResource CommonLabelStyle}"/>
             <Button
                 DockPanel.Dock="Right"
-                Content="{x:Static ext:Resources.PublishDialogFlexSelectGcpProjectButtonLabel}"
+                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
                 Style="{StaticResource CommonButtonStyle}"
                 Command="{Binding SelectProjectCommand}"/>
             <TextBox

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
@@ -28,7 +28,12 @@
                 Content="{x:Static ext:Resources.PublishDialogFlexSelectGcpProjectButtonLabel}"
                 Style="{StaticResource CommonButtonStyle}"
                 Command="{Binding SelectProjectCommand}"/>
-            <TextBox Text="{Binding GcpProjectId}" Width="100" Margin="0,0,5,0" IsReadOnly="True"/>
+            <TextBox
+                Text="{Binding GcpProjectId, Mode=OneWay}"
+                Width="200"
+                Margin="0,0,5,0"
+                IsReadOnly="True"
+                Style="{StaticResource CommonTextBoxStyle}"/>
         </DockPanel>
         <Label Content="{x:Static ext:Resources.PublishDialogFlexVersionNameCaption}"
                Target="{Binding ElementName=_version}"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
@@ -22,13 +22,18 @@
             <Label
                 DockPanel.Dock="Top"
                 Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
-                Style="{StaticResource CommonLabelStyle}" />
+                Style="{StaticResource CommonLabelStyle}"/>
+            <Button
+                DockPanel.Dock="Right"
+                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
+                Style="{StaticResource CommonButtonDynamicStyle}"
+                Command="{Binding SelectProjectCommand}"/>
             <TextBox
                 Text="{Binding GcpProjectId, Mode=OneWay}"
                 Width="200"
                 Margin="0,0,5,0"
                 IsReadOnly="True"
-                Style="{StaticResource CommonTextBoxStyle}" />
+                Style="{StaticResource CommonTextBoxStyle}"/>
         </DockPanel>
         <Label Content="{x:Static ext:Resources.PublishDialogFlexVersionNameCaption}"
                Target="{Binding ElementName=_version}"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
@@ -18,6 +18,18 @@
     </UserControl.Resources>
 
     <StackPanel>
+        <DockPanel HorizontalAlignment="Left">
+            <Label
+                DockPanel.Dock="Top"
+                Content="{x:Static ext:Resources.PublishDialogFlexGcpProjectIdLabel}"
+                Style="{StaticResource CommonLabelStyle}"/>
+            <Button
+                DockPanel.Dock="Right"
+                Content="{x:Static ext:Resources.PublishDialogFlexSelectGcpProjectButtonLabel}"
+                Style="{StaticResource CommonButtonStyle}"
+                Command="{Binding SelectProjectCommand}"/>
+            <TextBox Text="{Binding GcpProjectId}" Width="100" Margin="0,0,5,0" IsReadOnly="True"/>
+        </DockPanel>
         <Label Content="{x:Static ext:Resources.PublishDialogFlexVersionNameCaption}"
                Target="{Binding ElementName=_version}"
                Style="{StaticResource CommonLabelStyle}"/>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepContent.xaml
@@ -22,18 +22,13 @@
             <Label
                 DockPanel.Dock="Top"
                 Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
-                Style="{StaticResource CommonLabelStyle}"/>
-            <Button
-                DockPanel.Dock="Right"
-                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
-                Style="{StaticResource CommonButtonStyle}"
-                Command="{Binding SelectProjectCommand}"/>
+                Style="{StaticResource CommonLabelStyle}" />
             <TextBox
                 Text="{Binding GcpProjectId, Mode=OneWay}"
                 Width="200"
                 Margin="0,0,5,0"
                 IsReadOnly="True"
-                Style="{StaticResource CommonTextBoxStyle}"/>
+                Style="{StaticResource CommonTextBoxStyle}" />
         </DockPanel>
         <Label Content="{x:Static ext:Resources.PublishDialogFlexVersionNameCaption}"
                Target="{Binding ElementName=_version}"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
@@ -17,6 +17,23 @@
     </UserControl.Resources>
 
     <StackPanel>
+        <DockPanel HorizontalAlignment="Left">
+            <Label
+                DockPanel.Dock="Top"
+                Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
+                Style="{StaticResource CommonLabelStyle}" />
+            <Button
+                DockPanel.Dock="Right"
+                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
+                Style="{StaticResource CommonButtonStyle}"
+                Command="{Binding SelectProjectCommand}" />
+            <TextBox
+                Text="{Binding GcpProjectId, Mode=OneWay}"
+                Width="200"
+                Margin="0,0,5,0"
+                IsReadOnly="True"
+                Style="{StaticResource CommonTextBoxStyle}" />
+        </DockPanel>
         <Label Content="{x:Static ext:Resources.PublishDialogGceStepSelectInstanceMessage}"
                Target="{Binding ElementName=_instances}"
                Style="{StaticResource CommonLabelStyle}"/>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
@@ -22,6 +22,11 @@
                 DockPanel.Dock="Top"
                 Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
                 Style="{StaticResource CommonLabelStyle}" />
+            <Button
+                DockPanel.Dock="Right"
+                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
+                Style="{StaticResource CommonButtonDynamicStyle}"
+                Command="{Binding SelectProjectCommand}" />
             <TextBox
                 Text="{Binding GcpProjectId, Mode=OneWay}"
                 Width="200"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
@@ -22,11 +22,6 @@
                 DockPanel.Dock="Top"
                 Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
                 Style="{StaticResource CommonLabelStyle}" />
-            <Button
-                DockPanel.Dock="Right"
-                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
-                Style="{StaticResource CommonButtonStyle}"
-                Command="{Binding SelectProjectCommand}" />
             <TextBox
                 Text="{Binding GcpProjectId, Mode=OneWay}"
                 Width="200"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
@@ -39,18 +39,22 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
     public class GceStepViewModel : PublishDialogStepBase
     {
         private readonly GceStepContent _content;
-        private IPublishDialog _publishDialog;
         private Instance _selectedInstance;
         private IEnumerable<WindowsInstanceCredentials> _credentials;
         private WindowsInstanceCredentials _selectedCredentials;
         private bool _openWebsite = true;
         private bool _launchRemoteDebugger;
+        private AsyncProperty<IEnumerable<Instance>> _instances;
 
         /// <summary>
         /// The asynchrnous value that will resolve to the list of instances in the current GCP Project, and that are
         /// the available target for the publish process.
         /// </summary>
-        public AsyncProperty<IEnumerable<Instance>> Instances { get; }
+        public AsyncProperty<IEnumerable<Instance>> Instances
+        {
+            get { return _instances; }
+            private set { SetValueAndRaise(ref _instances, value); }
+        }
 
         /// <summary>
         /// The selected GCE VM that will be the target of the publish process.
@@ -121,7 +125,12 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
         {
             _content = content;
 
-            Instances = AsyncPropertyUtils.CreateAsyncProperty(GetAllWindowsInstances());
+            Instances = AsyncPropertyUtils.CreateAsyncProperty(GetAllWindowsInstancesAsync());
+
+            CredentialsStore.Default.CurrentProjectIdChanged += (sender, args) =>
+            {
+                Instances = AsyncPropertyUtils.CreateAsyncProperty(GetAllWindowsInstancesAsync());
+            };
 
             ManageCredentialsCommand = new ProtectedCommand(OnManageCredentialsCommand, canExecuteCommand: false);
         }
@@ -132,13 +141,13 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
             UpdateCredentials();
         }
 
-        private async Task<IEnumerable<Instance>> GetAllWindowsInstances()
+        private async Task<IEnumerable<Instance>> GetAllWindowsInstancesAsync()
         {
             var dataSource = new GceDataSource(
                 CredentialsStore.Default.CurrentProjectId,
                 CredentialsStore.Default.CurrentGoogleCredential,
                 GoogleCloudExtensionPackage.ApplicationName);
-            var instances = await dataSource.GetInstanceListAsync();
+            IList<Instance> instances = await dataSource.GetInstanceListAsync();
             return instances.Where(x => x.IsRunning() && x.IsWindowsInstance()).OrderBy(x => x.Name);
         }
 
@@ -148,7 +157,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
 
         public override async void Publish()
         {
-            var project = _publishDialog.Project;
+            IParsedProject project = PublishDialog.Project;
 
             try
             {
@@ -156,18 +165,19 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
 
                 GcpOutputWindow.Activate();
                 GcpOutputWindow.Clear();
-                GcpOutputWindow.OutputLine(String.Format(Resources.GcePublishStepStartMessage, project.Name));
+                GcpOutputWindow.OutputLine(string.Format(Resources.GcePublishStepStartMessage, project.Name));
 
-                _publishDialog.FinishFlow();
+                PublishDialog.FinishFlow();
 
+                string progressBarTitle = string.Format(Resources.GcePublishProgressMessage, SelectedInstance.Name);
                 TimeSpan deploymentDuration;
                 bool result;
-                using (var frozen = StatusbarHelper.Freeze())
-                using (var animationShown = StatusbarHelper.ShowDeployAnimation())
-                using (var progress = StatusbarHelper.ShowProgressBar(String.Format(Resources.GcePublishProgressMessage, SelectedInstance.Name)))
-                using (var deployingOperation = ShellUtils.SetShellUIBusy())
+                using (StatusbarHelper.Freeze())
+                using (StatusbarHelper.ShowDeployAnimation())
+                using (ShellUtils.SetShellUIBusy())
+                using (ProgressBarHelper progress = StatusbarHelper.ShowProgressBar(progressBarTitle))
                 {
-                    var startDeploymentTime = DateTime.Now;
+                    DateTime startDeploymentTime = DateTime.Now;
                     result = await WindowsVmDeployment.PublishProjectAsync(
                         project,
                         SelectedInstance,
@@ -180,11 +190,11 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
 
                 if (result)
                 {
-                    GcpOutputWindow.OutputLine(String.Format(Resources.GcePublishSuccessMessage, project.Name, SelectedInstance.Name));
+                    GcpOutputWindow.OutputLine(string.Format(Resources.GcePublishSuccessMessage, project.Name, SelectedInstance.Name));
                     StatusbarHelper.SetText(Resources.PublishSuccessStatusMessage);
 
-                    var url = SelectedInstance.GetDestinationAppUri();
-                    GcpOutputWindow.OutputLine(String.Format(Resources.PublishUrlMessage, url));
+                    string url = SelectedInstance.GetDestinationAppUri();
+                    GcpOutputWindow.OutputLine(string.Format(Resources.PublishUrlMessage, url));
                     if (OpenWebsite)
                     {
                         Process.Start(url);
@@ -199,7 +209,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
                 }
                 else
                 {
-                    GcpOutputWindow.OutputLine(String.Format(Resources.GcePublishFailedMessage, project.Name));
+                    GcpOutputWindow.OutputLine(string.Format(Resources.GcePublishFailedMessage, project.Name));
                     StatusbarHelper.SetText(Resources.PublishFailureStatusMessage);
 
                     EventsReporterWrapper.ReportEvent(GceDeployedEvent.Create(CommandStatus.Failure));
@@ -207,7 +217,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
             }
             catch (Exception ex) when (!ErrorHandlerUtils.IsCriticalException(ex))
             {
-                GcpOutputWindow.OutputLine(String.Format(Resources.GcePublishFailedMessage, project.Name));
+                GcpOutputWindow.OutputLine(string.Format(Resources.GcePublishFailedMessage, project.Name));
                 StatusbarHelper.SetText(Resources.PublishFailureStatusMessage);
 
                 EventsReporterWrapper.ReportEvent(GceDeployedEvent.Create(CommandStatus.Failure));
@@ -216,9 +226,9 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
 
         public override void OnPushedToDialog(IPublishDialog dialog)
         {
-            _publishDialog = dialog;
+            base.OnPushedToDialog(dialog);
 
-            _publishDialog.TrackTask(Instances.ValueTask);
+            PublishDialog.TrackTask(Instances.ValueTask);
         }
 
         #endregion

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
@@ -22,6 +22,11 @@
                 DockPanel.Dock="Top"
                 Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
                 Style="{StaticResource CommonLabelStyle}" />
+            <Button
+                DockPanel.Dock="Right"
+                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
+                Style="{StaticResource CommonButtonDynamicStyle}"
+                Command="{Binding SelectProjectCommand}" />
             <TextBox
                 Text="{Binding GcpProjectId, Mode=OneWay}"
                 Width="200"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
@@ -22,11 +22,6 @@
                 DockPanel.Dock="Top"
                 Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
                 Style="{StaticResource CommonLabelStyle}" />
-            <Button
-                DockPanel.Dock="Right"
-                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
-                Style="{StaticResource CommonButtonStyle}"
-                Command="{Binding SelectProjectCommand}" />
             <TextBox
                 Text="{Binding GcpProjectId, Mode=OneWay}"
                 Width="200"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepContent.xaml
@@ -17,6 +17,23 @@
     </UserControl.Resources>
 
     <StackPanel>
+        <DockPanel HorizontalAlignment="Left">
+            <Label
+                DockPanel.Dock="Top"
+                Content="{x:Static ext:Resources.PublishDialogGcpProjectIdLabel}"
+                Style="{StaticResource CommonLabelStyle}" />
+            <Button
+                DockPanel.Dock="Right"
+                Content="{x:Static ext:Resources.PublishDialogSelectGcpProjectButtonLabel}"
+                Style="{StaticResource CommonButtonStyle}"
+                Command="{Binding SelectProjectCommand}" />
+            <TextBox
+                Text="{Binding GcpProjectId, Mode=OneWay}"
+                Width="200"
+                Margin="0,0,5,0"
+                IsReadOnly="True"
+                Style="{StaticResource CommonTextBoxStyle}" />
+        </DockPanel>
         <Label Content="{x:Static ext:Resources.GkePublishClusterMessage}"
                Target="{Binding ElementName=_clusters}"
                Style="{StaticResource CommonLabelStyle}"/>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -43,7 +43,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         private static readonly IList<Cluster> s_placeholderList = new List<Cluster> { s_placeholderCluster };
 
         private readonly GkeStepContent _content;
-        private IPublishDialog _publishDialog;
         private AsyncProperty<IList<Cluster>> _clusters;
         private Cluster _selectedCluster;
         private string _deploymentName;
@@ -175,7 +174,12 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
             Clusters = new AsyncProperty<IList<Cluster>>(GetAllClustersAsync());
             CreateClusterCommand = new ProtectedCommand(OnCreateClusterCommand);
-            RefreshClustersListCommand = new ProtectedCommand(OnRefreshClustersListCommand);
+            RefreshClustersListCommand = new ProtectedCommand(RefreshClustersList);
+
+            CredentialsStore.Default.CurrentProjectIdChanged += (sender, args) =>
+            {
+                RefreshClustersList();
+            };
         }
 
         private void UpdateCanPublish()
@@ -188,11 +192,11 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             UpdateCanPublish();
         }
 
-        private void OnRefreshClustersListCommand()
+        private void RefreshClustersList()
         {
-            var refreshTask = GetAllClustersAsync();
+            Task<IList<Cluster>> refreshTask = GetAllClustersAsync();
             Clusters = new AsyncProperty<IList<Cluster>>(refreshTask);
-            _publishDialog.TrackTask(refreshTask);
+            PublishDialog.TrackTask(refreshTask);
         }
 
         private void OnCreateClusterCommand()
@@ -206,13 +210,13 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
         public override void OnPushedToDialog(IPublishDialog dialog)
         {
-            _publishDialog = dialog;
+            base.OnPushedToDialog(dialog);
 
-            DeploymentName = _publishDialog.Project.Name.ToLower();
+            DeploymentName = PublishDialog.Project.Name.ToLower();
             DeploymentVersion = GcpPublishStepsUtils.GetDefaultVersion();
 
             // Mark that the dialog is going to be busy until we have loaded the data.
-            _publishDialog.TrackTask(Clusters.ValueTask);
+            PublishDialog.TrackTask(Clusters.ValueTask);
         }
 
         /// <summary>
@@ -226,13 +230,13 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                 return;
             }
 
-            var project = _publishDialog.Project;
+            var project = PublishDialog.Project;
             try
             {
                 ShellUtils.SaveAllFiles();
 
                 var verifyGCloudTask = GCloudWrapperUtils.VerifyGCloudDependencies(GCloudComponent.Kubectl);
-                _publishDialog.TrackTask(verifyGCloudTask);
+                PublishDialog.TrackTask(verifyGCloudTask);
                 if (!await verifyGCloudTask)
                 {
                     Debug.WriteLine("Aborting deployment, no kubectl was found.");
@@ -251,12 +255,12 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                     cluster: SelectedCluster.Name,
                     zone: SelectedCluster.Zone,
                     context: gcloudContext);
-                _publishDialog.TrackTask(kubectlContextTask);
+                PublishDialog.TrackTask(kubectlContextTask);
 
                 using (var kubectlContext = await kubectlContextTask)
                 {
                     var deploymentExistsTask = KubectlWrapper.DeploymentExistsAsync(DeploymentName, kubectlContext);
-                    _publishDialog.TrackTask(deploymentExistsTask);
+                    PublishDialog.TrackTask(deploymentExistsTask);
                     if (await deploymentExistsTask)
                     {
                         if (!UserPromptUtils.ActionPrompt(
@@ -286,7 +290,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                     GcpOutputWindow.Clear();
                     GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishDeployingToGkeMessage, project.Name));
 
-                    _publishDialog.FinishFlow();
+                    PublishDialog.FinishFlow();
 
                     TimeSpan deploymentDuration;
                     GkeDeploymentResult result;
@@ -331,7 +335,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
             {
                 GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishDeploymentFailureMessage, project.Name));
                 StatusbarHelper.SetText(Resources.PublishFailureStatusMessage);
-                _publishDialog.FinishFlow();
+                PublishDialog.FinishFlow();
 
                 EventsReporterWrapper.ReportEvent(GkeDeployedEvent.Create(CommandStatus.Failure));
             }
@@ -339,7 +343,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
         private void OutputResultData(GkeDeploymentResult result, GkeDeployment.DeploymentOptions options)
         {
-            GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishDeploymentSuccessMessage, _publishDialog.Project.Name));
+            GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishDeploymentSuccessMessage, PublishDialog.Project.Name));
             if (result.DeploymentUpdated)
             {
                 GcpOutputWindow.OutputLine(String.Format(Resources.GkePublishDeploymentUpdatedMessage, options.DeploymentName));

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -5178,24 +5178,6 @@ namespace GoogleCloudExtension {
         public static string PublishDialogPublishButtonCaption {
             get {
                 return ResourceManager.GetString("PublishDialogPublishButtonCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Select _Project....
-        /// </summary>
-        public static string PublishDialogSelectGcpProjectButtonLabel {
-            get {
-                return ResourceManager.GetString("PublishDialogSelectGcpProjectButtonLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Select Google Cloud Project to publish to - {0}.
-        /// </summary>
-        public static string PublishDialogSelectGcpProjectTitle {
-            get {
-                return ResourceManager.GetString("PublishDialogSelectGcpProjectTitle", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -5182,6 +5182,24 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change Current _Project....
+        /// </summary>
+        public static string PublishDialogSelectGcpProjectButtonLabel {
+            get {
+                return ResourceManager.GetString("PublishDialogSelectGcpProjectButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Google Cloud Project to Publish to - {0}.
+        /// </summary>
+        public static string PublishDialogSelectGcpProjectTitle {
+            get {
+                return ResourceManager.GetString("PublishDialogSelectGcpProjectTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deployment failed.
         /// </summary>
         public static string PublishFailureStatusMessage {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -5074,11 +5074,38 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Google Cloud Project ID:.
+        /// </summary>
+        public static string PublishDialogFlexGcpProjectIdLabel {
+            get {
+                return ResourceManager.GetString("PublishDialogFlexGcpProjectIdLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to P_romote version.
         /// </summary>
         public static string PublishDialogFlexPromoteVersionCaption {
             get {
                 return ResourceManager.GetString("PublishDialogFlexPromoteVersionCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select _Project....
+        /// </summary>
+        public static string PublishDialogFlexSelectGcpProjectButtonLabel {
+            get {
+                return ResourceManager.GetString("PublishDialogFlexSelectGcpProjectButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Google Cloud Project to publish to - {0}.
+        /// </summary>
+        public static string PublishDialogFlexSelectGcpProjectTitle {
+            get {
+                return ResourceManager.GetString("PublishDialogFlexSelectGcpProjectTitle", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -5074,38 +5074,11 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Google Cloud Project ID:.
-        /// </summary>
-        public static string PublishDialogFlexGcpProjectIdLabel {
-            get {
-                return ResourceManager.GetString("PublishDialogFlexGcpProjectIdLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to P_romote version.
         /// </summary>
         public static string PublishDialogFlexPromoteVersionCaption {
             get {
                 return ResourceManager.GetString("PublishDialogFlexPromoteVersionCaption", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Select _Project....
-        /// </summary>
-        public static string PublishDialogFlexSelectGcpProjectButtonLabel {
-            get {
-                return ResourceManager.GetString("PublishDialogFlexSelectGcpProjectButtonLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Select Google Cloud Project to publish to - {0}.
-        /// </summary>
-        public static string PublishDialogFlexSelectGcpProjectTitle {
-            get {
-                return ResourceManager.GetString("PublishDialogFlexSelectGcpProjectTitle", resourceCulture);
             }
         }
         
@@ -5142,6 +5115,15 @@ namespace GoogleCloudExtension {
         public static string PublishDialogGceStepSelectInstanceMessage {
             get {
                 return ResourceManager.GetString("PublishDialogGceStepSelectInstanceMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Google Cloud Project ID:.
+        /// </summary>
+        public static string PublishDialogGcpProjectIdLabel {
+            get {
+                return ResourceManager.GetString("PublishDialogGcpProjectIdLabel", resourceCulture);
             }
         }
         
@@ -5196,6 +5178,24 @@ namespace GoogleCloudExtension {
         public static string PublishDialogPublishButtonCaption {
             get {
                 return ResourceManager.GetString("PublishDialogPublishButtonCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select _Project....
+        /// </summary>
+        public static string PublishDialogSelectGcpProjectButtonLabel {
+            get {
+                return ResourceManager.GetString("PublishDialogSelectGcpProjectButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select Google Cloud Project to publish to - {0}.
+        /// </summary>
+        public static string PublishDialogSelectGcpProjectTitle {
+            get {
+                return ResourceManager.GetString("PublishDialogSelectGcpProjectTitle", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2819,12 +2819,4 @@
     <value>Google Cloud Project ID:</value>
     <comment>The Google Cloud Project ID label of the AppEngine Flex Publish dialog.</comment>
   </data>
-  <data name="PublishDialogSelectGcpProjectButtonLabel" xml:space="preserve">
-    <value>Select _Project...</value>
-    <comment>The label of the Select Project button of the AppEngine Flex Publish dialog.</comment>
-  </data>
-  <data name="PublishDialogSelectGcpProjectTitle" xml:space="preserve">
-    <value>Select Google Cloud Project to publish to - {0}</value>
-    <comment>The title of the Select Google Cloud Project dialog created from the Publish dialogs. The parameter is the name of the Visual Studio project.</comment>
-  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2815,4 +2815,16 @@
     <value>Features:</value>
     <comment>The label for the features section of the Project Template Chooser dialog.</comment>
   </data>
+  <data name="PublishDialogFlexGcpProjectIdLabel" xml:space="preserve">
+    <value>Google Cloud Project ID:</value>
+    <comment>The Google Cloud Project ID label of the AppEngine Flex Publish dialog.</comment>
+  </data>
+  <data name="PublishDialogFlexSelectGcpProjectButtonLabel" xml:space="preserve">
+    <value>Select _Project...</value>
+    <comment>The label of the Select Project button of the AppEngine Flex Publish dialog.</comment>
+  </data>
+  <data name="PublishDialogFlexSelectGcpProjectTitle" xml:space="preserve">
+    <value>Select Google Cloud Project to publish to - {0}</value>
+    <comment>The title of the Select Google Cloud Project dialog created from the Publish App Engine Flex dialog. The parameter is the name of the Visual Studio project.</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2819,4 +2819,12 @@
     <value>Google Cloud Project ID:</value>
     <comment>The Google Cloud Project ID label of the AppEngine Flex Publish dialog.</comment>
   </data>
+  <data name="PublishDialogSelectGcpProjectButtonLabel" xml:space="preserve">
+    <value>Change Current _Project...</value>
+    <comment>The label of the Change Current Project button of the AppEngine Flex Publish dialog.</comment>
+  </data>
+  <data name="PublishDialogSelectGcpProjectTitle" xml:space="preserve">
+    <value>Select Google Cloud Project to Publish to - {0}</value>
+    <comment>The title of the Select Google Cloud Project dialog created from the Publish dialogs. The parameter is the name of the Visual Studio project.</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2815,16 +2815,16 @@
     <value>Features:</value>
     <comment>The label for the features section of the Project Template Chooser dialog.</comment>
   </data>
-  <data name="PublishDialogFlexGcpProjectIdLabel" xml:space="preserve">
+  <data name="PublishDialogGcpProjectIdLabel" xml:space="preserve">
     <value>Google Cloud Project ID:</value>
     <comment>The Google Cloud Project ID label of the AppEngine Flex Publish dialog.</comment>
   </data>
-  <data name="PublishDialogFlexSelectGcpProjectButtonLabel" xml:space="preserve">
+  <data name="PublishDialogSelectGcpProjectButtonLabel" xml:space="preserve">
     <value>Select _Project...</value>
     <comment>The label of the Select Project button of the AppEngine Flex Publish dialog.</comment>
   </data>
-  <data name="PublishDialogFlexSelectGcpProjectTitle" xml:space="preserve">
+  <data name="PublishDialogSelectGcpProjectTitle" xml:space="preserve">
     <value>Select Google Cloud Project to publish to - {0}</value>
-    <comment>The title of the Select Google Cloud Project dialog created from the Publish App Engine Flex dialog. The parameter is the name of the Visual Studio project.</comment>
+    <comment>The title of the Select Google Cloud Project dialog created from the Publish dialogs. The parameter is the name of the Visual Studio project.</comment>
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdViewModel.cs
@@ -168,6 +168,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
 
         private void OnOk()
         {
+            CredentialsStore.Default.UpdateCurrentProject(SelectedProject);
             Result = ProjectId;
             _owner.Close();
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdViewModel.cs
@@ -32,7 +32,6 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
     {
         private IList<Project> _projects;
         private Project _selectedProject;
-        private string _projectId;
         private AsyncProperty _loadTask;
 
         private readonly IPickProjectIdWindow _owner;
@@ -43,7 +42,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
         /// Result of the view model after the dialog window is closed. Remains
         /// null until an action buttion is clicked.
         /// </summary>
-        public string Result { get; private set; }
+        public Project Result { get; private set; }
 
         /// <summary>
         /// Command to open the manage users dialog.
@@ -54,11 +53,6 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
         /// Command to confirm the selection of a project id.
         /// </summary>
         public ProtectedCommand OkCommand { get; }
-
-        /// <summary>
-        /// Command to skip project input.
-        /// </summary>
-        public ProtectedCommand SkipCommand { get; }
 
         /// <summary>
         /// The list of projects available to the current user.
@@ -78,23 +72,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
             set
             {
                 SetValueAndRaise(ref _selectedProject, value);
-                if (SelectedProject != null)
-                {
-                    ProjectId = SelectedProject.ProjectId;
-                }
-            }
-        }
-
-        /// <summary>
-        /// The project id that will be selected on an OkCommand.
-        /// </summary>
-        public string ProjectId
-        {
-            get { return _projectId; }
-            set
-            {
-                SetValueAndRaise(ref _projectId, value);
-                OkCommand.CanExecuteCommand = !string.IsNullOrEmpty(ProjectId);
+                OkCommand.CanExecuteCommand = !string.IsNullOrEmpty(SelectedProject?.ProjectId);
             }
         }
 
@@ -128,8 +106,6 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
 
             ChangeUserCommand = new ProtectedCommand(OnChangeUser);
             OkCommand = new ProtectedCommand(OnOk, false);
-            SkipCommand = new ProtectedCommand(OnSkip);
-            ProjectId = CredentialsStore.Default.CurrentProjectId;
             StartLoadProjects();
         }
 
@@ -148,16 +124,14 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
         private async Task LoadProjectsAsync()
         {
             Projects = await _resourceManagerDataSourceFactory().GetSortedActiveProjectsAsync();
-            if (string.IsNullOrEmpty(ProjectId) || ProjectId == SelectedProject?.ProjectId)
+            if (SelectedProject == null)
             {
-                // Updates ProjectId within the property.
                 SelectedProject =
-                    Projects.FirstOrDefault(p => p.ProjectId == CredentialsStore.Default.CurrentProjectId) ??
-                    Projects.FirstOrDefault();
+                    Projects.FirstOrDefault(p => p.ProjectId == CredentialsStore.Default.CurrentProjectId);
             }
             else
             {
-                SelectedProject = Projects.FirstOrDefault(p => p.ProjectId == ProjectId);
+                SelectedProject = Projects.FirstOrDefault(p => p.ProjectId == SelectedProject.ProjectId);
             }
         }
 
@@ -169,14 +143,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
 
         private void OnOk()
         {
-            CredentialsStore.Default.UpdateCurrentProject(SelectedProject);
-            Result = ProjectId;
-            _owner.Close();
-        }
-
-        private void OnSkip()
-        {
-            Result = "";
+            Result = SelectedProject;
             _owner.Close();
         }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdWindow.cs
@@ -23,8 +23,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
     {
         private PickProjectIdViewModel ViewModel { get; }
 
-        private PickProjectIdWindow(string projectName) :
-            base(string.Format(GoogleCloudExtension.Resources.WizardTemplateChooserTitle, projectName))
+        private PickProjectIdWindow(string title) : base(title)
         {
             ViewModel = new PickProjectIdViewModel(this);
             Content = new PickProjectIdWindowContent { DataContext = ViewModel };
@@ -33,15 +32,13 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
         /// <summary>
         /// Initalizes the Pick Project Window and waits for it to finish.
         /// </summary>
-        /// <param name="projectName">
-        /// The user readable Visual Studio project name to add as part of the dialog title.
-        /// </param>
+        /// <param name="dialogTitle">The title of the pick project id dialog.</param>
         /// <returns>
         /// The project ID selected, or an empty string if skipped, or null if canceled.
         /// </returns>
-        public static string PromptUser(string projectName)
+        public static string PromptUser(string dialogTitle)
         {
-            var dialog = new PickProjectIdWindow(projectName);
+            var dialog = new PickProjectIdWindow(dialogTitle);
             dialog.ShowModal();
             return dialog.ViewModel.Result;
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/ProjectIdDialog/PickProjectIdWindow.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.CloudResourceManager.v1.Data;
 using GoogleCloudExtension.Theming;
 
 namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
@@ -36,7 +37,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.ProjectIdDialog
         /// <returns>
         /// The project ID selected, or an empty string if skipped, or null if canceled.
         /// </returns>
-        public static string PromptUser(string dialogTitle)
+        public static Project PromptUser(string dialogTitle)
         {
             var dialog = new PickProjectIdWindow(dialogTitle);
             dialog.ShowModal();

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.CloudResourceManager.v1.Data;
 using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.Utils;
 using System;
@@ -150,7 +151,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
 
         /// <param name="closeWindow">The action that will close the dialog.</param>
         /// <param name="promptPickProject">The function that will prompt the user to pick an existing project.</param>
-        public TemplateChooserViewModel(Action closeWindow, Func<string> promptPickProject)
+        public TemplateChooserViewModel(Action closeWindow, Func<Project> promptPickProject)
         {
             GcpProjectId = CredentialsStore.Default.CurrentProjectId ?? "";
             OkCommand = new ProtectedCommand(
@@ -160,7 +161,8 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
                     closeWindow();
                 },
                 false);
-            SelectProjectCommand = new ProtectedCommand(() => GcpProjectId = promptPickProject() ?? GcpProjectId);
+            SelectProjectCommand =
+                new ProtectedCommand(() => GcpProjectId = promptPickProject()?.ProjectId ?? GcpProjectId);
             SelectedFramework = NetCoreAvailable ? FrameworkType.NetCore : FrameworkType.NetFramework;
         }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserWindow.cs
@@ -24,10 +24,9 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
     {
         private TemplateChooserViewModel ViewModel { get; }
 
-        private TemplateChooserWindow(string projectName)
-            : base(string.Format(GoogleCloudExtension.Resources.WizardTemplateChooserTitle, projectName))
+        private TemplateChooserWindow(string dialogTitle) : base(dialogTitle)
         {
-            ViewModel = new TemplateChooserViewModel(Close, () => PickProjectIdWindow.PromptUser(projectName));
+            ViewModel = new TemplateChooserViewModel(Close, () => PickProjectIdWindow.PromptUser(dialogTitle));
             Content = new TemplateChooserWindowContent { DataContext = ViewModel };
         }
 
@@ -38,7 +37,8 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
         /// <returns>The result of the dialog. Will return null when the dialog is canceled.</returns>
         public static TemplateChooserViewModelResult PromptUser(string projectName)
         {
-            var dialog = new TemplateChooserWindow(projectName);
+            var dialog = new TemplateChooserWindow(
+                string.Format(GoogleCloudExtension.Resources.WizardTemplateChooserTitle, projectName));
             dialog.ShowModal();
             return dialog.ViewModel.Result;
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/GoogleProjectTemplateWizard.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/GoogleProjectTemplateWizard.cs
@@ -30,7 +30,8 @@ namespace GoogleCloudExtension.TemplateWizards
     public class GoogleProjectTemplateWizard : IGoogleProjectTemplateWizard
     {
         // Mockable static methods for testing.
-        internal Func<string, string> PromptPickProjectId = projectName => PickProjectIdWindow.PromptUser(projectName);
+        internal Func<string, string> PromptPickProjectId = projectName =>
+            PickProjectIdWindow.PromptUser(string.Format(Resources.WizardTemplateChooserTitle, projectName));
         internal Action<Dictionary<string, string>> CleanupDirectories = GoogleTemplateWizardHelper.CleanupDirectories;
 
         ///<inheritdoc />

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/GoogleProjectTemplateWizard.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/GoogleProjectTemplateWizard.cs
@@ -20,6 +20,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
+using GcpProject = Google.Apis.CloudResourceManager.v1.Data.Project;
+using VsProject = EnvDTE.Project;
 
 namespace GoogleCloudExtension.TemplateWizards
 {
@@ -30,7 +32,7 @@ namespace GoogleCloudExtension.TemplateWizards
     public class GoogleProjectTemplateWizard : IGoogleProjectTemplateWizard
     {
         // Mockable static methods for testing.
-        internal Func<string, string> PromptPickProjectId = projectName =>
+        internal Func<string, GcpProject> PromptPickProjectId = projectName =>
             PickProjectIdWindow.PromptUser(string.Format(Resources.WizardTemplateChooserTitle, projectName));
         internal Action<Dictionary<string, string>> CleanupDirectories = GoogleTemplateWizardHelper.CleanupDirectories;
 
@@ -46,14 +48,14 @@ namespace GoogleCloudExtension.TemplateWizards
                 // Don't show the popup if the key has already been set.
                 if (!replacements.ContainsKey(ReplacementsKeys.GcpProjectIdKey))
                 {
-                    string projectId = PromptPickProjectId(replacements[ReplacementsKeys.ProjectNameKey]);
+                    GcpProject project = PromptPickProjectId(replacements[ReplacementsKeys.ProjectNameKey]);
 
-                    if (projectId == null)
+                    if (project == null)
                     {
                         // Null indicates a canceled operation.
                         throw new WizardBackoutException();
                     }
-                    replacements.Add(ReplacementsKeys.GcpProjectIdKey, projectId);
+                    replacements.Add(ReplacementsKeys.GcpProjectIdKey, project.ProjectId ?? "");
                 }
                 if (!replacements.ContainsKey(ReplacementsKeys.PackagesPathKey))
                 {
@@ -95,7 +97,7 @@ namespace GoogleCloudExtension.TemplateWizards
         }
 
         ///<inheritdoc />
-        public void ProjectFinishedGenerating(Project project)
+        public void ProjectFinishedGenerating(VsProject project)
         {
         }
     }

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -48,7 +48,7 @@ namespace GoogleCloudExtension.Utils
         /// </summary>
         /// <param name="name">The name to check.</param>
         /// <returns>True if the name is valid, false otherwise.</returns>
-        public static bool IsValidName(string name) => !String.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
+        public static bool IsValidName(string name) => !string.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
 
         public static IEnumerable<ValidationResult> ValidateName(string name, string fieldName)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/GcpPublishStepsUtils.cs
@@ -48,7 +48,7 @@ namespace GoogleCloudExtension.Utils
         /// </summary>
         /// <param name="name">The name to check.</param>
         /// <returns>True if the name is valid, false otherwise.</returns>
-        public static bool IsValidName(string name) => !string.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
+        public static bool IsValidName(string name) => !String.IsNullOrEmpty(name) && s_validNamePattern.IsMatch(name);
 
         public static IEnumerable<ValidationResult> ValidateName(string name, string fieldName)
         {

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -227,6 +227,7 @@
     <Compile Include="GoogleCloudExtensionPackageTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PublishDialogSteps\FlexStep\FlexStepViewModelTests.cs" />
+    <Compile Include="PublishDialog\PublishDialogStepBaseTests.cs" />
     <Compile Include="SplitStringBySpaceOrQuoteTests.cs" />
     <Compile Include="StackframeParserTests.cs" />
     <Compile Include="SolutionUserOptionsTests.cs" />
@@ -244,6 +245,10 @@
     <ProjectReference Include="..\GoogleCloudExtension.DataSources\GoogleCloudExtension.DataSources.csproj">
       <Project>{3988AAC1-3B20-4BA1-9627-ED7D3C80145F}</Project>
       <Name>GoogleCloudExtension.DataSources</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GoogleCloudExtension.Deployment\GoogleCloudExtension.Deployment.csproj">
+      <Project>{92C6E0D0-41D8-4ECC-87E1-AE72FCA891FC}</Project>
+      <Name>GoogleCloudExtension.Deployment</Name>
     </ProjectReference>
     <ProjectReference Include="..\GoogleCloudExtension.Interop\GoogleCloudExtension.Interop.csproj">
       <Project>{856b9f2e-441f-405a-9d5c-af5dc5653902}</Project>

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -226,6 +226,7 @@
     <Compile Include="CloudSourceRepository\RepoNameConverterTests.cs" />
     <Compile Include="GoogleCloudExtensionPackageTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PublishDialogSteps\FlexStep\FlexStepViewModelTests.cs" />
     <Compile Include="SplitStringBySpaceOrQuoteTests.cs" />
     <Compile Include="StackframeParserTests.cs" />
     <Compile Include="SolutionUserOptionsTests.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialog/PublishDialogStepBaseTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialog/PublishDialogStepBaseTests.cs
@@ -13,15 +13,11 @@
 // limitations under the License.
 
 using Google.Apis.CloudResourceManager.v1.Data;
-using GoogleCloudExtension;
 using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.Deployment;
 using GoogleCloudExtension.PublishDialog;
-using GoogleCloudExtension.PublishDialogSteps.FlexStep;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System;
-using System.Collections.Generic;
 
 namespace GoogleCloudExtensionUnitTests.PublishDialog
 {
@@ -31,12 +27,7 @@ namespace GoogleCloudExtensionUnitTests.PublishDialog
         private const string TargetProjectId = "TargetProjectId";
         private const string VisualStudioProjectName = "VisualStudioProjectName";
 
-        private static readonly string s_pickProjectDialogTitle =
-            string.Format(Resources.PublishDialogSelectGcpProjectTitle, VisualStudioProjectName);
-
         private PublishDialogStepBase _objectUnderTest;
-        private Mock<Func<string, string>> _pickProjectPromptMock;
-        private List<string> _changedProperties;
 
         [TestInitialize]
         public void BeforeEach()
@@ -47,32 +38,6 @@ namespace GoogleCloudExtensionUnitTests.PublishDialog
             var mockedProject = Mock.Of<IParsedProject>(p => p.Name == VisualStudioProjectName);
             var mockedPublishDialog = Mock.Of<IPublishDialog>(d => d.Project == mockedProject);
             _objectUnderTest.OnPushedToDialog(mockedPublishDialog);
-            _pickProjectPromptMock = new Mock<Func<string, string>>();
-            _objectUnderTest.PickProjectPrompt = _pickProjectPromptMock.Object;
-            _changedProperties = new List<string>();
-            _objectUnderTest.PropertyChanged += (sender, args) => _changedProperties.Add(args.PropertyName);
-        }
-
-        [TestMethod]
-        public void TestSelectProjectCommandCanceled()
-        {
-            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns((string)null);
-
-            _objectUnderTest.SelectProjectCommand.Execute(null);
-
-            CollectionAssert.DoesNotContain(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
-            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
-        }
-
-        [TestMethod]
-        public void TestSelectProjectCommand()
-        {
-            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns(TargetProjectId);
-
-            _objectUnderTest.SelectProjectCommand.Execute(null);
-
-            CollectionAssert.Contains(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
-            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
         }
 
         [TestMethod]
@@ -89,16 +54,6 @@ namespace GoogleCloudExtensionUnitTests.PublishDialog
             CredentialsStore.Default.UpdateCurrentProject(null);
 
             Assert.IsNull(_objectUnderTest.GcpProjectId);
-        }
-
-        [TestMethod]
-        public void TestOnPushedToDialog()
-        {
-            var dialogMock = new Mock<IPublishDialog>();
-
-            _objectUnderTest.OnPushedToDialog(dialogMock.Object);
-
-            Assert.AreEqual(dialogMock.Object, _objectUnderTest.PublishDialog);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialog/PublishDialogStepBaseTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialog/PublishDialogStepBaseTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.CloudResourceManager.v1.Data;
+using GoogleCloudExtension;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.Deployment;
+using GoogleCloudExtension.PublishDialog;
+using GoogleCloudExtension.PublishDialogSteps.FlexStep;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+
+namespace GoogleCloudExtensionUnitTests.PublishDialog
+{
+    [TestClass]
+    public class PublishDialogStepBaseTests
+    {
+        private const string TargetProjectId = "TargetProjectId";
+        private const string VisualStudioProjectName = "VisualStudioProjectName";
+
+        private static readonly string s_pickProjectDialogTitle =
+            string.Format(Resources.PublishDialogSelectGcpProjectTitle, VisualStudioProjectName);
+
+        private PublishDialogStepBase _objectUnderTest;
+        private Mock<Func<string, string>> _pickProjectPromptMock;
+        private List<string> _changedProperties;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            CredentialsStore.Default.UpdateCurrentProject(null);
+            var mockImpl = new Mock<PublishDialogStepBase> { CallBase = true };
+            _objectUnderTest = mockImpl.Object;
+            var mockedProject = Mock.Of<IParsedProject>(p => p.Name == VisualStudioProjectName);
+            var mockedPublishDialog = Mock.Of<IPublishDialog>(d => d.Project == mockedProject);
+            _objectUnderTest.OnPushedToDialog(mockedPublishDialog);
+            _pickProjectPromptMock = new Mock<Func<string, string>>();
+            _objectUnderTest.PickProjectPrompt = _pickProjectPromptMock.Object;
+            _changedProperties = new List<string>();
+            _objectUnderTest.PropertyChanged += (sender, args) => _changedProperties.Add(args.PropertyName);
+        }
+
+        [TestMethod]
+        public void TestSelectProjectCommandCanceled()
+        {
+            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns((string)null);
+
+            _objectUnderTest.SelectProjectCommand.Execute(null);
+
+            CollectionAssert.DoesNotContain(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
+            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestSelectProjectCommand()
+        {
+            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns(TargetProjectId);
+
+            _objectUnderTest.SelectProjectCommand.Execute(null);
+
+            CollectionAssert.Contains(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
+            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestGcpProjectIdWithProject()
+        {
+            CredentialsStore.Default.UpdateCurrentProject(new Project { ProjectId = TargetProjectId });
+
+            Assert.AreEqual(TargetProjectId, _objectUnderTest.GcpProjectId);
+        }
+
+        [TestMethod]
+        public void TestGcpProjectIdWithNoProject()
+        {
+            CredentialsStore.Default.UpdateCurrentProject(null);
+
+            Assert.IsNull(_objectUnderTest.GcpProjectId);
+        }
+
+        [TestMethod]
+        public void TestOnPushedToDialog()
+        {
+            var dialogMock = new Mock<IPublishDialog>();
+
+            _objectUnderTest.OnPushedToDialog(dialogMock.Object);
+
+            Assert.AreEqual(dialogMock.Object, _objectUnderTest.PublishDialog);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
@@ -12,30 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.CloudResourceManager.v1.Data;
 using GoogleCloudExtension;
-using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.PublishDialogSteps.FlexStep;
 using GoogleCloudExtension.UserPrompt;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using System.Collections.Generic;
 
 namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.FlexStep
 {
     [TestClass]
     public class FlexStepViewModelTests
     {
-        private const string TargetProjectId = "TargetProjectId";
-        private const string VisualStudioProjectName = "VisualStudioProjectName";
-
-        private static readonly string s_pickProjectDialogTitle =
-            string.Format(Resources.PublishDialogFlexSelectGcpProjectTitle, VisualStudioProjectName);
 
         private FlexStepViewModel _objectUnderTest;
-        private Mock<Func<string, string>> _pickProjectPromptMock;
-        private List<string> _changedProperties;
         private Mock<Func<UserPromptWindow.Options, bool>> _promptUserFunctionMock;
 
 
@@ -43,52 +33,9 @@ namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.FlexStep
         [TestInitialize]
         public void BeforeEach()
         {
-            CredentialsStore.Default.UpdateCurrentProject(null);
             _promptUserFunctionMock = new Mock<Func<UserPromptWindow.Options, bool>>();
             UserPromptWindow.PromptUserFunction = _promptUserFunctionMock.Object;
-            _objectUnderTest = FlexStepViewModel.CreateStep(VisualStudioProjectName);
-            _pickProjectPromptMock = new Mock<Func<string, string>>();
-            _objectUnderTest.PickProjectPrompt = _pickProjectPromptMock.Object;
-            _changedProperties = new List<string>();
-            _objectUnderTest.PropertyChanged += (sender, args) => _changedProperties.Add(args.PropertyName);
-        }
-
-        [TestMethod]
-        public void TestSelectProjectCommandCanceled()
-        {
-            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns((string)null);
-
-            _objectUnderTest.SelectProjectCommand.Execute(null);
-
-            CollectionAssert.DoesNotContain(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
-            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
-        }
-
-        [TestMethod]
-        public void TestSelectProjectCommand()
-        {
-            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns(TargetProjectId);
-
-            _objectUnderTest.SelectProjectCommand.Execute(null);
-
-            CollectionAssert.Contains(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
-            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
-        }
-
-        [TestMethod]
-        public void TestGcpProjectIdWithProject()
-        {
-            CredentialsStore.Default.UpdateCurrentProject(new Project { ProjectId = TargetProjectId });
-
-            Assert.AreEqual(TargetProjectId, _objectUnderTest.GcpProjectId);
-        }
-
-        [TestMethod]
-        public void TestGcpProjectIdWithNoProject()
-        {
-            CredentialsStore.Default.UpdateCurrentProject(null);
-
-            Assert.IsNull(_objectUnderTest.GcpProjectId);
+            _objectUnderTest = FlexStepViewModel.CreateStep();
         }
 
         [TestMethod]

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
@@ -1,0 +1,158 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.CloudResourceManager.v1.Data;
+using GoogleCloudExtension;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.PublishDialogSteps.FlexStep;
+using GoogleCloudExtension.UserPrompt;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+
+namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.FlexStep
+{
+    [TestClass]
+    public class FlexStepViewModelTests
+    {
+        private const string TargetProjectId = "TargetProjectId";
+        private const string VisualStudioProjectName = "VisualStudioProjectName";
+
+        private static readonly string s_pickProjectDialogTitle =
+            string.Format(Resources.PublishDialogFlexSelectGcpProjectTitle, VisualStudioProjectName);
+
+        private FlexStepViewModel _objectUnderTest;
+        private Mock<Func<string, string>> _pickProjectPromptMock;
+        private List<string> _changedProperties;
+        private Mock<Func<UserPromptWindow.Options, bool>> _promptUserFunctionMock;
+
+
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            CredentialsStore.Default.UpdateCurrentProject(null);
+            _promptUserFunctionMock = new Mock<Func<UserPromptWindow.Options, bool>>();
+            UserPromptWindow.PromptUserFunction = _promptUserFunctionMock.Object;
+            _objectUnderTest = FlexStepViewModel.CreateStep(VisualStudioProjectName);
+            _pickProjectPromptMock = new Mock<Func<string, string>>();
+            _objectUnderTest.PickProjectPrompt = _pickProjectPromptMock.Object;
+            _changedProperties = new List<string>();
+            _objectUnderTest.PropertyChanged += (sender, args) => _changedProperties.Add(args.PropertyName);
+        }
+
+        [TestMethod]
+        public void TestSelectProjectCommandCanceled()
+        {
+            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns((string)null);
+
+            _objectUnderTest.SelectProjectCommand.Execute(null);
+
+            CollectionAssert.DoesNotContain(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
+            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestSelectProjectCommand()
+        {
+            _pickProjectPromptMock.Setup(f => f(It.IsAny<string>())).Returns(TargetProjectId);
+
+            _objectUnderTest.SelectProjectCommand.Execute(null);
+
+            CollectionAssert.Contains(_changedProperties, nameof(FlexStepViewModel.GcpProjectId));
+            _pickProjectPromptMock.Verify(f => f(s_pickProjectDialogTitle), Times.Once);
+        }
+
+        [TestMethod]
+        public void TestGcpProjectIdWithProject()
+        {
+            CredentialsStore.Default.UpdateCurrentProject(new Project { ProjectId = TargetProjectId });
+
+            Assert.AreEqual(TargetProjectId, _objectUnderTest.GcpProjectId);
+        }
+
+        [TestMethod]
+        public void TestGcpProjectIdWithNoProject()
+        {
+            CredentialsStore.Default.UpdateCurrentProject(null);
+
+            Assert.IsNull(_objectUnderTest.GcpProjectId);
+        }
+
+        [TestMethod]
+        public void TestValidateInputNullVersion()
+        {
+            _promptUserFunctionMock.Setup(f => f(It.IsAny<UserPromptWindow.Options>())).Returns(true);
+            _objectUnderTest.Version = null;
+
+            bool result = _objectUnderTest.ValidateInput();
+
+            Assert.IsFalse(result);
+            _promptUserFunctionMock.Verify(
+                f => f(
+                    It.Is<UserPromptWindow.Options>(
+                        o => o.Title == Resources.UiInvalidValueTitle &&
+                            o.Prompt == Resources.FlexPublishEmptyVersionMessage)),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void TestValidateInputEmptyVersion()
+        {
+            _promptUserFunctionMock.Setup(f => f(It.IsAny<UserPromptWindow.Options>())).Returns(true);
+            _objectUnderTest.Version = "";
+
+            bool result = _objectUnderTest.ValidateInput();
+
+            Assert.IsFalse(result);
+            Func<UserPromptWindow.Options, bool> optionsPredicate =
+                o => o.Title == Resources.UiInvalidValueTitle &&
+                o.Prompt == Resources.FlexPublishEmptyVersionMessage;
+            _promptUserFunctionMock.Verify(
+                f => f(
+                    It.Is<UserPromptWindow.Options>(o => optionsPredicate(o))),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void TestValidateInputInvalidVersion()
+        {
+            _promptUserFunctionMock.Setup(f => f(It.IsAny<UserPromptWindow.Options>())).Returns(true);
+            _objectUnderTest.Version = "-Invalid Version Name!";
+
+            bool result = _objectUnderTest.ValidateInput();
+
+            Assert.IsFalse(result);
+            _promptUserFunctionMock.Verify(
+                f => f(
+                    It.Is<UserPromptWindow.Options>(
+                        o => o.Title == Resources.UiInvalidValueTitle &&
+                            o.Prompt == string.Format(Resources.FlexPublishInvalidVersionMessage, _objectUnderTest.Version))),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void TestValidateInputValidVersion()
+        {
+            _promptUserFunctionMock.Setup(f => f(It.IsAny<UserPromptWindow.Options>())).Returns(true);
+            _objectUnderTest.Version = "valid-version-name";
+
+            bool result = _objectUnderTest.ValidateInput();
+
+            Assert.IsTrue(result);
+            _promptUserFunctionMock.Verify(f => f(It.IsAny<UserPromptWindow.Options>()), Times.Never);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
@@ -24,11 +24,8 @@ namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.FlexStep
     [TestClass]
     public class FlexStepViewModelTests
     {
-
         private FlexStepViewModel _objectUnderTest;
         private Mock<Func<UserPromptWindow.Options, bool>> _promptUserFunctionMock;
-
-
 
         [TestInitialize]
         public void BeforeEach()

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/Dialogs/PickProjectIdViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/Dialogs/PickProjectIdViewModelTests.cs
@@ -350,7 +350,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
 
             _windowMock.Verify(window => window.Close());
             Assert.AreEqual(TestInputProjectId, _testObject.Result);
-            Assert.AreEqual(DefaultProjectId, CredentialsStore.Default.CurrentProjectId);
+            Assert.AreEqual(null, CredentialsStore.Default.CurrentProjectId);
         }
 
         [TestMethod]

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/Dialogs/TemplateChooserViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/Dialogs/TemplateChooserViewModelTests.cs
@@ -33,7 +33,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
     {
         private const string DefaultProjectId = "default-project-id";
         private Mock<Action> _closeWindowMock;
-        private Mock<Func<string>> _promptPickProjectMock;
+        private Mock<Func<Project>> _promptPickProjectMock;
         private TemplateChooserViewModel _objectUnderTest;
         private List<string> _targetSdkVersions;
 
@@ -45,7 +45,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
                 () => Mock.Of<IToolsPathProvider>(tpp => tpp.GetNetCoreSdkVersions() == _targetSdkVersions));
             CredentialsStore.Default.UpdateCurrentProject(Mock.Of<Project>(p => p.ProjectId == DefaultProjectId));
             _closeWindowMock = new Mock<Action>();
-            _promptPickProjectMock = new Mock<Func<string>>();
+            _promptPickProjectMock = new Mock<Func<Project>>();
             GoogleCloudExtensionPackageTests.InitPackageMock(
                 dteMock => dteMock.Setup(dte => dte.Version).Returns(VsVersionUtils.VisualStudio2017Version));
             _objectUnderTest = new TemplateChooserViewModel(_closeWindowMock.Object, _promptPickProjectMock.Object);
@@ -286,7 +286,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
         public void TestSelectProject()
         {
             const string mockProjectID = "mock-project-id";
-            _promptPickProjectMock.Setup(f => f()).Returns(mockProjectID);
+            _promptPickProjectMock.Setup(f => f()).Returns(new Project { ProjectId = mockProjectID });
 
             _objectUnderTest.SelectProjectCommand.Execute(null);
 
@@ -296,7 +296,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
         [TestMethod]
         public void TestSelectProjectCanceled()
         {
-            _promptPickProjectMock.Setup(f => f()).Returns((string) null);
+            _promptPickProjectMock.Setup(f => f()).Returns((Project) null);
 
             _objectUnderTest.SelectProjectCommand.Execute(null);
 

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/GoogleProjectTemplateWizardTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/GoogleProjectTemplateWizardTests.cs
@@ -19,6 +19,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using GcpProject = Google.Apis.CloudResourceManager.v1.Data.Project;
+using VsProject = EnvDTE.Project;
 
 namespace GoogleCloudExtensionUnitTests.TemplateWizards
 {
@@ -54,7 +56,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards
 
         private GoogleProjectTemplateWizard _objectUnderTest;
         private Mock<Action<Dictionary<string, string>>> _cleanupDirectoriesMock;
-        private Mock<Func<string, string>> _pickProjectMock;
+        private Mock<Func<string, GcpProject>> _pickProjectMock;
         private Dictionary<string, string> _replacementsDictionary;
         private DTE _mockedDte;
 
@@ -62,7 +64,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards
         public void BeforeEachTest()
         {
             _mockedDte = Mock.Of<DTE>(dte => dte.CommandLineArguments == "");
-            _pickProjectMock = new Mock<Func<string, string>>();
+            _pickProjectMock = new Mock<Func<string, GcpProject>>();
             _cleanupDirectoriesMock = new Mock<Action<Dictionary<string, string>>>();
             _objectUnderTest =
                 new GoogleProjectTemplateWizard
@@ -104,7 +106,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards
         [TestMethod]
         public void TestRunStartedPickProjectSkipped()
         {
-            _pickProjectMock.Setup(x => x(It.IsAny<string>())).Returns(() => string.Empty);
+            _pickProjectMock.Setup(x => x(It.IsAny<string>())).Returns(() => new GcpProject());
             foreach (string projectDir in s_projectDirectoriesToTest)
             {
                 foreach (string solutionDir in s_solutionDirectoriesToTest)
@@ -138,7 +140,8 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards
         [TestMethod]
         public void TestRunStartedSuccess()
         {
-            _pickProjectMock.Setup(x => x(It.IsAny<string>())).Returns(() => MockProjectId);
+            _pickProjectMock.Setup(x => x(It.IsAny<string>()))
+                .Returns(() => new GcpProject { ProjectId = MockProjectId });
             _replacementsDictionary.Add(ReplacementsKeys.SafeProjectNameKey, ProjectName);
 
             _objectUnderTest.RunStarted(
@@ -183,7 +186,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards
         [TestMethod]
         public void TestProjectFinishedGenerating()
         {
-            _objectUnderTest.ProjectFinishedGenerating(new Mock<Project>(MockBehavior.Strict).Object);
+            _objectUnderTest.ProjectFinishedGenerating(new Mock<VsProject>(MockBehavior.Strict).Object);
         }
     }
 }


### PR DESCRIPTION
Fixes #791.

Adds *Google Cloud Project ID* `TextBox` and *Select Project* `Button` to Publish dialogs.

Change project select dialog to change the current project (both for template dialogs and for publish dialogs).