### PR TITLE
Make MVC the default for the new template dialog box.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
@@ -158,8 +158,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
                 {
                     Result = new TemplateChooserViewModelResult(this);
                     closeWindow();
-                },
-                AppType != AppType.None);
+                });
             SelectProjectCommand = new ProtectedCommand(() => GcpProjectId = promptPickProject() ?? GcpProjectId);
             SelectedFramework = NetCoreAvailable ? FrameworkType.NetCore : FrameworkType.NetFramework;
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserViewModel.cs
@@ -29,7 +29,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
         private FrameworkType _selectedFramework;
         private AspNetVersion _selectedVersion;
         private IList<AspNetVersion> _availableVersions;
-        private AppType _appType = AppType.None;
+        private AppType _appType = AppType.Mvc;
 
         /// <summary>
         /// The id of a google cloud project.
@@ -125,7 +125,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
             private set
             {
                 SetValueAndRaise(ref _appType, value);
-                OkCommand.CanExecuteCommand = _appType != AppType.None;
+                OkCommand.CanExecuteCommand = AppType != AppType.None;
             }
         }
 
@@ -159,7 +159,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
                     Result = new TemplateChooserViewModelResult(this);
                     closeWindow();
                 },
-                false);
+                AppType != AppType.None);
             SelectProjectCommand = new ProtectedCommand(() => GcpProjectId = promptPickProject() ?? GcpProjectId);
             SelectedFramework = NetCoreAvailable ? FrameworkType.NetCore : FrameworkType.NetFramework;
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserWindowContent.xaml
@@ -33,17 +33,19 @@
                 IsCancel="True"/>
         </theming:CommonDialogWindowBaseContent.Buttons>
         <StackPanel Orientation="Vertical">
-            <DockPanel Margin="0,5,0,0">
+            <DockPanel Margin="0,0,0,8">
                 <Label
                     DockPanel.Dock ="Top"
                     Content="{x:Static ext:Resources.WizardTemplateChooserTargetFrameworkLabel}"
-                    Target="{Binding ElementName=_targetFramework}"/>
+                    Target="{Binding ElementName=_targetFramework}"
+                    Margin="0,0,0,5"/>
                 <StackPanel Orientation="Horizontal">
                     <ComboBox
                         x:Name="_targetFramework"
                         SelectedValuePath="Tag"
                         SelectedValue="{Binding SelectedFramework}"
-                        MinWidth="150px">
+                        MinWidth="150px"
+                        Margin="0,0,5,0">
                         
                         <ComboBoxItem
                             Tag="{x:Static local:FrameworkType.NetCore}"
@@ -57,34 +59,37 @@
                     <ComboBox
                         ItemsSource="{Binding AvailableVersions}"
                         SelectedItem="{Binding SelectedVersion}"
-                        MinWidth="180px"/>
+                        MinWidth="180px"
+                        Margin="0"/>
                 </StackPanel>
             </DockPanel>
-            <DockPanel Margin="0,5,0,0">
+            <DockPanel>
                 <Label
                     DockPanel.Dock="Top"
                     Content="{x:Static ext:Resources.WizardTemplateChooserProjectIdLabel}"
-                    Target="{Binding ElementName=_projectIdBox}"/>
-                <StackPanel Orientation="Horizontal">
-                    <TextBox x:Name="_projectIdBox" Text="{Binding GcpProjectId}" Width="200px"/>
+                    Target="{Binding ElementName=_projectIdBox}"
+                    Margin="0,0,0,5"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <TextBox x:Name="_projectIdBox" Text="{Binding GcpProjectId}" Width="200" Margin="0,0,5,0"/>
                     <Button
                         Command="{Binding SelectProjectCommand}"
-                        Content="{x:Static ext:Resources.WizardTemplateChooserSelectProjectButton}"/>
+                        Content="{x:Static ext:Resources.WizardTemplateChooserSelectProjectButton}"
+                        Margin="0" />
                 </StackPanel>
             </DockPanel>
-            <DockPanel Margin="0,5,0,0">
-                <TextBlock DockPanel.Dock="Top" Text="{x:Static ext:Resources.WizardTemplateChooserFeaturesLabel}"/>
-                <StackPanel Orientation="Horizontal">
-                    <RadioButton
-                        GroupName="AppType"
-                        Content="{x:Static ext:Resources.WizardTemplateChooserMvcLabel}"
-                        IsChecked="{Binding IsMvc}"/>
-                    <RadioButton
-                        GroupName="AppType"
-                        Content="{x:Static ext:Resources.WizardTemplateChooserWebApiLabel}"
-                        IsChecked="{Binding IsWebApi}"/>
-                </StackPanel>
-            </DockPanel>
+            <StackPanel>
+                <TextBlock Text="{x:Static ext:Resources.WizardTemplateChooserFeaturesLabel}" Margin="0,0,0,3"/>
+                <RadioButton
+                    GroupName="AppType"
+                    Content="{x:Static ext:Resources.WizardTemplateChooserMvcLabel}"
+                    IsChecked="{Binding IsMvc}"
+                    Margin="0,0,0,4"/>
+                <RadioButton
+                    GroupName="AppType"
+                    Content="{x:Static ext:Resources.WizardTemplateChooserWebApiLabel}"
+                    IsChecked="{Binding IsWebApi}"
+                    Margin="0"/>
+            </StackPanel>
         </StackPanel>
     </theming:CommonDialogWindowBaseContent>
 </UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/Dialogs/TemplateChooserViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/TemplateWizards/Dialogs/TemplateChooserViewModelTests.cs
@@ -54,8 +54,8 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
         [TestMethod]
         public void TestInitialConditions()
         {
-            Assert.AreEqual(AppType.None, _objectUnderTest.AppType);
-            Assert.AreEqual(false, _objectUnderTest.OkCommand.CanExecuteCommand);
+            Assert.AreEqual(AppType.Mvc, _objectUnderTest.AppType);
+            Assert.AreEqual(true, _objectUnderTest.OkCommand.CanExecuteCommand);
             Assert.AreEqual(DefaultProjectId, _objectUnderTest.GcpProjectId);
             Assert.IsNull(_objectUnderTest.Result);
         }
@@ -296,7 +296,7 @@ namespace GoogleCloudExtensionUnitTests.TemplateWizards.Dialogs
         [TestMethod]
         public void TestSelectProjectCanceled()
         {
-            _promptPickProjectMock.Setup(f => f()).Returns((string) null);
+            _promptPickProjectMock.Setup(f => f()).Returns((string)null);
 
             _objectUnderTest.SelectProjectCommand.Execute(null);
 


### PR DESCRIPTION
Fixes #814.

Make MVC the default for the new template dialog box.
Change the margins of the Template Chooser dialog to match the Microsoft UX Style Guide.

