### PR TITLE
Updating the gcloud dependency and version number.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/GCloudWrapper.cs
@@ -31,7 +31,7 @@ namespace GoogleCloudExtension.GCloud
     {
         // The minimum version of the Google Cloud SDK that the extension can work with. Update this only when
         // a feature appears in the Cloud SDK that is absolutely required for the extension to work.
-        public const string GCloudSdkMinimumVersion = "164.0.0";
+        public const string GCloudSdkMinimumVersion = "174.0.0";
 
         // These variables specify the environment to be reported by gcloud when reporting metrics. These variables
         // are only used with gcloud which is why they're private here.

--- a/GoogleCloudExtension/GoogleCloudExtension/Properties/AssemblyInfo.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Properties/AssemblyInfo.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 
 // This version number matches the version in the .vsixmanifest. Please update both versions at the
 // same time.
-[assembly: AssemblyVersion("1.2.9.0")]
+[assembly: AssemblyVersion("1.2.10.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo(
     "GoogleCloudExtensionUnitTests," +

--- a/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
+++ b/GoogleCloudExtension/GoogleCloudExtension/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
     The Version attribute of the Identity element *must* match the version number in Properties\AssemblyInfo.cs, to ensure 
     accurate metrics.
     -->
-        <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="1.2.9.0" Language="en-US" Publisher="Google Inc." />
+        <Identity Id="GoogleAppEngine.Google.d3d3eeb8-3710-4bd9-97ba-1401bf2acd22" Version="1.2.10.0" Language="en-US" Publisher="Google Inc." />
         <DisplayName>Google Cloud Tools for Visual Studio</DisplayName>
         <Description xml:space="preserve">Tools to develop applications for Google Cloud Platform.</Description>
         <MoreInfo>https://cloud.google.com/visual-studio/</MoreInfo>


### PR DESCRIPTION
This PR updates the gcloud dependency to 174.0.0 which includes support for .NET Core in the GA track. This PR also updates the version of the extension to be able to create a new release from this.

Fixes #821 