### PR TITLE
Adding support for enabling APIs for GCP projects.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/GoogleCloudExtension.DataSources.UnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/GoogleCloudExtension.DataSources.UnitTests.csproj
@@ -77,6 +77,10 @@
       <HintPath>..\packages\Google.Apis.Pubsub.v1.1.29.1.971\lib\net45\Google.Apis.Pubsub.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Google.Apis.ServiceManagement.v1, Version=1.29.1.981, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.ServiceManagement.v1.1.29.1.981\lib\net45\Google.Apis.ServiceManagement.v1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.7.127.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.127\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
@@ -106,6 +110,7 @@
     <Compile Include="DataSourceUnitTestsBase.cs" />
     <Compile Include="PubSubDataSourceUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceManagementDataSourceUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GoogleCloudExtension.DataSources\GoogleCloudExtension.DataSources.csproj">

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/ServiceManagementDataSourceUnitTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/ServiceManagementDataSourceUnitTests.cs
@@ -1,4 +1,18 @@
-﻿using Google.Apis.ServiceManagement.v1;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.ServiceManagement.v1;
 using Google.Apis.ServiceManagement.v1.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/ServiceManagementDataSourceUnitTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/ServiceManagementDataSourceUnitTests.cs
@@ -53,16 +53,16 @@ namespace GoogleCloudExtension.DataSources.UnitTests
                 responses);
 
             var dataSource = new ServiceManagementDataSource(service, ProjectName);
-            var serviceStatus = await dataSource.CheckServicesStatusAsync(new[] { Service1, Service2, Service3 });
+            var actualResults = (await dataSource.CheckServicesStatusAsync(new[] { Service1, Service2, Service3 })).ToList();
 
-            var expectedResult = new[]
+            var expectedResults = new[]
             {
                 new ServiceStatus(Service1, true),
                 new ServiceStatus(Service2, false),
                 new ServiceStatus(Service3, true)
             };
-            Assert.AreEqual(expectedResult.Length, serviceStatus.Count());
-            Assert.IsTrue(expectedResult.Zip(serviceStatus, (x, y) => x.Name == y.Name && x.Enabled == y.Enabled).All(x => x));
+            Assert.AreEqual(expectedResults.Length, actualResults.Count);
+            CollectionAssert.AreEqual(expectedResults, actualResults);
         }
 
         [TestMethod]
@@ -93,16 +93,16 @@ namespace GoogleCloudExtension.DataSources.UnitTests
                 responses);
 
             var dataSource = new ServiceManagementDataSource(service, ProjectName);
-            var serviceStatus = await dataSource.CheckServicesStatusAsync(new[] { Service1, Service2, Service3 });
+            var actualResults = (await dataSource.CheckServicesStatusAsync(new[] { Service1, Service2, Service3 })).ToList();
 
-            var expectedResult = new[]
+            var expectedResults = new[]
             {
                 new ServiceStatus(Service1, true),
                 new ServiceStatus(Service2, true),
                 new ServiceStatus(Service3, true)
             };
-            Assert.AreEqual(expectedResult.Length, serviceStatus.Count());
-            Assert.IsTrue(expectedResult.Zip(serviceStatus, (x, y) => x.Name == y.Name && x.Enabled == y.Enabled).All(x => x));
+            Assert.AreEqual(expectedResults.Length, actualResults.Count);
+            CollectionAssert.AreEqual(expectedResults, actualResults);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/ServiceManagementDataSourceUnitTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/ServiceManagementDataSourceUnitTests.cs
@@ -1,0 +1,94 @@
+﻿using Google.Apis.ServiceManagement.v1;
+using Google.Apis.ServiceManagement.v1.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.DataSources.UnitTests
+{
+    /// <summary>
+    /// Test class for <seealso cref="ServiceManagementDataSource"/>
+    /// </summary>
+    [TestClass]
+    public class ServiceManagementDataSourceUnitTests : DataSourceUnitTestsBase
+    {
+        private const string ProjectName = "Project";
+        private const string Service1 = "Service1";
+        private const string Service2 = "Service2";
+        private const string Service3 = "Service3";
+        private const string PageToken = "Token";
+
+        [TestMethod]
+        public async Task TestCheckServicesStatusAsyncSinglePage()
+        {
+            var responses = new[]
+            {
+                new ListServicesResponse
+                {
+                    Services = new List<ManagedService>
+                    {
+                        new ManagedService { ServiceName=Service1 },
+                        new ManagedService { ServiceName=Service3 }
+                    }
+                }
+            };
+            ServiceManagementService service = GetMockedService(
+                (ServiceManagementService s) => s.Services,
+                t => t.List(),
+                responses);
+
+            var dataSource = new ServiceManagementDataSource(service, ProjectName);
+            var serviceStatus = await dataSource.CheckServicesStatusAsync(new[] { Service1, Service2, Service3 });
+
+            var expectedResult = new[]
+            {
+                new ServiceStatus(Service1, true),
+                new ServiceStatus(Service2, false),
+                new ServiceStatus(Service3, true)
+            };
+            Assert.AreEqual(expectedResult.Length, serviceStatus.Count());
+            Assert.IsTrue(expectedResult.Zip(serviceStatus, (x, y) => x.Name == y.Name && x.Enabled == y.Enabled).All(x => x));
+        }
+
+        [TestMethod]
+        public async Task TestCheckServicesStatusAsyncMultiplePage()
+        {
+            var responses = new[]
+            {
+                new ListServicesResponse
+                {
+                    NextPageToken = PageToken,
+                    Services = new List<ManagedService>
+                    {
+                        new ManagedService { ServiceName=Service1 },
+                        new ManagedService { ServiceName=Service3 }
+                    }
+                },
+                new ListServicesResponse
+                {
+                    Services = new List<ManagedService>
+                    {
+                        new ManagedService { ServiceName=Service2 }
+                    }
+                }
+            };
+            ServiceManagementService service = GetMockedService(
+                (ServiceManagementService s) => s.Services,
+                t => t.List(),
+                responses);
+
+            var dataSource = new ServiceManagementDataSource(service, ProjectName);
+            var serviceStatus = await dataSource.CheckServicesStatusAsync(new[] { Service1, Service2, Service3 });
+
+            var expectedResult = new[]
+            {
+                new ServiceStatus(Service1, true),
+                new ServiceStatus(Service2, true),
+                new ServiceStatus(Service3, true)
+            };
+            Assert.AreEqual(expectedResult.Length, serviceStatus.Count());
+            Assert.IsTrue(expectedResult.Zip(serviceStatus, (x, y) => x.Name == y.Name && x.Enabled == y.Enabled).All(x => x));
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources.UnitTests/packages.config
@@ -7,6 +7,7 @@
   <package id="Google.Apis.Compute.v1" version="1.29.1.981" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.29.1" targetFramework="net452" />
   <package id="Google.Apis.Pubsub.v1" version="1.29.1.971" targetFramework="net452" />
+  <package id="Google.Apis.ServiceManagement.v1" version="1.29.1.981" targetFramework="net452" />
   <package id="Moq" version="4.7.127" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net452" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GaeDataSource.cs
@@ -54,6 +54,12 @@ namespace GoogleCloudExtension.DataSources
             }
             catch (GoogleApiException ex)
             {
+                if (ex.Error.Code == 404)
+                {
+                    Debug.WriteLine("Failed to find application, not an error.");
+                    return null;
+                }
+
                 Debug.WriteLine($"Failed to get application: {ex.Message}");
                 throw new DataSourceException(ex.Message, ex);
             }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GceDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GceDataSource.cs
@@ -434,7 +434,7 @@ namespace GoogleCloudExtension.DataSources
                 zoneName = new Uri(operation.Zone).Segments.Last();
             }
 
-            return OperationsUtils.AwaitOperationAsync(
+            return OperationUtils.AwaitOperationAsync(
                 operation,
                 refreshOperation: (op) =>
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -142,6 +142,7 @@
     <Compile Include="OperationUtils.cs" />
     <Compile Include="PubSubDataSource.cs" />
     <Compile Include="ServiceManagementDataSource.cs" />
+    <Compile Include="ServiceStatus.cs" />
     <Compile Include="StackdriverErrorReportingDataSource.cs" />
     <Compile Include="FirewallPort.cs" />
     <Compile Include="GaeDataSource.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -139,7 +139,7 @@
     <Compile Include="DataSourceException.cs" />
     <Compile Include="IPubsubDataSource.cs" />
     <Compile Include="IResourceManagerDataSource.cs" />
-    <Compile Include="OperationsUtils.cs" />
+    <Compile Include="OperationUtils.cs" />
     <Compile Include="PubSubDataSource.cs" />
     <Compile Include="ServiceManagementDataSource.cs" />
     <Compile Include="StackdriverErrorReportingDataSource.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -139,7 +139,7 @@
     <Compile Include="DataSourceException.cs" />
     <Compile Include="IPubsubDataSource.cs" />
     <Compile Include="IResourceManagerDataSource.cs" />
-    <Compile Include="Operations.cs" />
+    <Compile Include="OperationsUtils.cs" />
     <Compile Include="PubSubDataSource.cs" />
     <Compile Include="ServiceManagementDataSource.cs" />
     <Compile Include="StackdriverErrorReportingDataSource.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -98,6 +98,10 @@
       <HintPath>..\packages\Google.Apis.Pubsub.v1.1.29.1.971\lib\net45\Google.Apis.Pubsub.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Google.Apis.ServiceManagement.v1, Version=1.29.1.981, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.ServiceManagement.v1.1.29.1.981\lib\net45\Google.Apis.ServiceManagement.v1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Google.Apis.SQLAdmin.v1beta4, Version=1.29.1.949, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.SQLAdmin.v1beta4.1.29.1.949\lib\net45\Google.Apis.SQLAdmin.v1beta4.dll</HintPath>
       <Private>True</Private>
@@ -136,6 +140,7 @@
     <Compile Include="IPubsubDataSource.cs" />
     <Compile Include="IResourceManagerDataSource.cs" />
     <Compile Include="PubSubDataSource.cs" />
+    <Compile Include="ServiceManagementDataSource.cs" />
     <Compile Include="StackdriverErrorReportingDataSource.cs" />
     <Compile Include="FirewallPort.cs" />
     <Compile Include="GaeDataSource.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -139,6 +139,7 @@
     <Compile Include="DataSourceException.cs" />
     <Compile Include="IPubsubDataSource.cs" />
     <Compile Include="IResourceManagerDataSource.cs" />
+    <Compile Include="Operations.cs" />
     <Compile Include="PubSubDataSource.cs" />
     <Compile Include="ServiceManagementDataSource.cs" />
     <Compile Include="StackdriverErrorReportingDataSource.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationUtils.cs
@@ -11,7 +11,7 @@ namespace GoogleCloudExtension.DataSources
     /// <summary>
     /// This class contains utility methods to apply to Operations created from data sources.
     /// </summary>
-    public static class OperationsUtils
+    public static class OperationUtils
     {
         // A default delay of 2 seconds in between polls.
         private static readonly TimeSpan s_defaultDelay = TimeSpan.FromMilliseconds(2000);

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationUtils.cs
@@ -1,9 +1,20 @@
-﻿using Google;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.DataSources

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationUtils.cs
@@ -49,7 +49,7 @@ namespace GoogleCloudExtension.DataSources
                 while (true)
                 {
                     Debug.WriteLine("Polling for operation to finish.");
-                    var newOperation = await refreshOperation(operation);
+                    TOperation newOperation = await refreshOperation(operation);
 
                     if (isFinished(newOperation))
                     {

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/Operations.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/Operations.cs
@@ -8,10 +8,23 @@ using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.DataSources
 {
-    internal static class Operations
+    /// <summary>
+    /// This class contains utility methods to apply to Operations created from data sources.
+    /// </summary>
+    public static class Operations
     {
         private static readonly TimeSpan s_defaultDelay = TimeSpan.FromMilliseconds(2000);
 
+        /// <summary>
+        /// This method will poll the state of an operation, effectively transforming an operation into a <seealso cref="Task"/>.
+        /// </summary>
+        /// <typeparam name="TOperation">The type of the operation to poll.</typeparam>
+        /// <param name="operation">The operation to poll.</param>
+        /// <param name="refreshOperation">An function that will refresh the operation, returning an updated instance.</param>
+        /// <param name="isFinished">A function thgat determines if the operation is done.</param>
+        /// <param name="getErrorData">A function that will extract the error message from the operation, if in error.</param>
+        /// <param name="delay">The delay to use in between refreshes.</param>
+        /// <returns>A <seealso cref="Task"/> that will be completed once the operation is done.</returns>
         public static async Task AwaitOperationAsync<TOperation>(
             TOperation operation,
             Func<TOperation, Task<TOperation>> refreshOperation,

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/Operations.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/Operations.cs
@@ -1,0 +1,49 @@
+﻿using Google;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.DataSources
+{
+    internal static class Operations
+    {
+        private static readonly TimeSpan s_defaultDelay = TimeSpan.FromMilliseconds(2000);
+
+        public static async Task AwaitOperationAsync<TOperation>(
+            TOperation operation,
+            Func<TOperation, Task<TOperation>> refreshOperation,
+            Func<TOperation, bool> isFinished,
+            Func<TOperation, string> getErrorData,
+            TimeSpan? delay = null)
+        {
+            try
+            {
+                while (true)
+                {
+                    var newOperation = await refreshOperation(operation);
+
+                    if (isFinished(newOperation))
+                    {
+                        string errorData = getErrorData(newOperation);
+                        if (errorData != null)
+                        {
+                            throw new DataSourceException($"Operation failed: {errorData}.");
+                        }
+                    }
+
+                    await Task.Delay(delay ?? s_defaultDelay);
+                }
+            }
+            catch (GoogleApiException ex)
+            {
+                Debug.WriteLine($"Failed to read operation: {ex.Message}");
+                throw new DataSourceException(ex.Message, ex);
+            }
+
+        }
+
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/Operations.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/Operations.cs
@@ -23,15 +23,18 @@ namespace GoogleCloudExtension.DataSources
             {
                 while (true)
                 {
+                    Debug.WriteLine("Polling for operation to finish.");
                     var newOperation = await refreshOperation(operation);
 
                     if (isFinished(newOperation))
                     {
+                        Debug.WriteLine("Operation finished.");
                         string errorData = getErrorData(newOperation);
                         if (errorData != null)
                         {
                             throw new DataSourceException($"Operation failed: {errorData}.");
                         }
+                        return;
                     }
 
                     await Task.Delay(delay ?? s_defaultDelay);

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationsUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/OperationsUtils.cs
@@ -11,8 +11,9 @@ namespace GoogleCloudExtension.DataSources
     /// <summary>
     /// This class contains utility methods to apply to Operations created from data sources.
     /// </summary>
-    public static class Operations
+    public static class OperationsUtils
     {
+        // A default delay of 2 seconds in between polls.
         private static readonly TimeSpan s_defaultDelay = TimeSpan.FromMilliseconds(2000);
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -1,0 +1,55 @@
+﻿using Google.Apis.Auth.OAuth2;
+using Google.Apis.ServiceManagement.v1;
+using Google.Apis.ServiceManagement.v1.Data;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.DataSources
+{
+    public class ServiceManagementDataSource : DataSourceBase<ServiceManagementService>
+    {
+        public ServiceManagementDataSource(string projectId, GoogleCredential credential, string appName)
+            : base(projectId, credential, init => new ServiceManagementService(init), appName)
+        { }
+
+        public async Task<IList<ManagedService>> GetServicesAvailableAsync()
+        {
+            var request = Service.Services.List();
+
+            return await LoadPagedListAsync(
+                (token) =>
+                {
+                    request.PageToken = token;
+                    return request.ExecuteAsync();
+                },
+                x => x.Services,
+                x => x.NextPageToken);
+        }
+
+        public async Task<IList<ManagedService>> GetProjectServicesAsync()
+        {
+            var request = Service.Services.List();
+            request.ConsumerId = $"project:{ProjectId}";
+
+            return await LoadPagedListAsync(
+                (token) =>
+                {
+                    request.PageToken = token;
+                    return request.ExecuteAsync();
+                },
+                x => x.Services,
+                x => x.NextPageToken);
+        }
+
+        public async Task EnableServiceAsync(string serviceName)
+        {
+            var operation = await Service.Services
+                .Enable(new EnableServiceRequest { ConsumerId = ProjectId }, serviceName)
+                .ExecuteAsync();
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -69,7 +69,7 @@ namespace GoogleCloudExtension.DataSources
         public async Task EnableServiceAsync(string serviceName)
         {
             var operation = await Service.Services
-                .Enable(new EnableServiceRequest { ConsumerId = ProjectId }, serviceName)
+                .Enable(new EnableServiceRequest { ConsumerId = $"project:{ProjectId}" }, serviceName)
                 .ExecuteAsync();
 
             await Operations.AwaitOperationAsync(

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -1,4 +1,5 @@
-﻿using Google.Apis.Auth.OAuth2;
+﻿using Google;
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.ServiceManagement.v1;
 using Google.Apis.ServiceManagement.v1.Data;
 using System;
@@ -52,6 +53,19 @@ namespace GoogleCloudExtension.DataSources
             return enabledServices.Select(x => x.ServiceName).Contains(serviceName);
         }
 
+        public async Task<Service> GetServiceAsync(string serviceName)
+        {
+            try
+            {
+                var configs = await GetServiceConfigurationsAsync(serviceName);
+                return configs.FirstOrDefault();
+            }
+            catch (GoogleApiException ex)
+            {
+                throw new DataSourceException($"Failed to read service {serviceName}", ex);
+            }
+        }
+
         public async Task EnableServiceAsync(string serviceName)
         {
             var operation = await Service.Services
@@ -63,6 +77,20 @@ namespace GoogleCloudExtension.DataSources
                 refreshOperation: x => Service.Operations.Get(x.Name).ExecuteAsync(),
                 isFinished: x => x.Done ?? false,
                 getErrorData: x => x.Error?.Message);
+        }
+
+        public async Task<IList<Service>> GetServiceConfigurationsAsync(string serviceName)
+        {
+            var request = Service.Services.Configs.List(serviceName);
+
+            return await LoadPagedListAsync(
+                (token) =>
+                {
+                    request.PageToken = token;
+                    return request.ExecuteAsync();
+                },
+                x => x.ServiceConfigs,
+                x => x.NextPageToken);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -1,12 +1,24 @@
-﻿using Google;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.ServiceManagement.v1;
 using Google.Apis.ServiceManagement.v1.Data;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.DataSources

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -76,7 +76,7 @@ namespace GoogleCloudExtension.DataSources
                 .Enable(new EnableServiceRequest { ConsumerId = $"project:{ProjectId}" }, serviceName)
                 .ExecuteAsync();
 
-            await Operations.AwaitOperationAsync(
+            await OperationsUtils.AwaitOperationAsync(
                 operation,
                 refreshOperation: x => Service.Operations.Get(x.Name).ExecuteAsync(),
                 isFinished: x => x.Done ?? false,

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -32,6 +32,11 @@ namespace GoogleCloudExtension.DataSources
             : base(projectId, credential, init => new ServiceManagementService(init), appName)
         { }
 
+        // For testing.
+        internal ServiceManagementDataSource(ServiceManagementService mockedService, string projectId)
+            : base(projectId, null, init => mockedService, null)
+        { }
+
         /// <summary>
         /// Returns the <seealso cref="ServiceStatus"/> for each service in the given collection.
         /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -44,7 +44,7 @@ namespace GoogleCloudExtension.DataSources
         /// <returns>A task that will contain the collection of <seealso cref="ServiceStatus"/> with the status of each service.</returns>
         public async Task<IEnumerable<ServiceStatus>> CheckServicesStatusAsync(IEnumerable<string> serviceNames)
         {
-            var enabledServices = (await GetProjectEnabledServicesAsync()).Select(x => x.ServiceName);
+            IEnumerable<string> enabledServices = (await GetProjectEnabledServicesAsync()).Select(x => x.ServiceName);
             return serviceNames.Select(x => new ServiceStatus(x, enabledServices.Contains(x)));
         }
 
@@ -57,7 +57,7 @@ namespace GoogleCloudExtension.DataSources
         {
             foreach (var service in serviceNames)
             {
-                var operation = await Service.Services
+                Operation operation = await Service.Services
                     .Enable(new EnableServiceRequest { ConsumerId = $"project:{ProjectId}" }, service)
                     .ExecuteAsync();
 

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -30,7 +30,7 @@ namespace GoogleCloudExtension.DataSources
                 x => x.NextPageToken);
         }
 
-        public async Task<IList<ManagedService>> GetProjectServicesAsync()
+        public async Task<IList<ManagedService>> GetProjectEnabledServicesAsync()
         {
             var request = Service.Services.List();
             request.ConsumerId = $"project:{ProjectId}";
@@ -43,6 +43,13 @@ namespace GoogleCloudExtension.DataSources
                 },
                 x => x.Services,
                 x => x.NextPageToken);
+        }
+
+        public async Task<bool> IsServiceEnabledAsync(string serviceName)
+        {
+            // TODO: Determine if catching the list of services enabled for a project is worth while.
+            var enabledServices = await GetProjectEnabledServicesAsync();
+            return enabledServices.Select(x => x.ServiceName).Contains(serviceName);
         }
 
         public async Task EnableServiceAsync(string serviceName)

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -50,6 +50,12 @@ namespace GoogleCloudExtension.DataSources
             var operation = await Service.Services
                 .Enable(new EnableServiceRequest { ConsumerId = ProjectId }, serviceName)
                 .ExecuteAsync();
+
+            await Operations.AwaitOperationAsync(
+                operation,
+                refreshOperation: x => Service.Operations.Get(x.Name).ExecuteAsync(),
+                isFinished: x => x.Done ?? false,
+                getErrorData: x => x.Error?.Message);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceManagementDataSource.cs
@@ -76,7 +76,7 @@ namespace GoogleCloudExtension.DataSources
                 .Enable(new EnableServiceRequest { ConsumerId = $"project:{ProjectId}" }, serviceName)
                 .ExecuteAsync();
 
-            await OperationsUtils.AwaitOperationAsync(
+            await OperationUtils.AwaitOperationAsync(
                 operation,
                 refreshOperation: x => Service.Operations.Get(x.Name).ExecuteAsync(),
                 isFinished: x => x.Done ?? false,

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceStatus.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceStatus.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace GoogleCloudExtension.DataSources
 {
     /// <summary>
@@ -31,8 +33,43 @@ namespace GoogleCloudExtension.DataSources
 
         public ServiceStatus(string name, bool enabled)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException(nameof(name));
+            }
+
             Name = name;
             Enabled = enabled;
+        }
+
+        /// <summary>
+        /// Checks if this object is equal to the one provided.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            var other = obj as ServiceStatus;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return Name == other.Name && Enabled == other.Enabled;
+        }
+
+        /// <summary>
+        /// Returns the hashcode for the object, required when implementing equality.
+        /// Implementation adapted from:
+        ///   https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode
+        /// </summary>
+        public override int GetHashCode()
+        {
+            unchecked 
+            {
+                int hash = 17;
+                hash = hash * 23 + Name.GetHashCode();
+                hash = hash * 23 + Enabled.GetHashCode();
+                return hash;
+            }
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceStatus.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ServiceStatus.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GoogleCloudExtension.DataSources
+{
+    /// <summary>
+    /// Contains the status of a single service.
+    /// </summary>
+    public class ServiceStatus
+    {
+        /// <summary>
+        /// The name of the service.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Whether the service is enabled or not.
+        /// </summary>
+        public bool Enabled { get; }
+
+        public ServiceStatus(string name, bool enabled)
+        {
+            Name = name;
+            Enabled = enabled;
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/packages.config
@@ -13,6 +13,7 @@
   <package id="Google.Apis.Logging.v2" version="1.29.1.991" targetFramework="net452" />
   <package id="Google.Apis.Plus.v1" version="1.29.1.970" targetFramework="net452" />
   <package id="Google.Apis.Pubsub.v1" version="1.29.1.971" targetFramework="net452" />
+  <package id="Google.Apis.ServiceManagement.v1" version="1.29.1.981" targetFramework="net452" />
   <package id="Google.Apis.SQLAdmin.v1beta4" version="1.29.1.949" targetFramework="net452" />
   <package id="Google.Apis.Storage.v1" version="1.29.1.988" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -1,4 +1,18 @@
-﻿using GoogleCloudExtension.Accounts;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.ProgressDialog;
 using GoogleCloudExtension.Utils;

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -24,10 +24,18 @@ using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.ApiManagement
 {
+    /// <summary>
+    /// This class helps manage the APIs required by the various features in the extension. This class is defined as a singleton
+    /// that manages its own <seealso cref="ServiceManagementDataSource"/> instance. This class will update itself when the user
+    /// changes the current project/user.
+    /// </summary>
     public class ApiManager
     {
         private static readonly Lazy<ApiManager> s_defaultManager = new Lazy<ApiManager>(CreateApiManager);
 
+        /// <summary>
+        /// The singleton instance for this class.
+        /// </summary>
         public static ApiManager Default => s_defaultManager.Value;
 
         private Lazy<ServiceManagementDataSource> _dataSource = new Lazy<ServiceManagementDataSource>(CreateDataSource);
@@ -38,6 +46,11 @@ namespace GoogleCloudExtension.ApiManagement
             CredentialsStore.Default.Reset += OnCurrentCredentialsChanged;
         }
 
+        /// <summary>
+        /// This method will check that all of the given service names are enabled.
+        /// </summary>
+        /// <param name="serviceNames">The list of services to check.</param>
+        /// <returns>A task that will be true if all services are enabled, false otherwise.</returns>
         public async Task<bool> AreServicesEnabledAsync(IEnumerable<string> serviceNames)
         {
             var dataSource = _dataSource.Value;
@@ -50,13 +63,14 @@ namespace GoogleCloudExtension.ApiManagement
             return serviceStatus.All(x => x.Enabled);
         }
 
-        public Task<bool> EnsureServiceEnabledAsync(
-            string serviceName,
-            string prompt)
-        {
-            return EnsureAllServicesEnabledAsync(new List<string> { serviceName }, prompt);
-        }
 
+        /// <summary>
+        /// This method will check that all given services are enabled and if not will prompt the user to enable the
+        /// necessary services.
+        /// </summary>
+        /// <param name="serviceNames">The services to check.</param>
+        /// <param name="prompt">The prompt to use in the prompt dialog to ask the user for permission to enable the services.</param>
+        /// <returns>A task that will be true if all services where enabled, false if the user cancelled or if the operation failed.</returns>
         public async Task<bool> EnsureAllServicesEnabledAsync(
             IEnumerable<string> serviceNames,
             string prompt)
@@ -110,6 +124,11 @@ namespace GoogleCloudExtension.ApiManagement
             }
         }
 
+        /// <summary>
+        /// This method will enable the list of services given.
+        /// </summary>
+        /// <param name="serviceNames">The list of services to enable.</param>
+        /// <returns>A task that will be completed once the operation finishes.</returns>
         public async Task EnableServicesAsync(IEnumerable<string> serviceNames)
         {
             var dataSource = _dataSource.Value;

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -1,0 +1,77 @@
+﻿using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.DataSources;
+using GoogleCloudExtension.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.ApiManagement
+{
+    public class ApiManager
+    {
+        private static readonly Lazy<ApiManager> s_defaultManager = new Lazy<ApiManager>();
+
+        public static ApiManager Default => s_defaultManager.Value;
+
+        private Lazy<ServiceManagementDataSource> _dataSource = new Lazy<ServiceManagementDataSource>(CreateDataSource);
+
+        private ApiManager()
+        {
+            CredentialsStore.Default.CurrentAccountChanged += OnCurrentCredentialsChanged;
+            CredentialsStore.Default.Reset += OnCurrentCredentialsChanged;
+        }
+
+        public async Task<bool> EnsureServiceEnabledAsync(string serviceName)
+        {
+            var dataSource = _dataSource.Value;
+            if (dataSource == null)
+            {
+                return false;
+            }
+
+            if (await dataSource.IsServiceEnabledAsync(serviceName))
+            {
+                // Nothing to do.
+                Debug.WriteLine($"The service {serviceName} is already enabled.");
+                return true;
+            }
+
+            // Need to enable the service.
+            Debug.WriteLine($"Need to enable the service {serviceName}.");
+            var service = await dataSource.GetServiceAsync(serviceName);
+            if (!UserPromptUtils.ActionPrompt(
+                    prompt: $"Do you want to enable the API {service.Title}?",
+                    title: "Enable needed API",
+                    actionCaption: "Enable"))
+            {
+                return false;
+            }
+
+            await dataSource.EnableServiceAsync(serviceName);
+            return true;
+        }
+
+        private void OnCurrentCredentialsChanged(object sender, EventArgs e)
+        {
+            _dataSource = new Lazy<ServiceManagementDataSource>(CreateDataSource);
+        }
+
+        private static ServiceManagementDataSource CreateDataSource()
+        {
+            if (CredentialsStore.Default.CurrentProjectId != null)
+            {
+                return new ServiceManagementDataSource(
+                    CredentialsStore.Default.CurrentProjectId,
+                    CredentialsStore.Default.CurrentGoogleCredential,
+                    GoogleCloudExtensionPackage.VersionedApplicationName);
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -47,7 +47,7 @@ namespace GoogleCloudExtension.ApiManagement
             }
 
             var serviceStatus = await dataSource.CheckServicesStatusAsync(serviceNames);
-            return serviceStatus.All(x => x.Item2);
+            return serviceStatus.All(x => x.Enabled);
         }
 
         public Task<bool> EnsureServiceEnabledAsync(
@@ -71,8 +71,8 @@ namespace GoogleCloudExtension.ApiManagement
             {
                 // Check all services in parallel.
                 var servicesToEnable = (await dataSource.CheckServicesStatusAsync(serviceNames))
-                    .Where(x => !x.Item2)
-                    .Select(x => x.Item1);
+                    .Where(x => !x.Enabled)
+                    .Select(x => x.Name);
                 if (servicesToEnable.Count() == 0)
                 {
                     Debug.WriteLine("All the services are already enabled.");

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.ApiManagement

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -53,13 +53,13 @@ namespace GoogleCloudExtension.ApiManagement
         /// <returns>A task that will be true if all services are enabled, false otherwise.</returns>
         public async Task<bool> AreServicesEnabledAsync(IEnumerable<string> serviceNames)
         {
-            var dataSource = _dataSource.Value;
+            ServiceManagementDataSource dataSource = _dataSource.Value;
             if (dataSource == null)
             {
                 return false;
             }
 
-            var serviceStatus = await dataSource.CheckServicesStatusAsync(serviceNames);
+            IEnumerable<ServiceStatus> serviceStatus = await dataSource.CheckServicesStatusAsync(serviceNames);
             return serviceStatus.All(x => x.Enabled);
         }
 
@@ -75,7 +75,7 @@ namespace GoogleCloudExtension.ApiManagement
             IEnumerable<string> serviceNames,
             string prompt)
         {
-            var dataSource = _dataSource.Value;
+            ServiceManagementDataSource dataSource = _dataSource.Value;
             if (dataSource == null)
             {
                 return false;
@@ -84,10 +84,11 @@ namespace GoogleCloudExtension.ApiManagement
             try
             {
                 // Check all services in parallel.
-                var servicesToEnable = (await dataSource.CheckServicesStatusAsync(serviceNames))
+                IList<string> servicesToEnable = (await dataSource.CheckServicesStatusAsync(serviceNames))
                     .Where(x => !x.Enabled)
-                    .Select(x => x.Name);
-                if (servicesToEnable.Count() == 0)
+                    .Select(x => x.Name)
+                    .ToList();
+                if (servicesToEnable.Count == 0)
                 {
                     Debug.WriteLine("All the services are already enabled.");
                     return true;
@@ -131,7 +132,7 @@ namespace GoogleCloudExtension.ApiManagement
         /// <returns>A task that will be completed once the operation finishes.</returns>
         public async Task EnableServicesAsync(IEnumerable<string> serviceNames)
         {
-            var dataSource = _dataSource.Value;
+            ServiceManagementDataSource dataSource = _dataSource.Value;
             if (dataSource == null)
             {
                 return;

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -70,8 +70,8 @@ namespace GoogleCloudExtension.ApiManagement
                 Debug.WriteLine($"Need to enable the services: {string.Join(",", servicesToEnable)}.");
                 if (!UserPromptUtils.ActionPrompt(
                         prompt: prompt,
-                        title: "Enable Required Services",
-                        actionCaption: "Enable"))
+                        title: Resources.ApiManagerEnableServicesTitle,
+                        actionCaption: Resources.UiEnableButtonCaption))
                 {
                     return false;
                 }
@@ -81,8 +81,8 @@ namespace GoogleCloudExtension.ApiManagement
                     dataSource.EnableAllServicesAsync(servicesToEnable),
                     new ProgressDialogWindow.Options
                     {
-                        Title = "Enabling Services",
-                        Message = "Enabling the necessary services.",
+                        Title = Resources.ApiManagerEnableServicesTitle,
+                        Message = Resources.ApiManagerEnableServicesProgressMessage,
                         IsCancellable = false
                     });
                 return true;
@@ -90,7 +90,7 @@ namespace GoogleCloudExtension.ApiManagement
             catch (DataSourceException ex)
             {
                 UserPromptUtils.ErrorPrompt(
-                    message: "Failed to enable the necessary services.",
+                    message: Resources.ApiManagerEnableServicesErrorMessage,
                     title: Resources.UiErrorCaption,
                     errorDetails: ex.Message);
                 return false;
@@ -111,15 +111,15 @@ namespace GoogleCloudExtension.ApiManagement
                     dataSource.EnableAllServicesAsync(serviceNames),
                     new ProgressDialogWindow.Options
                     {
-                        Title = "Enabling Services",
-                        Message = "Enabling the necessary services.",
+                        Title = Resources.ApiManagerEnableServicesTitle,
+                        Message = Resources.ApiManagerEnableServicesProgressMessage,
                         IsCancellable = false
                     });
             }
             catch (DataSourceException ex)
             {
                 UserPromptUtils.ErrorPrompt(
-                    message: "Failed to enable the necessary services.",
+                    message: Resources.ApiManagerEnableServicesErrorMessage,
                     title: Resources.UiErrorCaption,
                     errorDetails: ex.Message);
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -12,7 +12,7 @@ namespace GoogleCloudExtension.ApiManagement
 {
     public class ApiManager
     {
-        private static readonly Lazy<ApiManager> s_defaultManager = new Lazy<ApiManager>();
+        private static readonly Lazy<ApiManager> s_defaultManager = new Lazy<ApiManager>(CreateApiManager);
 
         public static ApiManager Default => s_defaultManager.Value;
 
@@ -24,7 +24,9 @@ namespace GoogleCloudExtension.ApiManagement
             CredentialsStore.Default.Reset += OnCurrentCredentialsChanged;
         }
 
-        public async Task<bool> EnsureServiceEnabledAsync(string serviceName)
+        public async Task<bool> EnsureServiceEnabledAsync(
+            string serviceName,
+            string displayName)
         {
             var dataSource = _dataSource.Value;
             if (dataSource == null)
@@ -41,9 +43,8 @@ namespace GoogleCloudExtension.ApiManagement
 
             // Need to enable the service.
             Debug.WriteLine($"Need to enable the service {serviceName}.");
-            var service = await dataSource.GetServiceAsync(serviceName);
             if (!UserPromptUtils.ActionPrompt(
-                    prompt: $"Do you want to enable the API {service.Title}?",
+                    prompt: $"Do you want to enable the API {displayName}?",
                     title: "Enable needed API",
                     actionCaption: "Enable"))
             {
@@ -58,6 +59,8 @@ namespace GoogleCloudExtension.ApiManagement
         {
             _dataSource = new Lazy<ServiceManagementDataSource>(CreateDataSource);
         }
+
+        private static ApiManager CreateApiManager() => new ApiManager();
 
         private static ServiceManagementDataSource CreateDataSource()
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -51,8 +51,13 @@ namespace GoogleCloudExtension.ApiManagement
         /// </summary>
         /// <param name="serviceNames">The list of services to check.</param>
         /// <returns>A task that will be true if all services are enabled, false otherwise.</returns>
-        public async Task<bool> AreServicesEnabledAsync(IEnumerable<string> serviceNames)
+        public async Task<bool> AreServicesEnabledAsync(IList<string> serviceNames)
         {
+            if (serviceNames == null || serviceNames.Count == 0)
+            {
+                return true;
+            }
+
             ServiceManagementDataSource dataSource = _dataSource.Value;
             if (dataSource == null)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -22,5 +22,8 @@ namespace GoogleCloudExtension.ApiManagement
 
         // The API necessary to use the Cloud Builder.
         public const string CloudBuildApiName = "cloudbuild.googleapis.com";
+
+        // The API necessary to manage Cloud SQL instances.
+        public const string CloudSQLApiName = "sqladmin.googleapis.com";
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -14,27 +14,44 @@
 
 namespace GoogleCloudExtension.ApiManagement
 {
+    /// <summary>
+    /// This class contains the well known API names of the APIs used by the extension.
+    /// </summary>
     public static class KnownApis
     {
-        // The API necessary to use App Engine services.
+        /// <summary>
+        /// The API necessary to use App Engine services.
+        /// </summary>
         public const string AppEngineAdminApiName = "appengine.googleapis.com";
 
-        // The API necessary to use GCE.
+        /// <summary>
+        /// The API necessary to use GCE.
+        /// </summary>
         public const string ComputeEngineApiName = "compute.googleapis.com";
 
-        // The API necessary to use GCS.
+        /// <summary>
+        /// The API necessary to use GCS.
+        /// </summary>
         public const string CloudStorageApiName = "storage-api.googleapis.com";
 
-        // The API necessary to use GKS.
+        /// <summary>
+        /// The API necessary to use GKS.
+        /// </summary>
         public const string ContainerEngineApiName = "container.googleapis.com";
 
-        // The API necessary to use the Cloud Builder.
+        /// <summary>
+        /// The API necessary to use the Cloud Builder.
+        /// </summary>
         public const string CloudBuildApiName = "cloudbuild.googleapis.com";
 
-        // The API necessary to manage Cloud SQL instances.
+        /// <summary>
+        /// The API necessary to manage Cloud SQL instances.
+        /// </summary>
         public const string CloudSQLApiName = "sqladmin.googleapis.com";
 
-        // The API necessary to manage Pub/Sub subscriptions.
+        /// <summary>
+        /// The API necessary to manage Pub/Sub subscriptions.
+        /// </summary>
         public const string PubSubApiName = "pubsub.googleapis.com";
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -1,4 +1,18 @@
-﻿namespace GoogleCloudExtension.ApiManagement
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GoogleCloudExtension.ApiManagement
 {
     public static class KnownApis
     {

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -13,5 +13,8 @@ namespace GoogleCloudExtension.ApiManagement
 
         // The API necessary to use GCE.
         public const string ComputeEngineApiName = "compute.googleapis.com";
+
+        // The API necessary to use GCS.
+        public const string CloudStorageApiName = "storage-component.googleapis.com";
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.ApiManagement
+{
+    public static class KnownApis
+    {
+        // The API necessary to use App Engine services.
+        public const string AppEngineAdminApiName = "appengine.googleapis.com";
+
+        // The API necessary to use GCE.
+        public const string ComputeEngineApiName = "compute.googleapis.com";
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -15,6 +15,12 @@ namespace GoogleCloudExtension.ApiManagement
         public const string ComputeEngineApiName = "compute.googleapis.com";
 
         // The API necessary to use GCS.
-        public const string CloudStorageApiName = "storage-component.googleapis.com";
+        public const string CloudStorageApiName = "storage-api.googleapis.com";
+
+        // The API necessary to use GKS.
+        public const string ContainerEngineApiName = "container.googleapis.com";
+
+        // The API necessary to use the Cloud Builder.
+        public const string CloudBuildApiName = "cloudbuild.googleapis.com";
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace GoogleCloudExtension.ApiManagement
+﻿namespace GoogleCloudExtension.ApiManagement
 {
     public static class KnownApis
     {

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/KnownApis.cs
@@ -25,5 +25,8 @@ namespace GoogleCloudExtension.ApiManagement
 
         // The API necessary to manage Cloud SQL instances.
         public const string CloudSQLApiName = "sqladmin.googleapis.com";
+
+        // The API necessary to manage Pub/Sub subscriptions.
+        public const string PubSubApiName = "pubsub.googleapis.com";
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/EnablePortStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/AttachDebuggerDialog/EnablePortStepViewModel.cs
@@ -31,7 +31,7 @@ namespace GoogleCloudExtension.AttachDebuggerDialog
         private string _progressMessage;
         private bool _askingToConfirm;
         private bool _askingToTestConnectivityLater;
-        private AttachDebuggerFirewallPort _port;
+        private readonly AttachDebuggerFirewallPort _port;
 
         /// <summary>
         /// Show the message if the port is not enabled.

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
@@ -87,7 +87,7 @@ namespace GoogleCloudExtension.CloudExplorer
         /// <summary>
         /// Returns the names of the required APIs for the source.
         /// </summary>
-        public abstract IEnumerable<string> RequiredApis { get; }
+        public abstract IList<string> RequiredApis { get; }
 
         /// <summary>
         /// Returns the context in which this source root view model is working.

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/SourceRootViewModelBase.cs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.ApiManagement;
 using GoogleCloudExtension.Theming;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Media;
 
@@ -76,6 +78,16 @@ namespace GoogleCloudExtension.CloudExplorer
         /// Returns the tree node to use while loading data.
         /// </summary>
         public abstract TreeLeaf LoadingPlaceholder { get; }
+
+        /// <summary>
+        /// Returns the tree node to use when we detect that the necessary APIs are not enabled.
+        /// </summary>
+        public abstract TreeLeaf ApiNotEnabledPlaceholder { get; }
+
+        /// <summary>
+        /// Returns the names of the required APIs for the source.
+        /// </summary>
+        public abstract IEnumerable<string> RequiredApis { get; }
 
         /// <summary>
         /// Returns the context in which this source root view model is working.
@@ -148,6 +160,13 @@ namespace GoogleCloudExtension.CloudExplorer
                 }
 
                 Children.Add(LoadingPlaceholder);
+
+                if (!await ApiManager.Default.AreServicesEnabledAsync(RequiredApis))
+                {
+                    Children.Clear();
+                    Children.Add(ApiNotEnabledPlaceholder);
+                    return;
+                }
 
                 await LoadDataOverride();
                 if (Children.Count == 0)

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
@@ -50,7 +50,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             IsError = true
         };
 
-        private static readonly IEnumerable<string> s_requiredApis = new List<string>
+        private static readonly IList<string> s_requiredApis = new List<string>
         {
             // Need the Cloud SQL API.
             KnownApis.CloudSQLApiName
@@ -84,7 +84,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
                 }
             };
 
-        public override IEnumerable<string> RequiredApis => s_requiredApis;
+        public override IList<string> RequiredApis => s_requiredApis;
 
         public override void Initialize(ICloudSourceContext context)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
@@ -49,18 +49,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             Caption = Resources.CloudExplorerSqlFailedToLoadInstancesCaption,
             IsError = true
         };
-        private static readonly TreeLeaf s_apiDisabledPlaceholder = new TreeLeaf
-        {
-            Caption = "The Cloud Storage API is not enabled.",
-            IsError = true,
-            ContextMenu = new ContextMenu
-            {
-                ItemsSource = new List<FrameworkElement>
-                {
-                    new MenuItem { Header = "Enable the Cloud Storage API", Command = new ProtectedCommand(OnEnableCloudSQLApi) }
-                }
-            }
-        };
 
         public static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
@@ -123,8 +111,21 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             {
                 if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
                 {
+                    var placeholder = new TreeLeaf
+                    {
+                        Caption = "The Cloud Storage API is not enabled.",
+                        IsError = true,
+                        ContextMenu = new ContextMenu
+                        {
+                            ItemsSource = new List<FrameworkElement>
+                            {
+                                new MenuItem { Header = "Enable the Cloud Storage API", Command = new ProtectedCommand(OnEnableCloudSQLApi) }
+                            }
+                        }
+                    };
+
                     Children.Clear();
-                    Children.Add(s_apiDisabledPlaceholder);
+                    Children.Add(placeholder);
                     return;
                 }
 
@@ -166,9 +167,10 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             return instances?.Select(x => new InstanceViewModel(this, x)).ToList();
         }
 
-        private static async void OnEnableCloudSQLApi()
+        private async void OnEnableCloudSQLApi()
         {
             await ApiManager.Default.EnableServicesAsync(s_requiredApis);
+            Refresh();
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
@@ -66,6 +66,26 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
 
         public override TreeLeaf NoItemsPlaceholder => s_noItemsPlacehoder;
 
+        public override TreeLeaf ApiNotEnabledPlaceholder
+            => new TreeLeaf
+            {
+                Caption = Resources.CloudExplorerSqlApiNotEnabledCaption,
+                IsError = true,
+                ContextMenu = new ContextMenu
+                {
+                    ItemsSource = new List<FrameworkElement>
+                    {
+                        new MenuItem
+                        {
+                            Header = Resources.CloudExplorerSqlEnableApiMenuHeader,
+                            Command = new ProtectedCommand(OnEnableCloudSQLApi)
+                        }
+                    }
+                }
+            };
+
+        public override IEnumerable<string> RequiredApis => s_requiredApis;
+
         public override void Initialize(ICloudSourceContext context)
         {
             base.Initialize(context);
@@ -109,26 +129,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
         {
             try
             {
-                if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
-                {
-                    var placeholder = new TreeLeaf
-                    {
-                        Caption = Resources.CloudExplorerSqlApiNotEnabledCaption,
-                        IsError = true,
-                        ContextMenu = new ContextMenu
-                        {
-                            ItemsSource = new List<FrameworkElement>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerSqlEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableCloudSQLApi) }
-                            }
-                        }
-                    };
-
-                    Children.Clear();
-                    Children.Add(placeholder);
-                    return;
-                }
-
                 Debug.WriteLine("Loading list of instances.");
                 var instances = await LoadInstanceList();
                 Children.Clear();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
@@ -50,7 +50,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
             IsError = true
         };
 
-        public static readonly IEnumerable<string> s_requiredApis = new List<string>
+        private static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
             // Need the Cloud SQL API.
             KnownApis.CloudSQLApiName

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/CloudSQL/CloudSQLSourceRootViewModel.cs
@@ -113,13 +113,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.CloudSQL
                 {
                     var placeholder = new TreeLeaf
                     {
-                        Caption = "The Cloud Storage API is not enabled.",
+                        Caption = Resources.CloudExplorerSqlApiNotEnabledCaption,
                         IsError = true,
                         ContextMenu = new ContextMenu
                         {
                             ItemsSource = new List<FrameworkElement>
                             {
-                                new MenuItem { Header = "Enable the Cloud Storage API", Command = new ProtectedCommand(OnEnableCloudSQLApi) }
+                                new MenuItem { Header = Resources.CloudExplorerSqlEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableCloudSQLApi) }
                             }
                         }
                     };

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -163,13 +163,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 {
                     var placeholder = new TreeLeaf
                     {
-                        Caption = "The App Engine Admin API is not enabled.",
+                        Caption = Resources.CloudExplorerGaeApiNotEnabledCaption,
                         IsError = true,
                         ContextMenu = new ContextMenu
                         {
                             ItemsSource = new List<MenuItem>
                             {
-                                new MenuItem { Header = "Enable App Engine Admin API", Command = new ProtectedCommand(OnEnableGaeApi) }
+                                new MenuItem { Header = Resources.CloudExplorerGaeEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGaeApi) }
                             }
                         }
                     };

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -156,7 +156,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 // Check that the service is enabled before doing anything.
                 if (!await ApiManager.Default.EnsureServiceEnabledAsync(
                         serviceName: KnownApis.AppEngineAdminApiName,
-                        displayName: "App Engine API"))
+                        prompt: "App Engine API"))
                 {
                     Children.Clear();
                     Children.Add(s_apiDisabledPlaceholder);

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -55,7 +55,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             IsError = true
         };
 
-        private static readonly IEnumerable<string> s_requiredApis = new List<string>
+        private static readonly IList<string> s_requiredApis = new List<string>
         {
             // Require the GAE API.
             KnownApis.AppEngineAdminApiName
@@ -93,7 +93,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 }
             };
 
-        public override IEnumerable<string> RequiredApis => s_requiredApis;
+        public override IList<string> RequiredApis => s_requiredApis;
 
         public override void Initialize(ICloudSourceContext context)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -55,9 +55,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             IsError = true
         };
 
-        // The name of the API to have enabled.
-        private const string AppEngineAdminApiName = "appengine.googleapis.com";
-
         private Lazy<GaeDataSource> _dataSource;
         private Task<Application> _gaeApplication;
 
@@ -158,7 +155,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
                 // Check that the service is enabled before doing anything.
                 if (!await ApiManager.Default.EnsureServiceEnabledAsync(
-                        serviceName: AppEngineAdminApiName,
+                        serviceName: KnownApis.AppEngineAdminApiName,
                         displayName: "App Engine API"))
                 {
                     Children.Clear();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -54,13 +54,17 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             Caption = "The App Engine Admin API is not enabled.",
             IsError = true
         };
+        private static readonly TreeLeaf s_noAppEngineAppPlaceholder = new TreeLeaf
+        {
+            Caption = "No App Engine app found.",
+            IsError = true
+        };
 
         private Lazy<GaeDataSource> _dataSource;
-        private Task<Application> _gaeApplication;
 
         public GaeDataSource DataSource => _dataSource.Value;
 
-        public Task<Application> GaeApplication => _gaeApplication;
+        public Application GaeApplication { get; private set; }
 
         public override string RootCaption => Resources.CloudExplorerGaeRootNodeCaption;
 
@@ -163,7 +167,14 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                     return;
                 }
 
-                _gaeApplication = _dataSource.Value.GetApplicationAsync();
+                GaeApplication = await _dataSource.Value.GetApplicationAsync();
+                if (GaeApplication == null)
+                {
+                    Children.Clear();
+                    Children.Add(s_noAppEngineAppPlaceholder);
+                    return;
+                }
+
                 IList<ServiceViewModel> services = await LoadServiceList();
 
                 Children.Clear();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -75,6 +75,22 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         public override TreeLeaf NoItemsPlaceholder => s_noItemsPlacehoder;
 
+        public override TreeLeaf ApiNotEnabledPlaceholder
+            => new TreeLeaf
+            {
+                Caption = Resources.CloudExplorerGaeApiNotEnabledCaption,
+                IsError = true,
+                ContextMenu = new ContextMenu
+                {
+                    ItemsSource = new List<MenuItem>
+                            {
+                                new MenuItem { Header = Resources.CloudExplorerGaeEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGaeApi) }
+                            }
+                }
+            };
+
+        public override IEnumerable<string> RequiredApis => s_requiredApis;
+
         public override void Initialize(ICloudSourceContext context)
         {
             base.Initialize(context);
@@ -157,27 +173,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             try
             {
                 Debug.WriteLine("Loading list of services.");
-
-                // Check that the service is enabled before doing anything.
-                if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
-                {
-                    var placeholder = new TreeLeaf
-                    {
-                        Caption = Resources.CloudExplorerGaeApiNotEnabledCaption,
-                        IsError = true,
-                        ContextMenu = new ContextMenu
-                        {
-                            ItemsSource = new List<MenuItem>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerGaeEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGaeApi) }
-                            }
-                        }
-                    };
-
-                    Children.Clear();
-                    Children.Add(placeholder);
-                    return;
-                }
 
                 GaeApplication = await _dataSource.Value.GetApplicationAsync();
                 if (GaeApplication == null)

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -51,7 +51,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
         };
         private static readonly TreeLeaf s_noAppEngineAppPlaceholder = new TreeLeaf
         {
-            Caption = "No App Engine app found.",
+            Caption = Resources.CloudExplorerGaeNoAppFoundCaption,
             IsError = true
         };
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/GaeSourceRootViewModel.cs
@@ -83,9 +83,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
                 ContextMenu = new ContextMenu
                 {
                     ItemsSource = new List<MenuItem>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerGaeEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGaeApi) }
-                            }
+                    {
+                        new MenuItem
+                        {
+                            Header = Resources.CloudExplorerGaeEnableApiMenuHeader,
+                            Command = new ProtectedCommand(OnEnableGaeApi)
+                        }
+                    }
                 }
             };
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -315,9 +315,9 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
             _owner.Context.ShowPropertiesWindow(GetItem());
         }
 
-        private async void OnOpenService()
+        private void OnOpenService()
         {
-            var app = await _owner.GaeApplication;
+            var app = _owner.GaeApplication;
             var url = GaeUtils.GetAppUrl(app.DefaultHostname, Service.Id);
             Process.Start(url);
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gae/ServiceViewModel.cs
@@ -317,9 +317,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gae
 
         private void OnOpenService()
         {
-            var app = _owner.GaeApplication;
-            var url = GaeUtils.GetAppUrl(app.DefaultHostname, Service.Id);
-            Process.Start(url);
+            Process.Start(GaeUtils.GetAppUrl(_owner.GaeApplication.DefaultHostname, Service.Id));
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -69,6 +69,22 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
 
         public override TreeLeaf NoItemsPlaceholder => s_noItemsPlacehoder;
 
+        public override TreeLeaf ApiNotEnabledPlaceholder
+            => new TreeLeaf
+            {
+                Caption = Resources.CloudExplorerGceApiNotEnabledCaption,
+                IsError = true,
+                ContextMenu = new ContextMenu
+                {
+                    ItemsSource = new List<FrameworkElement>
+                            {
+                                new MenuItem { Header = Resources.CloudExplorerGceEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGceApi) }
+                            }
+                }
+            };
+
+        public override IEnumerable<string> RequiredApis => s_requiredApis;
+
         public override string RootCaption => Resources.CloudExplorerGceRootNodeCaption;
 
         /// <summary>
@@ -222,27 +238,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             try
             {
                 _instancesPerZone = null;
-
-                if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
-                {
-                    var placeholder = new TreeLeaf
-                    {
-                        Caption = Resources.CloudExplorerGceApiNotEnabledCaption,
-                        IsError = true,
-                        ContextMenu = new ContextMenu
-                        {
-                            ItemsSource = new List<FrameworkElement>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerGceEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGceApi) }
-                            }
-                        }
-                    };
-
-                    Children.Clear();
-                    Children.Add(placeholder);
-                    return;
-                }
-
                 _instancesPerZone = await _dataSource.Value.GetAllInstancesPerZonesAsync();
                 PresentViewModels();
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -219,7 +219,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 // Ensure that the GCE API is enabled before continuing.
                 if (!await ApiManager.Default.EnsureServiceEnabledAsync(
                         serviceName: KnownApis.ComputeEngineApiName,
-                        displayName: "Compute Engine API"))
+                        prompt: "Compute Engine API"))
                 {
                     Debug.WriteLine("The user refused to enable the GCE API.");
                     Children.Clear();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -77,9 +77,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 ContextMenu = new ContextMenu
                 {
                     ItemsSource = new List<FrameworkElement>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerGceEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGceApi) }
-                            }
+                    {
+                        new MenuItem
+                        {
+                            Header = Resources.CloudExplorerGceEnableApiMenuHeader,
+                            Command = new ProtectedCommand(OnEnableGceApi)
+                        }
+                    }
                 }
             };
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -50,7 +50,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
             IsWarning = true
         };
 
-        private static readonly IEnumerable<string> s_requiredApis = new List<string>
+        private static readonly IList<string> s_requiredApis = new List<string>
         {
             // The GCE API is required.
             KnownApis.ComputeEngineApiName
@@ -87,7 +87,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 }
             };
 
-        public override IEnumerable<string> RequiredApis => s_requiredApis;
+        public override IList<string> RequiredApis => s_requiredApis;
 
         public override string RootCaption => Resources.CloudExplorerGceRootNodeCaption;
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gce/GceSourceRootViewModel.cs
@@ -227,13 +227,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gce
                 {
                     var placeholder = new TreeLeaf
                     {
-                        Caption = "The Compute Engine API is not enabled.",
+                        Caption = Resources.CloudExplorerGceApiNotEnabledCaption,
                         IsError = true,
                         ContextMenu = new ContextMenu
                         {
                             ItemsSource = new List<FrameworkElement>
                             {
-                                new MenuItem { Header = "Enable Compute Engine API", Command = new ProtectedCommand(OnEnableGceApi) }
+                                new MenuItem { Header = Resources.CloudExplorerGceEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGceApi) }
                             }
                         }
                     };

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -51,7 +51,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
             IsError = true
         };
 
-        private static readonly IEnumerable<string> s_requiredApis = new List<string>
+        private static readonly IList<string> s_requiredApis = new List<string>
         {
             // The GCS API is required.
             KnownApis.CloudStorageApiName
@@ -87,7 +87,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
                 }
             };
 
-        public override IEnumerable<string> RequiredApis => s_requiredApis;
+        public override IList<string> RequiredApis => s_requiredApis;
 
         public bool ShowLocations
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -158,13 +158,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
                 {
                     var placeholder = new TreeLeaf
                     {
-                        Caption = "The Cloud Storage API is not enabled.",
+                        Caption = Resources.CloudExplorerGcsApiNotEnabledCaption,
                         IsError = true,
                         ContextMenu = new ContextMenu
                         {
                             ItemsSource = new List<FrameworkElement>
                             {
-                                new MenuItem { Header = "Enable the Cloud Storage API", Command = new ProtectedCommand(OnEnableGcsApi) }
+                                new MenuItem { Header = Resources.CloudExplorerGcsEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGcsApi) }
                             }
                         }
                     };

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -69,6 +69,22 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
 
         public override TreeLeaf NoItemsPlaceholder => s_noItemsPlacehoder;
 
+        public override TreeLeaf ApiNotEnabledPlaceholder
+            => new TreeLeaf
+            {
+                Caption = Resources.CloudExplorerGcsApiNotEnabledCaption,
+                IsError = true,
+                ContextMenu = new ContextMenu
+                {
+                    ItemsSource = new List<FrameworkElement>
+                            {
+                                new MenuItem { Header = Resources.CloudExplorerGcsEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGcsApi) }
+                            }
+                }
+            };
+
+        public override IEnumerable<string> RequiredApis => s_requiredApis;
+
         public bool ShowLocations
         {
             get { return _showLocations; }
@@ -153,27 +169,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
             try
             {
                 Debug.WriteLine("Loading list of buckets.");
-
-                if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
-                {
-                    var placeholder = new TreeLeaf
-                    {
-                        Caption = Resources.CloudExplorerGcsApiNotEnabledCaption,
-                        IsError = true,
-                        ContextMenu = new ContextMenu
-                        {
-                            ItemsSource = new List<FrameworkElement>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerGcsEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGcsApi) }
-                            }
-                        }
-                    };
-
-                    Debug.WriteLine("The user refused to enable the GCS API.");
-                    Children.Clear();
-                    Children.Add(placeholder);
-                    return;
-                }
 
                 _buckets = await LoadBucketList();
                 PresentViewModels();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -50,18 +50,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
             Caption = Resources.CloudExplorerGcsFailedToListBucketsCaption,
             IsError = true
         };
-        private static readonly TreeLeaf s_apiDisabledPlaceholder = new TreeLeaf
-        {
-            Caption = "The Cloud Storage API is not enabled.",
-            IsError = true,
-            ContextMenu = new ContextMenu
-            {
-                ItemsSource = new List<FrameworkElement>
-                {
-                    new MenuItem { Header = "Enable the Cloud Storage API", Command = new ProtectedCommand(OnEnableGcsApi) } 
-                }
-            }
-        };
 
         private static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
@@ -133,9 +121,10 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
             ShowLocations = false;
         }
 
-        private static async void OnEnableGcsApi()
+        private async void OnEnableGcsApi()
         {
             await ApiManager.Default.EnableServicesAsync(s_requiredApis);
+            Refresh();
         }
 
         public override void InvalidateProjectOrAccount()
@@ -167,9 +156,22 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
 
                 if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
                 {
+                    var placeholder = new TreeLeaf
+                    {
+                        Caption = "The Cloud Storage API is not enabled.",
+                        IsError = true,
+                        ContextMenu = new ContextMenu
+                        {
+                            ItemsSource = new List<FrameworkElement>
+                            {
+                                new MenuItem { Header = "Enable the Cloud Storage API", Command = new ProtectedCommand(OnEnableGcsApi) }
+                            }
+                        }
+                    };
+
                     Debug.WriteLine("The user refused to enable the GCS API.");
                     Children.Clear();
-                    Children.Add(s_apiDisabledPlaceholder);
+                    Children.Add(placeholder);
                     return;
                 }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -148,7 +148,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
 
                 if (!await ApiManager.Default.EnsureServiceEnabledAsync(
                         serviceName: KnownApis.CloudStorageApiName,
-                        displayName: "Google Cloud Storage"))
+                        prompt: "Google Cloud Storage"))
                 {
                     Debug.WriteLine("The user refused to enable the GCS API.");
                     Children.Clear();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/Gcs/GcsSourceRootViewModel.cs
@@ -77,9 +77,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.Gcs
                 ContextMenu = new ContextMenu
                 {
                     ItemsSource = new List<FrameworkElement>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerGcsEnableApiMenuHeader, Command = new ProtectedCommand(OnEnableGcsApi) }
-                            }
+                    {
+                        new MenuItem
+                        {
+                            Header = Resources.CloudExplorerGcsEnableApiMenuHeader,
+                            Command = new ProtectedCommand(OnEnableGcsApi)
+                        }
+                    }
                 }
             };
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
@@ -273,6 +273,5 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
             await ApiManager.Default.EnableServicesAsync(s_requiredApis);
             Refresh();
         }
-
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
@@ -145,13 +145,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
                 {
                     var placeholder = new TreeLeaf
                     {
-                        Caption = "The Pub/Sub API is not enabled.",
+                        Caption = Resources.CloudExplorerPubSubApiNotEnabledCaption,
                         IsError = true,
                         ContextMenu = new ContextMenu
                         {
                             ItemsSource = new List<MenuItem>
                             {
-                                new MenuItem { Header = "Enable the Pub/Sub API", Command = new ProtectedCommand(OnEnablePubSubApi) }
+                                new MenuItem { Header = Resources.CloudExplorerPubSubEnableApiMenuHeader, Command = new ProtectedCommand(OnEnablePubSubApi) }
                             }
                         }
                     };

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
@@ -94,9 +94,13 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
                 ContextMenu = new ContextMenu
                 {
                     ItemsSource = new List<MenuItem>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerPubSubEnableApiMenuHeader, Command = new ProtectedCommand(OnEnablePubSubApi) }
-                            }
+                    {
+                        new MenuItem
+                        {
+                            Header = Resources.CloudExplorerPubSubEnableApiMenuHeader,
+                            Command = new ProtectedCommand(OnEnablePubSubApi)
+                        }
+                    }
                 }
             };
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
@@ -86,6 +86,22 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
         public override TreeLeaf NoItemsPlaceholder => s_noItemsPlacehoder;
         public override TreeLeaf LoadingPlaceholder => s_loadingPlaceholder;
 
+        public override TreeLeaf ApiNotEnabledPlaceholder
+            => new TreeLeaf
+            {
+                Caption = Resources.CloudExplorerPubSubApiNotEnabledCaption,
+                IsError = true,
+                ContextMenu = new ContextMenu
+                {
+                    ItemsSource = new List<MenuItem>
+                            {
+                                new MenuItem { Header = Resources.CloudExplorerPubSubEnableApiMenuHeader, Command = new ProtectedCommand(OnEnablePubSubApi) }
+                            }
+                }
+            };
+
+        public override IEnumerable<string> RequiredApis => s_requiredApis;
+
         private string CurrentProjectId => Context.CurrentProject.ProjectId;
 
         /// <summary>
@@ -141,26 +157,6 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
         {
             try
             {
-                if (!await ApiManager.Default.AreServicesEnabledAsync(s_requiredApis))
-                {
-                    var placeholder = new TreeLeaf
-                    {
-                        Caption = Resources.CloudExplorerPubSubApiNotEnabledCaption,
-                        IsError = true,
-                        ContextMenu = new ContextMenu
-                        {
-                            ItemsSource = new List<MenuItem>
-                            {
-                                new MenuItem { Header = Resources.CloudExplorerPubSubEnableApiMenuHeader, Command = new ProtectedCommand(OnEnablePubSubApi) }
-                            }
-                        }
-                    };
-
-                    Children.Clear();
-                    Children.Add(placeholder);
-                    return;
-                }
-
                 Task<IList<Subscription>> subscriptionsTask = DataSource.GetSubscriptionListAsync();
                 IEnumerable<Topic> topics = await DataSource.GetTopicListAsync();
                 IList<Subscription> subscriptions = await subscriptionsTask;

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorerSources/PubSub/PubSubSourceRootViewModel.cs
@@ -57,7 +57,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
             IsError = true
         };
 
-        private static readonly IEnumerable<string> s_requiredApis = new List<string>
+        private static readonly IList<string> s_requiredApis = new List<string>
         {
             // Require the Pub/Sub API.
             KnownApis.PubSubApiName
@@ -104,7 +104,7 @@ namespace GoogleCloudExtension.CloudExplorerSources.PubSub
                 }
             };
 
-        public override IEnumerable<string> RequiredApis => s_requiredApis;
+        public override IList<string> RequiredApis => s_requiredApis;
 
         private string CurrentProjectId => Context.CurrentProject.ProjectId;
 

--- a/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using GoogleCloudExtension.Deployment;
-using GoogleCloudExtension.PublishDialog;
 using GoogleCloudExtension.SolutionUtils;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.Shell;

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -752,6 +752,10 @@
       <HintPath>..\packages\Google.Apis.Pubsub.v1.1.29.1.971\lib\net45\Google.Apis.Pubsub.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Google.Apis.ServiceManagement.v1, Version=1.29.1.981, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.ServiceManagement.v1.1.29.1.981\lib\net45\Google.Apis.ServiceManagement.v1.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Google.Apis.SQLAdmin.v1beta4, Version=1.29.1.949, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.SQLAdmin.v1beta4.1.29.1.949\lib\net45\Google.Apis.SQLAdmin.v1beta4.dll</HintPath>
       <Private>True</Private>

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Analytics\Events\StopGceInstanceEvent.cs" />
     <Compile Include="Analytics\Events\UnhandledExceptionEvent.cs" />
     <Compile Include="Analytics\Events\UpgradeEvent.cs" />
+    <Compile Include="ApiManagement\ApiManager.cs" />
     <Compile Include="AttachDebuggerDialog\AttachDebuggerContext.cs" />
     <Compile Include="AttachDebuggerDialog\AttachDebuggerSettingsStore.cs" />
     <Compile Include="AttachDebuggerDialog\AttachDebuggerSettings.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Analytics\Events\UnhandledExceptionEvent.cs" />
     <Compile Include="Analytics\Events\UpgradeEvent.cs" />
     <Compile Include="ApiManagement\ApiManager.cs" />
+    <Compile Include="ApiManagement\KnownApis.cs" />
     <Compile Include="AttachDebuggerDialog\AttachDebuggerContext.cs" />
     <Compile Include="AttachDebuggerDialog\AttachDebuggerSettingsStore.cs" />
     <Compile Include="AttachDebuggerDialog\AttachDebuggerSettings.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -45,7 +45,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
 
         private readonly FlexStepContent _content;
         private readonly Task<bool> _projectStateValidation;
-        private IPublishDialog _publishDialog;
         private string _version = GcpPublishStepsUtils.GetDefaultVersion();
         private bool _promote = true;
         private bool _openWebsite = true;
@@ -100,14 +99,14 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
 
         public override async void OnPushedToDialog(IPublishDialog dialog)
         {
-            _publishDialog = dialog;
+            base.OnPushedToDialog(dialog);
 
-            _publishDialog.TrackTask(_projectStateValidation);
+            PublishDialog.TrackTask(_projectStateValidation);
 
             if (!await _projectStateValidation)
             {
                 // Close the dialog if the project cannot be deployed.
-                _publishDialog.FinishFlow();
+                PublishDialog.FinishFlow();
             }
         }
 
@@ -252,7 +251,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
                 UserPromptUtils.ExceptionPrompt(ex);
                 return false;
             }
-	}
+    }
 
         internal bool ValidateInput()
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -84,7 +84,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
         private FlexStepViewModel(FlexStepContent content)
         {
             _content = content;
-            _projectStateValidation = ValidatGcpeProjectState();
+            _projectStateValidation = ValidatGcpProjectState();
             CanPublish = true;
         }
 
@@ -215,14 +215,14 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             return viewModel;
         }
 
-        private async Task<bool> ValidatGcpeProjectState()
+        private async Task<bool> ValidatGcpProjectState()
         {
             // Ensure the necessary APIs are enabled.
             if (!await ApiManager.Default.EnsureAllServicesEnabledAsync(
                     s_requiredApis,
                     Resources.FlexPublishEnableApiMessage))
             {
-                Debug.WriteLine($"The user refused to enable the APIs for GAE.");
+                Debug.WriteLine("The user refused to enable the APIs for GAE.");
                 return false;
             }
 
@@ -230,10 +230,10 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             {
                 // Using the GAE API, check if there's an app for the project.
                 var appEngineDataSource = new GaeDataSource(
-                    CredentialsStore.Default.CurrentProjectId,
-                    CredentialsStore.Default.CurrentGoogleCredential,
-                    GoogleCloudExtensionPackage.ApplicationName);
-                var app = await appEngineDataSource.GetApplicationAsync();
+                     CredentialsStore.Default.CurrentProjectId,
+                     CredentialsStore.Default.CurrentGoogleCredential,
+                     GoogleCloudExtensionPackage.ApplicationName);
+                Google.Apis.Appengine.v1.Data.Application app = await appEngineDataSource.GetApplicationAsync();
                 if (app == null)
                 {
                     Debug.WriteLine("There's no App Engine app for the project.");
@@ -251,7 +251,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
                 UserPromptUtils.ExceptionPrompt(ex);
                 return false;
             }
-    }
+        }
 
         internal bool ValidateInput()
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -237,7 +237,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             // Ensure the necessary APIs are enabled.
             if (!await ApiManager.Default.EnsureAllServicesEnabledAsync(
                     s_requiredApis,
-                    "Your project needs to setup to deploy to App Engine flexible environment. Do you want to enable the necessary services now?"))
+                    Resources.FlexPublishEnableApiMessage))
             {
                 Debug.WriteLine($"The user refused to enable the APIs for GAE.");
                 return false;
@@ -255,7 +255,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
                 {
                     Debug.WriteLine("There's no App Engine app for the project.");
                     UserPromptUtils.ErrorPrompt(
-                        message: "Your project does not contain an App Engine app. Please create one using the Cloud Console or in the command line with gcloud.",
+                        message: Resources.FlexPublishNoAppFoundMessage,
                         title: Resources.UiErrorCaption);
                     return false;
                 }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -36,6 +36,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
     /// </summary>
     public class FlexStepViewModel : PublishDialogStepBase
     {
+        // The list of APIs that are required for a successful deployment to App Engine Flex.
         private static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
             // We require the App Engine Admin API in order to deploy to app engine.

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
@@ -155,7 +155,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
                     s_requiredApis,
                     Resources.GcePublishEnableApiMessage))
             {
-                _publishDialog.FinishFlow();
+                PublishDialog.FinishFlow();
                 return Enumerable.Empty<Instance>();
             }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepViewModel.cs
@@ -39,6 +39,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
     /// </summary>
     public class GceStepViewModel : PublishDialogStepBase
     {
+        // The list of APIs that are required for a succesful deployment to GCE.
         private static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
             // Need the GCE API to perform all work.
@@ -143,7 +144,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GceStep
         {
             if (!await ApiManager.Default.EnsureAllServicesEnabledAsync(
                     s_requiredApis,
-                    "Your project needs to be setup to be able to deploy to Compute Engine VMs, do you want to enable the necessary services now?"))
+                    Resources.GcePublishEnableApiMessage))
             {
                 _publishDialog.FinishFlow();
                 return Enumerable.Empty<Instance>();

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -207,7 +207,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
         private void RefreshClustersList()
         {
-            var refreshTask = GetAllClustersAsync();
+            Task<IEnumerable<Cluster>> refreshTask = GetAllClustersAsync();
             Clusters = new AsyncProperty<IEnumerable<Cluster>>(refreshTask);
             PublishDialog.TrackTask(refreshTask);
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -54,7 +54,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         };
 
         private readonly GkeStepContent _content;
-        private IPublishDialog _publishDialog;
         private AsyncProperty<IEnumerable<Cluster>> _clusters;
         private Cluster _selectedCluster;
         private string _deploymentName;
@@ -210,7 +209,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         {
             var refreshTask = GetAllClustersAsync();
             Clusters = new AsyncProperty<IEnumerable<Cluster>>(refreshTask);
-            _publishDialog.TrackTask(refreshTask);
+            PublishDialog.TrackTask(refreshTask);
         }
 
         private void OnCreateClusterCommand()
@@ -454,7 +453,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                     s_requiredApis,
                     Resources.GkePublishEnableApiMessage))
             {
-                _publishDialog.FinishFlow();
+                PublishDialog.FinishFlow();
                 return Enumerable.Empty<Cluster>();
             }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -42,7 +42,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
     {
         private static readonly Cluster s_placeholderCluster = new Cluster { Name = Resources.GkePublishNoClustersPlaceholder };
         private static readonly IList<Cluster> s_placeholderList = new List<Cluster> { s_placeholderCluster };
-        
+
         // The APIs required for a succesful deployment to GKE.
         private static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
@@ -191,8 +191,8 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
         private void UpdateCanPublish()
         {
-            CanPublish = SelectedCluster != null 
-                && SelectedCluster != s_placeholderCluster 
+            CanPublish = SelectedCluster != null
+                && SelectedCluster != s_placeholderCluster
                 && !HasErrors;
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -43,6 +43,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         private static readonly Cluster s_placeholderCluster = new Cluster { Name = Resources.GkePublishNoClustersPlaceholder };
         private static readonly IList<Cluster> s_placeholderList = new List<Cluster> { s_placeholderCluster };
         
+        // The APIs required for a succesful deployment to GKE.
         private static readonly IEnumerable<string> s_requiredApis = new List<string>
         {
             // Need the GKE API to be able to list clusters.
@@ -446,7 +447,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
         {
             if (!await ApiManager.Default.EnsureAllServicesEnabledAsync(
                     s_requiredApis,
-                    "Your project needs to be setup to be able to deploy apps to Container Engine, do you want to enable the necessary services now?"))
+                    Resources.GkePublishEnableApiMessage))
             {
                 _publishDialog.FinishFlow();
                 return Enumerable.Empty<Cluster>();

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -452,6 +452,7 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
                     s_requiredApis,
                     "Your project needs to be setup to be able to deploy apps to Container Engine, do you want to enable the necessary services now?"))
             {
+                _publishDialog.FinishFlow();
                 return s_noApiPlaceholderList;
             }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension
-{
-
-
+namespace GoogleCloudExtension {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -2230,7 +2230,7 @@ namespace GoogleCloudExtension
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Cloud Storage API is not enabled..
+        ///   Looks up a localized string similar to The Cloud SQL API is not enabled..
         /// </summary>
         public static string CloudExplorerSqlApiNotEnabledCaption {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -241,6 +241,33 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to enable the necessary services..
+        /// </summary>
+        public static string ApiManagerEnableServicesErrorMessage {
+            get {
+                return ResourceManager.GetString("ApiManagerEnableServicesErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enabling the required services..
+        /// </summary>
+        public static string ApiManagerEnableServicesProgressMessage {
+            get {
+                return ResourceManager.GetString("ApiManagerEnableServicesProgressMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Required Services.
+        /// </summary>
+        public static string ApiManagerEnableServicesTitle {
+            get {
+                return ResourceManager.GetString("ApiManagerEnableServicesTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ASP.NET Core {0}.
         /// </summary>
         public static string AspNetCoreVersionedName {
@@ -5727,6 +5754,15 @@ namespace GoogleCloudExtension {
         public static string UiDownloadButtonCaption {
             get {
                 return ResourceManager.GetString("UiDownloadButtonCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable.
+        /// </summary>
+        public static string UiEnableButtonCaption {
+            get {
+                return ResourceManager.GetString("UiEnableButtonCaption", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -790,6 +790,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No App Engine app found..
+        /// </summary>
+        public static string CloudExplorerGaeNoAppFoundCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGaeNoAppFoundCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No services found..
         /// </summary>
         public static string CloudExplorerGaeNoServicesFoundCaption {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -664,6 +664,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The App Engine Admin API is not enabled..
+        /// </summary>
+        public static string CloudExplorerGaeApiNotEnabledCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGaeApiNotEnabledCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete Service.
         /// </summary>
         public static string CloudExplorerGaeDeleteService {
@@ -714,6 +723,15 @@ namespace GoogleCloudExtension {
         public static string CloudExplorerGaeDeleteVersionErrorMessage {
             get {
                 return ResourceManager.GetString("CloudExplorerGaeDeleteVersionErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable the App Engine Admin API.
+        /// </summary>
+        public static string CloudExplorerGaeEnableApiMenuHeader {
+            get {
+                return ResourceManager.GetString("CloudExplorerGaeEnableApiMenuHeader", resourceCulture);
             }
         }
         
@@ -1123,11 +1141,29 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Compute Engine API is not enabled..
+        /// </summary>
+        public static string CloudExplorerGceApiNotEnabledCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGceApiNotEnabledCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Attach debugger.
         /// </summary>
         public static string CloudExplorerGceAttachDebuggerMenuHeader {
             get {
                 return ResourceManager.GetString("CloudExplorerGceAttachDebuggerMenuHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable the Compute Engine API.
+        /// </summary>
+        public static string CloudExplorerGceEnableApiMenuHeader {
+            get {
+                return ResourceManager.GetString("CloudExplorerGceEnableApiMenuHeader", resourceCulture);
             }
         }
         
@@ -1699,6 +1735,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Cloud Storage API is not enabled..
+        /// </summary>
+        public static string CloudExplorerGcsApiNotEnabledCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerGcsApiNotEnabledCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bucket Properties.
         /// </summary>
         public static string CloudExplorerGcsBucketCategory {
@@ -1794,6 +1839,15 @@ namespace GoogleCloudExtension {
         public static string CloudExplorerGcsBucketVersioningEnabledDisplayName {
             get {
                 return ResourceManager.GetString("CloudExplorerGcsBucketVersioningEnabledDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable the Cloud Storage API.
+        /// </summary>
+        public static string CloudExplorerGcsEnableApiMenuHeader {
+            get {
+                return ResourceManager.GetString("CloudExplorerGcsEnableApiMenuHeader", resourceCulture);
             }
         }
         
@@ -1933,6 +1987,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Pub/Sub API is not enabled..
+        /// </summary>
+        public static string CloudExplorerPubSubApiNotEnabledCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerPubSubApiNotEnabledCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete Subscription.
         /// </summary>
         public static string CloudExplorerPubSubDeleteSubscriptionMenuHeader {
@@ -1947,6 +2010,15 @@ namespace GoogleCloudExtension {
         public static string CloudExplorerPubSubDeleteTopicMenuHeader {
             get {
                 return ResourceManager.GetString("CloudExplorerPubSubDeleteTopicMenuHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable the Pub/Sub API.
+        /// </summary>
+        public static string CloudExplorerPubSubEnableApiMenuHeader {
+            get {
+                return ResourceManager.GetString("CloudExplorerPubSubEnableApiMenuHeader", resourceCulture);
             }
         }
         
@@ -2149,6 +2221,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Cloud Storage API is not enabled..
+        /// </summary>
+        public static string CloudExplorerSqlApiNotEnabledCaption {
+            get {
+                return ResourceManager.GetString("CloudExplorerSqlApiNotEnabledCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Backend Type.
         /// </summary>
         public static string CloudExplorerSqlBackendTypeDisplayName {
@@ -2163,6 +2244,15 @@ namespace GoogleCloudExtension {
         public static string CloudExplorerSqlDatabaseVersionDisplayName {
             get {
                 return ResourceManager.GetString("CloudExplorerSqlDatabaseVersionDisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable the Cloud SQL API.
+        /// </summary>
+        public static string CloudExplorerSqlEnableApiMenuHeader {
+            get {
+                return ResourceManager.GetString("CloudExplorerSqlEnableApiMenuHeader", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -3013,6 +3013,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your project needs to be setup to deploy to App Engine flexible environment. Do you want to enable the necessary services now?.
+        /// </summary>
+        public static string FlexPublishEnableApiMessage {
+            get {
+                return ResourceManager.GetString("FlexPublishEnableApiMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to deploy project {0} to App Engine Flex..
         /// </summary>
         public static string FlexPublishFailedMessage {
@@ -3027,6 +3036,15 @@ namespace GoogleCloudExtension {
         public static string FlexPublishInvalidVersionMessage {
             get {
                 return ResourceManager.GetString("FlexPublishInvalidVersionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project does not contain an App Engine app. Please create one using the Cloud Console or in the command line with gcloud..
+        /// </summary>
+        public static string FlexPublishNoAppFoundMessage {
+            get {
+                return ResourceManager.GetString("FlexPublishNoAppFoundMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -3094,6 +3094,15 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your project needs to be setup to deploy to Compute Engine VMs. Do you want to enable the necessary services now?.
+        /// </summary>
+        public static string GcePublishEnableApiMessage {
+            get {
+                return ResourceManager.GetString("GcePublishEnableApiMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to publish project {0}..
         /// </summary>
         public static string GcePublishFailedMessage {
@@ -4035,6 +4044,15 @@ namespace GoogleCloudExtension {
         public static string GkePublishEmptyDeploymentVersionMessage {
             get {
                 return ResourceManager.GetString("GkePublishEmptyDeploymentVersionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project needs to be setup to deploy to Container Engine. Do you want to enable the necessary services now?.
+        /// </summary>
+        public static string GkePublishEnableApiMessage {
+            get {
+                return ResourceManager.GetString("GkePublishEnableApiMessage", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace GoogleCloudExtension {
-    using System;
-    
-    
+namespace GoogleCloudExtension
+{
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2864,7 +2864,7 @@
     <comment>Header for the menu item to enable the Pub/Sub API.</comment>
   </data>
   <data name="CloudExplorerSqlApiNotEnabledCaption" xml:space="preserve">
-    <value>The Cloud Storage API is not enabled.</value>
+    <value>The Cloud SQL API is not enabled.</value>
     <comment>Caption shown in the placeholder displayed when the Cloud SQL API is not enabled.</comment>
   </data>
   <data name="CloudExplorerSqlEnableApiMenuHeader" xml:space="preserve">

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2827,6 +2827,46 @@
     <value>Enable Required Services</value>
     <comment>The title for the enable services dialogs.</comment>
   </data>
+  <data name="CloudExplorerGaeApiNotEnabledCaption" xml:space="preserve">
+    <value>The App Engine Admin API is not enabled.</value>
+    <comment>Caption shown in the placeholder displayed when the App Engine API is not enabled.</comment>
+  </data>
+  <data name="CloudExplorerGaeEnableApiMenuHeader" xml:space="preserve">
+    <value>Enable the App Engine Admin API</value>
+    <comment>Header for the menu item to enable the Cloud SQL API.</comment>
+  </data>
+  <data name="CloudExplorerGceApiNotEnabledCaption" xml:space="preserve">
+    <value>The Compute Engine API is not enabled.</value>
+    <comment>Caption shown in the placeholder displayed when the GCE API is not enabled.</comment>
+  </data>
+  <data name="CloudExplorerGceEnableApiMenuHeader" xml:space="preserve">
+    <value>Enable the Compute Engine API</value>
+    <comment>Header for the menu item to enable the GCE API.</comment>
+  </data>
+  <data name="CloudExplorerGcsApiNotEnabledCaption" xml:space="preserve">
+    <value>The Cloud Storage API is not enabled.</value>
+    <comment>Caption shown in the placeholder displayed when the GCS API is not enabled.</comment>
+  </data>
+  <data name="CloudExplorerGcsEnableApiMenuHeader" xml:space="preserve">
+    <value>Enable the Cloud Storage API</value>
+    <comment>Header for the menu item to enable the GCS API.</comment>
+  </data>
+  <data name="CloudExplorerPubSubApiNotEnabledCaption" xml:space="preserve">
+    <value>The Pub/Sub API is not enabled.</value>
+    <comment>Caption shown in the placeholder displayed when the Pub/Sub API is not enabled.</comment>
+  </data>
+  <data name="CloudExplorerPubSubEnableApiMenuHeader" xml:space="preserve">
+    <value>Enable the Pub/Sub API</value>
+    <comment>Header for the menu item to enable the Pub/Sub API.</comment>
+  </data>
+  <data name="CloudExplorerSqlApiNotEnabledCaption" xml:space="preserve">
+    <value>The Cloud Storage API is not enabled.</value>
+    <comment>Caption shown in the placeholder displayed when the Cloud SQL API is not enabled.</comment>
+  </data>
+  <data name="CloudExplorerSqlEnableApiMenuHeader" xml:space="preserve">
+    <value>Enable the Cloud SQL API</value>
+    <comment>Header for the menu item to enable the Cloud SQL API.</comment>
+  </data>
   <data name="FlexPublishEnableApiMessage" xml:space="preserve">
     <value>Your project needs to be setup to deploy to App Engine flexible environment. Do you want to enable the necessary services now?</value>
     <comment>Message shown when we need to enable APIs to deploy to an app to App Engine flex.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2815,4 +2815,20 @@
     <value>Features:</value>
     <comment>The label for the features section of the Project Template Chooser dialog.</comment>
   </data>
+  <data name="ApiManagerEnableServicesErrorMessage" xml:space="preserve">
+    <value>Failed to enable the necessary services.</value>
+    <comment>The message shown when there's a failure enabling services.</comment>
+  </data>
+  <data name="ApiManagerEnableServicesProgressMessage" xml:space="preserve">
+    <value>Enabling the required services.</value>
+    <comment>The message for the progress dialog shown while enabling services.</comment>
+  </data>
+  <data name="ApiManagerEnableServicesTitle" xml:space="preserve">
+    <value>Enable Required Services</value>
+    <comment>The title for the enable services dialogs.</comment>
+  </data>
+  <data name="UiEnableButtonCaption" xml:space="preserve">
+    <value>Enable</value>
+    <comment>Caption for enable buttons.</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2835,6 +2835,10 @@
     <value>Enable the App Engine Admin API</value>
     <comment>Header for the menu item to enable the Cloud SQL API.</comment>
   </data>
+  <data name="CloudExplorerGaeNoAppFoundCaption" xml:space="preserve">
+    <value>No App Engine app found.</value>
+    <comment>Caption shown in the placheolder when no App Engine app was found.</comment>
+  </data>
   <data name="CloudExplorerGceApiNotEnabledCaption" xml:space="preserve">
     <value>The Compute Engine API is not enabled.</value>
     <comment>Caption shown in the placeholder displayed when the GCE API is not enabled.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2835,6 +2835,14 @@
     <value>Your project does not contain an App Engine app. Please create one using the Cloud Console or in the command line with gcloud.</value>
     <comment>Message shwon when there's no App Engine app defined for the project.</comment>
   </data>
+  <data name="GcePublishEnableApiMessage" xml:space="preserve">
+    <value>Your project needs to be setup to deploy to Compute Engine VMs. Do you want to enable the necessary services now?</value>
+    <comment>Message shown when we need to enable APIs to deploy to a GCE VM.</comment>
+  </data>
+  <data name="GkePublishEnableApiMessage" xml:space="preserve">
+    <value>Your project needs to be setup to deploy to Container Engine. Do you want to enable the necessary services now?</value>
+    <comment>Message shown when we need to enable APIs to deploy to GKE.</comment>
+  </data>
   <data name="UiEnableButtonCaption" xml:space="preserve">
     <value>Enable</value>
     <comment>Caption for enable buttons.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2827,6 +2827,14 @@
     <value>Enable Required Services</value>
     <comment>The title for the enable services dialogs.</comment>
   </data>
+  <data name="FlexPublishEnableApiMessage" xml:space="preserve">
+    <value>Your project needs to be setup to deploy to App Engine flexible environment. Do you want to enable the necessary services now?</value>
+    <comment>Message shown when we need to enable APIs to deploy to an app to App Engine flex.</comment>
+  </data>
+  <data name="FlexPublishNoAppFoundMessage" xml:space="preserve">
+    <value>Your project does not contain an App Engine app. Please create one using the Cloud Console or in the command line with gcloud.</value>
+    <comment>Message shwon when there's no App Engine app defined for the project.</comment>
+  </data>
   <data name="UiEnableButtonCaption" xml:space="preserve">
     <value>Enable</value>
     <comment>Caption for enable buttons.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/VsVersion/ToolsPathProviderBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/VsVersion/ToolsPathProviderBase.cs
@@ -1,4 +1,18 @@
-﻿using GoogleCloudExtension.Deployment;
+﻿// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension.Deployment;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/GoogleCloudExtension/GoogleCloudExtension/VsVersion/VS15/ToolsPathProvider.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/VsVersion/VS15/ToolsPathProvider.cs
@@ -19,7 +19,7 @@ using System.IO;
 namespace GoogleCloudExtension.VsVersion.VS15
 {
     /// <summary>
-    /// The implementation of <seealso cref="IToolsPathProvider"/> for Visual Studio 2017 (v 15.0).
+    /// The implementation of <seealso cref="Deployment.IToolsPathProvider"/> for Visual Studio 2017 (v 15.0).
     /// </summary>
     internal class ToolsPathProvider : ToolsPathProviderBase
     {

--- a/GoogleCloudExtension/GoogleCloudExtension/VsVersion/VS15/ToolsPathProvider.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/VsVersion/VS15/ToolsPathProvider.cs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using GoogleCloudExtension.Deployment;
 using GoogleCloudExtension.Utils;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace GoogleCloudExtension.VsVersion.VS15
 {

--- a/GoogleCloudExtension/GoogleCloudExtension/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension/packages.config
@@ -13,6 +13,7 @@
   <package id="Google.Apis.Logging.v2" version="1.29.1.991" targetFramework="net452" />
   <package id="Google.Apis.Plus.v1" version="1.29.1.970" targetFramework="net452" />
   <package id="Google.Apis.Pubsub.v1" version="1.29.1.971" targetFramework="net452" />
+  <package id="Google.Apis.ServiceManagement.v1" version="1.29.1.981" targetFramework="net452" />
   <package id="Google.Apis.SQLAdmin.v1beta4" version="1.29.1.949" targetFramework="net452" />
   <package id="Google.Apis.Storage.v1" version="1.29.1.988" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />


### PR DESCRIPTION
This PR adds functionality to enable the required APIs for GCP projects when performing operations that require them. For example, this PR adds functionality to enable the App Engine Admin API when deploying to App Engine flexible environment.

This PR also adds functionality to the Cloud Explorer to enable APIs directly from there. If the user expands a node for which a required API is not enabled the user will see a message to that effect and will be able to right click on the node to enable the API.

The user will always be prompted to enable the API because it takes a while to perform the operation.

Fixes #783 Fixes #519 Fixes #509 Fixes #507 Fixes #204 

