### PR TITLE
Simplify the generated Dockerfile.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.Deployment/NetCoreAppUtils.cs
@@ -39,9 +39,7 @@ namespace GoogleCloudExtension.Deployment
 
         /// <summary>
         /// This template is the smallest possible Dockerfile needed to deploy an ASP.NET Core app to
-        /// App Engine Flex environment. It invokes the entry point .dll given by {1}, sets up the environment
-        /// so the app listens on port 8080.
-        /// All of the files composing the app are copied to the /app path, then it is set as the working directory.
+        /// App Engine Flex environment. It invokes the entry point .dll given by {1}.
         /// The parameters into the string are:
         ///   {0}, the base image for the app's Docker image.
         ///   {1}, the entrypoint .dll for the app.
@@ -50,8 +48,6 @@ namespace GoogleCloudExtension.Deployment
             "FROM {0}\n" +
             "COPY . /app\n" +
             "WORKDIR /app\n" +
-            "EXPOSE 8080\n" +
-            "ENV ASPNETCORE_URLS=http://*:8080\n" +
             "ENTRYPOINT [\"dotnet\", \"{1}.dll\"]\n";
 
         /// <summary>


### PR DESCRIPTION
This PR updates the Dockerfile template to remove the `ASPNETCORE_URLS` and `PORT` environment variables, which are now part of the base images for all .NET Core runtimes. See [this PR](https://github.com/GoogleCloudPlatform/aspnet-docker/pull/76) for more context.

Fixes #831 