### PR TITLE
Updating Container Engine to Kubernetes Engine

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -4012,7 +4012,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deploying {0} to Container Engine.
+        ///   Looks up a localized string similar to Deploying {0} to Kubernetes Engine.
         /// </summary>
         public static string GkePublishDeployingToGkeMessage {
             get {
@@ -4039,7 +4039,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to deploy {0} to Container Engine.
+        ///   Looks up a localized string similar to Failed to deploy {0} to Kubernetes Engine.
         /// </summary>
         public static string GkePublishDeploymentFailureMessage {
             get {
@@ -4075,7 +4075,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deploying to Container Engine.
+        ///   Looks up a localized string similar to Deploying to Kubernetes Engine.
         /// </summary>
         public static string GkePublishDeploymentStatusMessage {
             get {
@@ -4084,7 +4084,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project {0} deployed to Container Engine.
+        ///   Looks up a localized string similar to Project {0} deployed to Kubernetes Engine.
         /// </summary>
         public static string GkePublishDeploymentSuccessMessage {
             get {
@@ -4147,7 +4147,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project needs to be setup to deploy to Container Engine. Do you want to enable the necessary services now?.
+        ///   Looks up a localized string similar to Your project needs to be setup to deploy to Kubernetes Engine. Do you want to enable the necessary services now?.
         /// </summary>
         public static string GkePublishEnableApiMessage {
             get {
@@ -5209,7 +5209,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to C_ontainer Engine.
+        ///   Looks up a localized string similar to _Kubernetes Engine.
         /// </summary>
         public static string PublishDialogChoiceStepGkeName {
             get {
@@ -5218,7 +5218,7 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deploy as a service to Container Engine.
+        ///   Looks up a localized string similar to Deploy as a service to Kubernetes Engine.
         /// </summary>
         public static string PublishDialogChoiceStepGkeToolTip {
             get {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1544,11 +1544,11 @@
     <comment>The message shown in the UI to choose cluster.</comment>
   </data>
   <data name="GkePublishDeployingToGkeMessage" xml:space="preserve">
-    <value>Deploying {0} to Container Engine</value>
+    <value>Deploying {0} to Kubernetes Engine</value>
     <comment>Message printed to the output window when deploying to GKE. {0} is the name of the project.</comment>
   </data>
   <data name="GkePublishDeploymentFailureMessage" xml:space="preserve">
-    <value>Failed to deploy {0} to Container Engine</value>
+    <value>Failed to deploy {0} to Kubernetes Engine</value>
     <comment>Message printed in the output window when the deployment fails. {0} is the project name.</comment>
   </data>
   <data name="GkePublishDeploymentNameMessage" xml:space="preserve">
@@ -1556,11 +1556,11 @@
     <comment>The message shown in the UI for deployment name textbox.</comment>
   </data>
   <data name="GkePublishDeploymentStatusMessage" xml:space="preserve">
-    <value>Deploying to Container Engine</value>
+    <value>Deploying to Kubernetes Engine</value>
     <comment>Message shown in the status bar while deploying.</comment>
   </data>
   <data name="GkePublishDeploymentSuccessMessage" xml:space="preserve">
-    <value>Project {0} deployed to Container Engine</value>
+    <value>Project {0} deployed to Kubernetes Engine</value>
     <comment>Message printed in the output window once the deployment finished succesfully. {0} is the project name.</comment>
   </data>
   <data name="GkePublishDeploymentVersionMessage" xml:space="preserve">
@@ -1584,11 +1584,11 @@
     <comment>Message shown while waiting for a public IP to be assigned to the exposed Kubernetes service.</comment>
   </data>
   <data name="PublishDialogChoiceStepGkeName" xml:space="preserve">
-    <value>C_ontainer Engine</value>
+    <value>_Kubernetes Engine</value>
     <comment>The name of the GKE choice.</comment>
   </data>
   <data name="PublishDialogChoiceStepGkeToolTip" xml:space="preserve">
-    <value>Deploy as a service to Container Engine</value>
+    <value>Deploy as a service to Kubernetes Engine</value>
     <comment>The tooltip for the GKE choice.</comment>
   </data>
   <data name="GkePublishDeploymentScaledMessage" xml:space="preserve">
@@ -2884,7 +2884,7 @@
     <comment>Message shown when we need to enable APIs to deploy to a GCE VM.</comment>
   </data>
   <data name="GkePublishEnableApiMessage" xml:space="preserve">
-    <value>Your project needs to be setup to deploy to Container Engine. Do you want to enable the necessary services now?</value>
+    <value>Your project needs to be setup to deploy to Kubernetes Engine. Do you want to enable the necessary services now?</value>
     <comment>Message shown when we need to enable APIs to deploy to GKE.</comment>
   </data>
   <data name="UiEnableButtonCaption" xml:space="preserve">


### PR DESCRIPTION
This PR fixes #848 by updating the strings that refer to "Container Engine" to read as "Kubernetes Engine".