### PR TITLE
Change the "Features:" label on the templates to "Template type:".

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -6370,24 +6370,6 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Google Cloud _Project ID:.
-        /// </summary>
-        public static string WizardTemplateChooserProjectIdLabel {
-            get {
-                return ResourceManager.GetString("WizardTemplateChooserProjectIdLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Select Project....
-        /// </summary>
-        public static string WizardTemplateChooserSelectProjectButton {
-            get {
-                return ResourceManager.GetString("WizardTemplateChooserSelectProjectButton", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Target _ASP.NET Framework:.
         /// </summary>
         public static string WizardTemplateChooserTargetAspFrameworkLabel {

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -6361,15 +6361,6 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Features:.
-        /// </summary>
-        public static string WizardTemplateChooserFeaturesLabel {
-            get {
-                return ResourceManager.GetString("WizardTemplateChooserFeaturesLabel", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to _MVC.
         /// </summary>
         public static string WizardTemplateChooserMvcLabel {
@@ -6397,11 +6388,29 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Target Framework:.
+        ///   Looks up a localized string similar to Target _ASP.NET Framework:.
         /// </summary>
-        public static string WizardTemplateChooserTargetFrameworkLabel {
+        public static string WizardTemplateChooserTargetAspFrameworkLabel {
             get {
-                return ResourceManager.GetString("WizardTemplateChooserTargetFrameworkLabel", resourceCulture);
+                return ResourceManager.GetString("WizardTemplateChooserTargetAspFrameworkLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target ._NET Framework:.
+        /// </summary>
+        public static string WizardTemplateChooserTargetNetFrameworkLabel {
+            get {
+                return ResourceManager.GetString("WizardTemplateChooserTargetNetFrameworkLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template type:.
+        /// </summary>
+        public static string WizardTemplateChooserTemplateTypeLabel {
+            get {
+                return ResourceManager.GetString("WizardTemplateChooserTemplateTypeLabel", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2803,16 +2803,16 @@
     <value>_Select Project...</value>
     <comment>The label of the Select Project button of the Project Template Chooser dialog.</comment>
   </data>
-  <data name="WizardTemplateChooserTargetFrameworkLabel" xml:space="preserve">
-    <value>_Target Framework:</value>
+  <data name="WizardTemplateChooserTargetNetFrameworkLabel" xml:space="preserve">
+    <value>Target ._NET Framework:</value>
     <comment>The label for the Target Framework input field of the Project Template Chooser dialog.</comment>
   </data>
   <data name="WizardTemplateChooserWebApiLabel" xml:space="preserve">
     <value>_Web API</value>
     <comment>The label for the WebAPI app type radio button of the Project Template Chooser dialog.</comment>
   </data>
-  <data name="WizardTemplateChooserFeaturesLabel" xml:space="preserve">
-    <value>Features:</value>
+  <data name="WizardTemplateChooserTemplateTypeLabel" xml:space="preserve">
+    <value>Template type:</value>
     <comment>The label for the features section of the Project Template Chooser dialog.</comment>
   </data>
   <data name="ApiManagerEnableServicesErrorMessage" xml:space="preserve">
@@ -2938,5 +2938,8 @@
   <data name="PublishDialogProjectNeedsApiMessage" xml:space="preserve">
     <value>The selected GCP project needs services to be enabled before you can deploy.</value>
     <comment>The message shown when a project needs an API enabled.</comment>
+  </data>
+  <data name="WizardTemplateChooserTargetAspFrameworkLabel" xml:space="preserve">
+    <value>Target _ASP.NET Framework:</value>
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2795,14 +2795,6 @@
     <value>_MVC</value>
     <comment>The label for the MVC app type radio button of the Project Template Chooser dialog.</comment>
   </data>
-  <data name="WizardTemplateChooserProjectIdLabel" xml:space="preserve">
-    <value>Google Cloud _Project ID:</value>
-    <comment>The label for the Project ID input field of the Project Template Chooser dialog.</comment>
-  </data>
-  <data name="WizardTemplateChooserSelectProjectButton" xml:space="preserve">
-    <value>_Select Project...</value>
-    <comment>The label of the Select Project button of the Project Template Chooser dialog.</comment>
-  </data>
   <data name="WizardTemplateChooserTargetNetFrameworkLabel" xml:space="preserve">
     <value>Target ._NET Framework:</value>
     <comment>The label for the Target Framework input field of the Project Template Chooser dialog.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/TemplateChooserWindowContent.xaml
@@ -33,63 +33,59 @@
                 IsCancel="True"/>
         </theming:CommonDialogWindowBaseContent.Buttons>
         <StackPanel Orientation="Vertical">
-            <DockPanel Margin="0,0,0,8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
                 <Label
-                    DockPanel.Dock ="Top"
-                    Content="{x:Static ext:Resources.WizardTemplateChooserTargetFrameworkLabel}"
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Content="{x:Static ext:Resources.WizardTemplateChooserTargetNetFrameworkLabel}"
                     Target="{Binding ElementName=_targetFramework}"
-                    Margin="0,0,0,5"/>
-                <StackPanel Orientation="Horizontal">
-                    <ComboBox
-                        x:Name="_targetFramework"
-                        SelectedValuePath="Tag"
-                        SelectedValue="{Binding SelectedFramework}"
-                        MinWidth="150px"
-                        Margin="0,0,5,0">
-                        
-                        <ComboBoxItem
-                            Tag="{x:Static local:FrameworkType.NetCore}"
-                            Content="{x:Static ext:Resources.FrameworkTypeDisplayNameNetCore}"
-                            Visibility="{Binding NetCoreAvailable, Converter={utils:VisibilityConverter}}"
-                            />
-                        <ComboBoxItem
-                            Tag="{x:Static local:FrameworkType.NetFramework}"
-                            Content="{x:Static ext:Resources.FrameworkTypeDisplayNameNetFramework}"/>
-                    </ComboBox>
-                    <ComboBox
-                        ItemsSource="{Binding AvailableVersions}"
-                        SelectedItem="{Binding SelectedVersion}"
-                        MinWidth="180px"
-                        Margin="0"/>
-                </StackPanel>
-            </DockPanel>
-            <DockPanel>
+                    Margin="0" />
+                <ComboBox
+                    x:Name="_targetFramework"
+                    Grid.Column="0"
+                    Grid.Row="1"
+                    SelectedValuePath="Tag"
+                    SelectedValue="{Binding SelectedFramework}"
+                    MinWidth="150px">
+
+                    <ComboBoxItem
+                        Tag="{x:Static local:FrameworkType.NetCore}"
+                        Content="{x:Static ext:Resources.FrameworkTypeDisplayNameNetCore}"
+                        Visibility="{Binding NetCoreAvailable, Converter={utils:VisibilityConverter}}" />
+                    <ComboBoxItem
+                        Tag="{x:Static local:FrameworkType.NetFramework}"
+                        Content="{x:Static ext:Resources.FrameworkTypeDisplayNameNetFramework}" />
+                </ComboBox>
                 <Label
-                    DockPanel.Dock="Top"
-                    Content="{x:Static ext:Resources.WizardTemplateChooserProjectIdLabel}"
-                    Target="{Binding ElementName=_projectIdBox}"
-                    Margin="0,0,0,5"/>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                    <TextBox x:Name="_projectIdBox" Text="{Binding GcpProjectId}" Width="200" Margin="0,0,5,0"/>
-                    <Button
-                        Command="{Binding SelectProjectCommand}"
-                        Content="{x:Static ext:Resources.WizardTemplateChooserSelectProjectButton}"
-                        Margin="0" />
-                </StackPanel>
-            </DockPanel>
-            <StackPanel>
-                <TextBlock Text="{x:Static ext:Resources.WizardTemplateChooserFeaturesLabel}" Margin="0,0,0,3"/>
-                <RadioButton
-                    GroupName="AppType"
-                    Content="{x:Static ext:Resources.WizardTemplateChooserMvcLabel}"
-                    IsChecked="{Binding IsMvc}"
-                    Margin="0,0,0,4"/>
-                <RadioButton
-                    GroupName="AppType"
-                    Content="{x:Static ext:Resources.WizardTemplateChooserWebApiLabel}"
-                    IsChecked="{Binding IsWebApi}"
-                    Margin="0"/>
-            </StackPanel>
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Content="{x:Static ext:Resources.WizardTemplateChooserTargetAspFrameworkLabel}"
+                    Target="{Binding ElementName=_targetAspNetFramework}" />
+                <ComboBox
+                    x:Name="_targetAspNetFramework"
+                    Grid.Column="1"
+                    Grid.Row="1"
+                    ItemsSource="{Binding AvailableVersions}"
+                    SelectedItem="{Binding SelectedVersion}"
+                    MinWidth="180px"/>
+            </Grid>
+            <Label Content="{x:Static ext:Resources.WizardTemplateChooserTemplateTypeLabel}" />
+            <RadioButton
+                GroupName="AppType"
+                Content="{x:Static ext:Resources.WizardTemplateChooserMvcLabel}"
+                IsChecked="{Binding IsMvc}"/>
+            <RadioButton
+                GroupName="AppType"
+                Content="{x:Static ext:Resources.WizardTemplateChooserWebApiLabel}"
+                IsChecked="{Binding IsWebApi}"/>
         </StackPanel>
     </theming:CommonDialogWindowBaseContent>
 </UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/DefaultStylesResource.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/DefaultStylesResource.xaml
@@ -17,13 +17,13 @@
     </Style>
 
     <Style TargetType="TextBox" BasedOn="{StaticResource CommonTextBoxStyle}">
-        <Setter Property="Margin" Value="5"/>
+        <Setter Property="Margin" Value="0,0,12,6"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
     </Style>
     
     <Style TargetType="Button" BasedOn="{StaticResource CommonButtonStyle}">
-        <Setter Property="Margin" Value="2"/>
+        <Setter Property="Margin" Value="0,0,0,6"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="Width" Value="Auto"/>
@@ -31,21 +31,21 @@
     </Style>
 
     <Style TargetType="RadioButton" BasedOn="{StaticResource LabeledRadioButtonStyle}">
-        <Setter Property="Margin" Value="2"/>
-        <Setter Property="Padding" Value="2"/>
+        <Setter Property="Margin" Value="0,4,12,4"/>
+        <Setter Property="Padding" Value="0"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
     </Style>
 
     <Style TargetType="ComboBox" BasedOn="{StaticResource CommonComboBoxStyle}">
-        <Setter Property="Margin" Value="2"/>
+        <Setter Property="Margin" Value="0,0,12,6"/>
         <Setter Property="Padding" Value="2"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
     </Style>
     
     <Style TargetType="Label" BasedOn="{StaticResource CommonLabelStyle}">
-        <Setter Property="Margin" Value="5"/>
+        <Setter Property="Margin" Value="0,0,0,2"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
 </ResourceDictionary>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.0-preview.vstemplate
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.0-preview.vstemplate
@@ -36,7 +36,6 @@
           <ProjectItem ReplaceParameters="true" TargetFileName="site.js">site.js</ProjectItem>
           <ProjectItem ReplaceParameters="true" TargetFileName="site.min.js">site.min.js</ProjectItem>
         </Folder>
-        <ProjectItem ReplaceParameters="true" TargetFileName="_references.js">_references.js</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="favicon.ico">favicon.ico</ProjectItem>
       </Folder>
       <Folder Name="Controllers" TargetFolderName="Controllers">

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.0.vstemplate
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.0.vstemplate
@@ -36,7 +36,6 @@
           <ProjectItem ReplaceParameters="true" TargetFileName="site.js">site.js</ProjectItem>
           <ProjectItem ReplaceParameters="true" TargetFileName="site.min.js">site.min.js</ProjectItem>
         </Folder>
-        <ProjectItem ReplaceParameters="true" TargetFileName="_references.js">_references.js</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="favicon.ico">favicon.ico</ProjectItem>
       </Folder>
       <Folder Name="Controllers" TargetFolderName="Controllers">

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.1.vstemplate
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.1.vstemplate
@@ -36,7 +36,6 @@
           <ProjectItem ReplaceParameters="true" TargetFileName="site.js">site.js</ProjectItem>
           <ProjectItem ReplaceParameters="true" TargetFileName="site.min.js">site.min.js</ProjectItem>
         </Folder>
-        <ProjectItem ReplaceParameters="true" TargetFileName="_references.js">_references.js</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="favicon.ico">favicon.ico</ProjectItem>
       </Folder>
       <Folder Name="Controllers" TargetFolderName="Controllers">

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/2.0.vstemplate
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/2.0.vstemplate
@@ -36,7 +36,6 @@
           <ProjectItem ReplaceParameters="true" TargetFileName="site.js">site.js</ProjectItem>
           <ProjectItem ReplaceParameters="true" TargetFileName="site.min.js">site.min.js</ProjectItem>
         </Folder>
-        <ProjectItem ReplaceParameters="true" TargetFileName="_references.js">_references.js</ProjectItem>
         <ProjectItem ReplaceParameters="false" TargetFileName="favicon.ico">favicon.ico</ProjectItem>
       </Folder>
       <Folder Name="Controllers" TargetFolderName="Controllers">

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/appsettings.json
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/appsettings.json
@@ -8,7 +8,7 @@
     }
   },
   "Google": {
-    "ProjectId": "$gcpprojectid$",
+    "ProjectId": "",
     "ErrorReporting": {
       "ServiceName": "_safe_project_name_",
       "Version": "1.0.0"

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/wwwroot/_references.js
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/wwwroot/_references.js
@@ -1,6 +1,0 @@
-﻿/// <autosync enabled="true" />
-/// <reference path="js/site.js" />
-/// <reference path="lib/bootstrap/dist/js/bootstrap.js" />
-/// <reference path="lib/jquery/dist/jquery.js" />
-/// <reference path="lib/jquery-validation/dist/jquery.validate.js" />
-/// <reference path="lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js" />

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/WebAPI/Startup.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/WebAPI/Startup.cs
@@ -13,8 +13,15 @@ namespace _safe_project_name_
 {
     public class Startup
     {
+        public IConfigurationRoot Configuration { get; }
+
+        private readonly Lazy<string> _projectIdLazy;
+        private string ProjectId => _projectIdLazy.Value;
+        private bool HasProjectId => _projectIdLazy.Value != null;
+
         public Startup(IHostingEnvironment env)
         {
+            _projectIdLazy = new Lazy<string>(GetProjectId);
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
@@ -23,43 +30,47 @@ namespace _safe_project_name_
             Configuration = builder.Build();
         }
 
-        public IConfigurationRoot Configuration { get; }
-
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            string projectId = GetProjectId();
             // Add framework services.
             services.AddMvc();
-            // Enables Stackdriver Trace.
-            services.AddGoogleTrace(options => options.ProjectId = projectId);
-            // Sends Exceptions to Stackdriver Error Reporting.
-            services.AddGoogleExceptionLogging(
-                options =>
-                {
-                    options.ProjectId = projectId;
-                    options.ServiceName = GetServiceName();
-                    options.Version = GetVersion();
-                });
-    }
+
+            if (HasProjectId)
+            {
+                // Enables Stackdriver Trace.
+                services.AddGoogleTrace(options => options.ProjectId = ProjectId);
+                // Sends Exceptions to Stackdriver Error Reporting.
+                services.AddGoogleExceptionLogging(
+                    options =>
+                    {
+                        options.ProjectId = ProjectId;
+                        options.ServiceName = GetServiceName();
+                        options.Version = GetVersion();
+                    });
+            }
+        }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            var projectId = GetProjectId();
 
             // Only use Console and Debug logging during development.
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
-            // Send logs to Stackdriver Logging.
-            loggerFactory.AddGoogle(projectId);
 
-            if (!env.IsDevelopment())
+            if (HasProjectId)
             {
-                app.UseGoogleExceptionLogging();
+                // Send logs to Stackdriver Logging.
+                loggerFactory.AddGoogle(ProjectId);
+
+                if (!env.IsDevelopment())
+                {
+                    app.UseGoogleExceptionLogging();
+                }
+                app.UseGoogleTrace();
             }
 
-            app.UseGoogleTrace();
 
             app.UseMvc();
         }
@@ -70,10 +81,8 @@ namespace _safe_project_name_
             var projectId = instance?.ProjectId ?? Configuration["Google:ProjectId"];
             if (string.IsNullOrEmpty(projectId))
             {
-                throw new Exception(
-                    "The logging, tracing and error reporting libraries need a project ID. " +
-                    "Update appsettings.json by setting the ProjectId property with your " +
-                    "Google Cloud Project ID, then recompile.");
+                // Set Google:ProjectId in appsettings.json to enable stackdriver logging outside of GCP.
+                return null;
             }
             return projectId;
         }

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/WebAPI/appsettings.json
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/WebAPI/appsettings.json
@@ -8,7 +8,7 @@
     }
   },
   "Google": {
-    "ProjectId": "$gcpprojectid$",
+    "ProjectId": "",
     "ErrorReporting": {
       "ServiceName": "_safe_project_name_",
       "Version": "1.0.0"

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/App_Start/FilterConfig.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/App_Start/FilterConfig.cs
@@ -4,6 +4,7 @@ using System.Web;
 using System.Web.Mvc;
 using System.Xml;
 using Google.Cloud.Diagnostics.AspNet;
+using log4net;
 
 namespace _safe_project_name_
 {
@@ -11,29 +12,37 @@ namespace _safe_project_name_
     {
         public static void RegisterGlobalFilters(GlobalFilterCollection filters)
         {
-
             // To enable Google Cloud Stackdriver Logging and Error Reporting
             // while running on your local machine edit Web.config and uncomment
             // the <projectId> value under the <log4net> section. Ensure that
             // the <projectId> is set to a valid Google Cloud Project Id.
             // Otherwise, the features will only work once deployed to GCP.
-
-            // [START error_reporting]
-            // Check to ensure that projectId has been changed from placeholder value.
+            
             string projectId =
                 Google.Api.Gax.Platform.Instance().GceDetails?.ProjectId ??
                 GetProjectIdFromConfig();
             if (!string.IsNullOrEmpty(projectId))
             {
-            var serviceName = ConfigurationManager.AppSettings["google_error_reporting:serviceName"];
-            var version = ConfigurationManager.AppSettings["google_error_reporting:version"];
-            // Add a catch all to log all uncaught exceptions to Stackdriver Error Reporting.
-            filters.Add(ErrorReportingExceptionFilter.Create(projectId, serviceName, version));
-                // [END error_reporting]
+                var serviceName = ConfigurationManager.AppSettings["google_error_reporting:serviceName"];
+                var version = ConfigurationManager.AppSettings["google_error_reporting:version"];
+
+                // Add a catch all to log all uncaught exceptions to Stackdriver Error Reporting.
+                filters.Add(ErrorReportingExceptionFilter.Create(projectId, serviceName, version));
+
+                // Retrieve a logger for this context.
+                ILog log = LogManager.GetLogger(typeof(FilterConfig));
+                // Log confirmation of set-up to Google Stackdriver Error Reporting.
+                log.Info("Stackdriver Error Reporting enabled: https://console.cloud.google.com/errors/");
+            }
+            else
+            {
+                // Retrieve a logger for this context.
+                ILog log = LogManager.GetLogger(typeof(FilterConfig));
+                // Log warning of missing config for Google Stackdriver Error Reporting.
+                log.Warn("Stackdriver Error Reporting not enabled. ProjectId missing from configuration.");
             }
 
             filters.Add(new HandleErrorAttribute());
-
         }
 
         private static string GetProjectIdFromConfig()

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/App_Start/FilterConfig.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/App_Start/FilterConfig.cs
@@ -11,31 +11,36 @@ namespace _safe_project_name_
     {
         public static void RegisterGlobalFilters(GlobalFilterCollection filters)
         {
-            // To enable Google Cloud Stackdrive Logging and Error Reporting
+
+            // To enable Google Cloud Stackdriver Logging and Error Reporting
             // while running on your local machine edit Web.config and uncomment
             // the <projectId> value under the <log4net> section. Ensure that
             // the <projectId> is set to a valid Google Cloud Project Id.
+            // Otherwise, the features will only work once deployed to GCP.
 
             // [START error_reporting]
             // Check to ensure that projectId has been changed from placeholder value.
-            var section = (XmlElement)ConfigurationManager.GetSection("log4net");
-            var projectIdElement =
-                (XmlElement)section.GetElementsByTagName("projectId").Item(0);
             string projectId =
                 Google.Api.Gax.Platform.Instance().GceDetails?.ProjectId ??
-                projectIdElement?.Attributes["value"]?.Value;
-            if (string.IsNullOrEmpty(projectId))
+                GetProjectIdFromConfig();
+            if (!string.IsNullOrEmpty(projectId))
             {
-                throw new Exception("The logging and error reporting libraries need a project ID. "
-                    + "Update Web.config and add a <projectId> entry in the <log4net> section.");
-            }
             var serviceName = ConfigurationManager.AppSettings["google_error_reporting:serviceName"];
             var version = ConfigurationManager.AppSettings["google_error_reporting:version"];
             // Add a catch all to log all uncaught exceptions to Stackdriver Error Reporting.
             filters.Add(ErrorReportingExceptionFilter.Create(projectId, serviceName, version));
-            // [END error_reporting]
+                // [END error_reporting]
+            }
 
             filters.Add(new HandleErrorAttribute());
+
+        }
+
+        private static string GetProjectIdFromConfig()
+        {
+            var log4NetSection = ConfigurationManager.GetSection("log4net") as XmlElement;
+            var projectIdElement =log4NetSection?.GetElementsByTagName("projectId")?.Item(0) as XmlElement;
+            return projectIdElement?.Attributes["value"]?.Value;
         }
     }
 }

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Global.asax.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Global.asax.cs
@@ -8,6 +8,7 @@ using System.Web.Routing;
 using System.Xml;
 using System.Configuration;
 using log4net;
+using Google.Cloud.Logging.Log4Net;
 
 namespace _safe_project_name_
 {
@@ -18,19 +19,16 @@ namespace _safe_project_name_
             // Configure Stackdriver Logging via Log4Net.
             log4net.Config.XmlConfigurator.Configure();
 
+            if (LogManager.GetRepository().GetAppenders().OfType<GoogleStackdriverAppender>().Any())
+            {
+                LogManager.GetLogger(nameof(MvcApplication))
+                    .Info("Google Stackdriver Logging enabled: https://cloud.google.com/logs/");
+            }
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
-
-            // [START enable_logging]
-            // Retrieve a logger for this context.
-            ILog log = LogManager.GetLogger(typeof(MvcApplication));
-            // Log confirmation of set-up to Google Stackdriver Logging.
-            log.Info("Stackdriver Logging with Log4net successfully configured for use.");
-            log.Info("Stackdriver Error Reporting enabled: " +
-                "https://console.cloud.google.com/errors/");
-            // [END enable_logging]
         }
     }
 }

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Project.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Project.csproj
@@ -285,7 +285,9 @@
     <Content Include="Scripts\respond.js" />
     <Content Include="Scripts\respond.min.js" />
     <Content Include="Scripts\_references.js" />
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </Content>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Web.config
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Web.config
@@ -22,8 +22,8 @@
         When running on Google Cloud the code will be able to determine the project
         ID automatically.
       -->
-      <projectId value="$gcpprojectid$" /> 
-      <logId value="$gcpprojectid$__safe_project_name_" />
+<!--  <projectId value="gcp-project-id" /> -->
+      <logId value="_safe_project_name_" />
     </appender>
     <root>
       <level value="ALL" />

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Web.config
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/MVC/Web.config
@@ -13,6 +13,11 @@
   </configSections>
   <!-- // [START log4net_web_config] -->
   <log4net>
+    <appender name="Debug" type="log4net.Appender.DebugAppender">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message" />
+      </layout>
+    </appender>
     <appender name="CloudLogger" type="Google.Cloud.Logging.Log4Net.GoogleStackdriverAppender,Google.Cloud.Logging.Log4Net">
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message" />
@@ -27,6 +32,7 @@
     </appender>
     <root>
       <level value="ALL" />
+      <appender-ref ref="Debug" />
       <appender-ref ref="CloudLogger" />
     </root>
   </log4net>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/App_Start/WebApiConfig.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/App_Start/WebApiConfig.cs
@@ -23,29 +23,30 @@ namespace _safe_project_name_
             // the <projectId> value under the <log4net> section. Ensure that
             // the <projectId> is set to a valid Google Cloud Project Id.
             // Otherwise, logging will only occur when deployed to GCP.
-
-            // [START logging_and_error_reporting]
+            
             string projectId =
                 Google.Api.Gax.Platform.Instance().GceDetails?.ProjectId ??
                 GetProjectIdFromConfig();
             if (!string.IsNullOrEmpty(projectId))
             {
-                // [START enable_error_reporting]
                 var serviceName = ConfigurationManager.AppSettings["google_error_reporting:serviceName"];
                 var version = ConfigurationManager.AppSettings["google_error_reporting:version"];
                 // Add a catch all to log all uncaught exceptions to Stackdriver Error Reporting.
-                config.Services.Add(typeof(IExceptionLogger),
+                config.Services.Add(
+                    typeof(IExceptionLogger),
                     ErrorReportingExceptionLogger.Create(projectId, serviceName, version));
-                // [END enable_error_reporting]
-                // [START enable_logging]
+
                 // Retrieve a logger for this context.
                 ILog log = LogManager.GetLogger(typeof(WebApiConfig));
-                // [END enable_logging]
-                // Log confirmation of set-up to Google Stackdriver Logging.
-                log.Info("Stackdriver Logging with Log4net successfully configured for use.");
-                log.Info("Stackdriver Error Reporting enabled: " +
-                    "https://console.cloud.google.com/errors/");
-                // [END logging_and_error_reporting]
+                // Log confirmation of set-up to Google Stackdriver Error Reporting.
+                log.Info("Stackdriver Error Reporting enabled: https://console.cloud.google.com/errors/");
+            }
+            else
+            {
+                // Retrieve a logger for this context.
+                ILog log = LogManager.GetLogger(typeof(WebApiConfig));
+                // Log failure of set-up to Google Stackdriver Error Reporting.
+                log.Warn("Stackdriver Error Reporting not enabled. ProjectId missing from configuration.");
             }
 
             // Web API configuration and services
@@ -59,7 +60,7 @@ namespace _safe_project_name_
             config.Routes.MapHttpRoute(
                 name: "DefaultApi",
                 routeTemplate: "api/{controller}/{id}",
-                defaults: new { id = RouteParameter.Optional }
+                defaults: new {id = RouteParameter.Optional}
             );
         }
 

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/App_Start/WebApiConfig.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/App_Start/WebApiConfig.cs
@@ -22,36 +22,31 @@ namespace _safe_project_name_
             // while running on your local machine edit Web.config and uncomment
             // the <projectId> value under the <log4net> section. Ensure that
             // the <projectId> is set to a valid Google Cloud Project Id.
+            // Otherwise, logging will only occur when deployed to GCP.
 
             // [START logging_and_error_reporting]
-            // Check to ensure that projectId has been changed from placeholder value.
-            var section = (XmlElement)ConfigurationManager.GetSection("log4net");
-            XmlElement projectIdElement =
-                (XmlElement)section.GetElementsByTagName("projectId").Item(0);
             string projectId =
                 Google.Api.Gax.Platform.Instance().GceDetails?.ProjectId ??
-                projectIdElement?.Attributes["value"].Value;
-            if (string.IsNullOrEmpty(projectId))
+                GetProjectIdFromConfig();
+            if (!string.IsNullOrEmpty(projectId))
             {
-                throw new Exception("The logging and error reporting libraries need a project ID. "
-                    + "Update Web.config and add a <projectId> entry in the <log4net> section.");
+                // [START enable_error_reporting]
+                var serviceName = ConfigurationManager.AppSettings["google_error_reporting:serviceName"];
+                var version = ConfigurationManager.AppSettings["google_error_reporting:version"];
+                // Add a catch all to log all uncaught exceptions to Stackdriver Error Reporting.
+                config.Services.Add(typeof(IExceptionLogger),
+                    ErrorReportingExceptionLogger.Create(projectId, serviceName, version));
+                // [END enable_error_reporting]
+                // [START enable_logging]
+                // Retrieve a logger for this context.
+                ILog log = LogManager.GetLogger(typeof(WebApiConfig));
+                // [END enable_logging]
+                // Log confirmation of set-up to Google Stackdriver Logging.
+                log.Info("Stackdriver Logging with Log4net successfully configured for use.");
+                log.Info("Stackdriver Error Reporting enabled: " +
+                    "https://console.cloud.google.com/errors/");
+                // [END logging_and_error_reporting]
             }
-            // [START enable_error_reporting]
-            var serviceName = ConfigurationManager.AppSettings["google_error_reporting:serviceName"];
-            var version = ConfigurationManager.AppSettings["google_error_reporting:version"];
-            // Add a catch all to log all uncaught exceptions to Stackdriver Error Reporting.
-            config.Services.Add(typeof(IExceptionLogger),
-                ErrorReportingExceptionLogger.Create(projectId, serviceName, version));
-            // [END enable_error_reporting]
-            // [START enable_logging]
-            // Retrieve a logger for this context.
-            ILog log = LogManager.GetLogger(typeof(WebApiConfig));
-            // [END enable_logging]
-            // Log confirmation of set-up to Google Stackdriver Logging.
-            log.Info("Stackdriver Logging with Log4net successfully configured for use.");
-            log.Info("Stackdriver Error Reporting enabled: " +
-                "https://console.cloud.google.com/errors/");
-            // [END logging_and_error_reporting]
 
             // Web API configuration and services
             // Configure Web API to use only bearer token authentication.
@@ -66,6 +61,13 @@ namespace _safe_project_name_
                 routeTemplate: "api/{controller}/{id}",
                 defaults: new { id = RouteParameter.Optional }
             );
+        }
+
+        private static string GetProjectIdFromConfig()
+        {
+            var log4NetSection = ConfigurationManager.GetSection("log4net") as XmlElement;
+            var projectIdElement = log4NetSection?.GetElementsByTagName("projectId")?.Item(0) as XmlElement;
+            return projectIdElement?.Attributes["value"]?.Value;
         }
     }
 }

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Global.asax.cs
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Global.asax.cs
@@ -8,6 +8,8 @@ using System.Web.Optimization;
 using System.Web.Routing;
 using System.Xml;
 using System.Configuration;
+using log4net;
+using Google.Cloud.Logging.Log4Net;
 
 namespace _safe_project_name_
 {
@@ -17,6 +19,12 @@ namespace _safe_project_name_
         {
             // Configure Stackdriver Logging via Log4Net
             log4net.Config.XmlConfigurator.Configure();
+
+            if (LogManager.GetRepository().GetAppenders().OfType<GoogleStackdriverAppender>().Any())
+            {
+                LogManager.GetLogger(nameof(WebApiApplication))
+                    .Info("Google Stackdriver Logging enabled: https://cloud.google.com/logs/");
+            }
 
             AreaRegistration.RegisterAllAreas();
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Project.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Project.csproj
@@ -343,7 +343,9 @@
     <Content Include="Scripts\modernizr-2.6.2.js" />
     <Content Include="Scripts\respond.js" />
     <Content Include="Scripts\respond.min.js" />
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </Content>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Web.config
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Web.config
@@ -18,10 +18,12 @@
   </configSections>
   <!-- [START log4net_web_config] -->
   <log4net>
-    <appender
-      name="CloudLogger"
-      type="Google.Cloud.Logging.Log4Net.GoogleStackdriverAppender,Google.Cloud.Logging.Log4Net">
-      
+    <appender name="Debug" type="log4net.Appender.DebugAppender">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message" />
+      </layout>
+    </appender>
+    <appender name="CloudLogger" type="Google.Cloud.Logging.Log4Net.GoogleStackdriverAppender,Google.Cloud.Logging.Log4Net">
       <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message" />
       </layout>
@@ -35,6 +37,7 @@
     </appender>
     <root>
       <level value="ALL" />
+      <appender-ref ref="Debug" />
       <appender-ref ref="CloudLogger" />
     </root>
   </log4net>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Web.config
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Framework/WebAPI/Web.config
@@ -30,8 +30,8 @@
         When running on Google Cloud the code will be able to determine the project
         ID automatically.
       -->
-      <projectId value="$gcpprojectid$" />
-      <logId value="$gcpprojectid$__safe_project_name_" />
+<!--  <projectId value="$gcpprojectid$" />-->
+      <logId value="_safe_project_name_" />
     </appender>
     <root>
       <level value="ALL" />

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/GcpProjectTemplate.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/GcpProjectTemplate.csproj
@@ -71,7 +71,6 @@
     <None Include="Core\MVC\project.json" />
     <None Include="Core\MVC\Properties\launchSettings.json" />
     <None Include="Core\MVC\web.config" />
-    <None Include="Core\MVC\wwwroot\_references.js" />
     <None Include="Core\MVC\wwwroot\css\site.css" />
     <None Include="Core\MVC\wwwroot\css\site.min.css" />
     <None Include="Core\MVC\wwwroot\favicon.ico" />


### PR DESCRIPTION
Fixes #823 

Remove the Google Cloud Project ID input from the templates.
Disable stackdriver logging when GCP Project ID is not set in the templates.
Fixes #830 