### PR TITLE
Prevent Downloading from GCS from crashing VS.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogViewModel.cs
@@ -93,7 +93,7 @@ namespace GoogleCloudExtension.GcsFileProgressDialog
         public int Completed
         {
             get { return _completed; }
-            private set
+            set
             {
                 SetValueAndRaise(ref _completed, value);
                 RaisePropertyChanged(nameof(ProgressMessage));

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindow.cs
@@ -24,7 +24,7 @@ namespace GoogleCloudExtension.GcsFileProgressDialog
     /// </summary>
     public class GcsFileProgressDialogWindow : CommonDialogWindowBase
     {
-        private GcsFileProgressDialogWindow(
+        internal GcsFileProgressDialogWindow(
             string caption,
             string message,
             string progressMessage,

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindowContent.xaml
@@ -39,13 +39,13 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <Label Content="{Binding ProgressMessage, Mode=OneWay}" Style="{StaticResource CommonLabelStyle}" />
+            <Label Content="{Binding ProgressMessage}" Style="{StaticResource CommonLabelStyle}" />
 
             <ProgressBar Grid.Row="1"
                          Margin="0,0,0,10"
                          Minimum="0"
                          Maximum="{Binding Operations.Count}"
-                         Value="{Binding Completed, Mode=OneWay}"
+                         Value="{Binding Completed}"
                          IsIndeterminate="{Binding OperationsPending}"
                          Style="{StaticResource CommonProgressBarStyle}"/>
 
@@ -73,7 +73,7 @@
             <StackPanel Grid.Row="3"
                         Margin="0,10,0,0"
                         Visibility="{Binding DetailsExpanded, Converter={StaticResource commonVisibilityConverter}}">
-                <Label Content="{Binding Message, Mode=OneWay}"
+                <Label Content="{Binding Message}"
                        Style="{StaticResource CommonLabelStyle}" />
                 <DataGrid IsReadOnly="True"
                           AutoGenerateColumns="False"

--- a/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/GcsFileProgressDialog/GcsFileProgressDialogWindowContent.xaml
@@ -39,13 +39,13 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <Label Content="{Binding ProgressMessage}" Style="{StaticResource CommonLabelStyle}" />
+            <Label Content="{Binding ProgressMessage, Mode=OneWay}" Style="{StaticResource CommonLabelStyle}" />
 
             <ProgressBar Grid.Row="1"
                          Margin="0,0,0,10"
                          Minimum="0"
                          Maximum="{Binding Operations.Count}"
-                         Value="{Binding Completed}"
+                         Value="{Binding Completed, Mode=OneWay}"
                          IsIndeterminate="{Binding OperationsPending}"
                          Style="{StaticResource CommonProgressBarStyle}"/>
 
@@ -73,7 +73,7 @@
             <StackPanel Grid.Row="3"
                         Margin="0,10,0,0"
                         Visibility="{Binding DetailsExpanded, Converter={StaticResource commonVisibilityConverter}}">
-                <Label Content="{Binding Message}"
+                <Label Content="{Binding Message, Mode=OneWay}"
                        Style="{StaticResource CommonLabelStyle}" />
                 <DataGrid IsReadOnly="True"
                           AutoGenerateColumns="False"

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
@@ -1,4 +1,18 @@
-﻿using GoogleCloudExtension.GcsFileProgressDialog;
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension.GcsFileProgressDialog;
 using GoogleCloudExtension.GcsUtils;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
@@ -1,0 +1,56 @@
+﻿using GoogleCloudExtension.GcsFileProgressDialog;
+using GoogleCloudExtension.GcsUtils;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace GoogleCloudExtensionUnitTests.GcsFileProgressDialog
+{
+    /// <summary>
+    /// Summary description for GcsFileProgressDialogContentTest
+    /// </summary>
+    [TestClass]
+    public class GcsFileProgressDialogWindowTest
+    {
+        private Mock<IVsSettingsManager> _settingManagerMock;
+        private Mock<IVsUIShell> _uiShellMock;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            _settingManagerMock = new Mock<IVsSettingsManager>();
+            _uiShellMock = new Mock<IVsUIShell>();
+            int intValue = 0;
+            IVsSettingsStore store = Mock.Of<IVsSettingsStore>(
+                ss => ss.GetIntOrDefault(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), out intValue) == 0);
+            _settingManagerMock.Setup(sm => sm.GetReadOnlySettingsStore(It.IsAny<uint>(), out store)).Returns(0);
+            GoogleCloudExtensionPackageTests.InitPackageMock(dte =>
+            {
+                Mock<IServiceProvider> providerMock = dte.As<IServiceProvider>();
+                GoogleCloudExtensionPackageTests.SetupService<SVsSettingsManager, IVsSettingsManager>(
+                    providerMock, _settingManagerMock);
+                GoogleCloudExtensionPackageTests.SetupService<IVsUIShell, IVsUIShell>(providerMock, _uiShellMock);
+            });
+        }
+
+        [TestMethod]
+        public async Task TestBindingsLoadCorrectly()
+        {
+            var objectUnderTest = new GcsFileProgressDialogWindow(
+                "test-caption", "test-message", "test-progress-message", new GcsOperation[0],
+                new CancellationTokenSource());
+            Task closeTask = Application.Current.Dispatcher.InvokeAsync(
+               () =>
+               {
+                   Thread.Yield();
+                   objectUnderTest.Close();
+               }).Task;
+            objectUnderTest.ShowModal();
+            await closeTask;
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -244,6 +244,7 @@
     <Compile Include="CloudSourceRepository\CsrAddRepoWindowViewModelTests.cs" />
     <Compile Include="CloudSourceRepository\CsrCloneWindowViewModelTests.cs" />
     <Compile Include="CloudSourceRepository\RepoNameConverterTests.cs" />
+    <Compile Include="GcsFileProgressDialog\GcsFileProgressDialogWindowTest.cs" />
     <Compile Include="GoogleCloudExtensionPackageTests.cs" />
     <Compile Include="Options\AnalyticsOptionsTests.cs" />
     <Compile Include="Options\AnalyticsOptionsPageViewModelTests.cs" />
@@ -279,6 +280,10 @@
     <ProjectReference Include="..\GoogleCloudExtension.Deployment\GoogleCloudExtension.Deployment.csproj">
       <Project>{92c6e0d0-41d8-4ecc-87e1-ae72fca891fc}</Project>
       <Name>GoogleCloudExtension.Deployment</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GoogleCloudExtension.GcsUtils\GoogleCloudExtension.GcsUtils.csproj">
+      <Project>{0C891356-CCD7-4A10-BA27-C4A4359EA825}</Project>
+      <Name>GoogleCloudExtension.GcsUtils</Name>
     </ProjectReference>
     <ProjectReference Include="..\GoogleCloudExtension.Interop\GoogleCloudExtension.Interop.csproj">
       <Project>{856b9f2e-441f-405a-9d5c-af5dc5653902}</Project>


### PR DESCRIPTION
Fix a property that had a default two way binding, but a private setter.
Fixes #878.