### PR TITLE
Enable Copying Log Item data from the StackdriverLogsViewer.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -141,6 +141,7 @@
     <Compile Include="IGaeDataSource.cs" />
     <Compile Include="IGceDataSource.cs" />
     <Compile Include="IGkeDataSource.cs" />
+    <Compile Include="ILoggingDataSource.cs" />
     <Compile Include="IPubsubDataSource.cs" />
     <Compile Include="IResourceManagerDataSource.cs" />
     <Compile Include="OperationUtils.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/ILoggingDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/ILoggingDataSource.cs
@@ -1,0 +1,82 @@
+﻿using Google.Apis.Logging.v2.Data;
+using Google.Apis.Logging.v2.Data.Extensions;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtension.DataSources
+{
+    public interface ILoggingDataSource
+    {
+
+        /// <summary>
+        /// Returns the list of MonitoredResourceDescriptor.
+        /// The size of entire set of MonitoredResourceDescriptor is small.
+        /// Batch all in one request in case it spans multiple pages.
+        /// </summary>
+        Task<IList<MonitoredResourceDescriptor>> GetResourceDescriptorsAsync();
+
+        /// <summary>
+        /// Returns the first page of log entries of the project id.
+        /// </summary>
+        /// <param name="filter">
+        /// Optional,
+        /// Refert to https://cloud.google.com/logging/docs/view/advanced_filters.
+        /// </param>
+        /// <param name="orderBy">
+        /// Optional, "timestamp desc" or "timestamp asc"
+        /// </param>
+        /// <param name="pageSize">
+        /// Optional,
+        /// If page size is not specified, a server side default value is used.
+        /// </param>
+        /// <param name="nextPageToken">
+        /// Optional,
+        /// The page token from last list request response.
+        /// If the value is null, fetch the first page results.
+        /// If the value is not null, it is hard requirement that the filter, orderBy and pageSize parameters
+        /// must stay same as the prior call.
+        /// </param>
+        /// <param name="cancelToken">Optional. A cancellation token.</param>
+        /// <returns>
+        ///     <seealso ref="LogEntryRequestResult" /> object that contains log entries and next page token.
+        /// </returns>
+        Task<LogEntryRequestResult> ListLogEntriesAsync(
+            string filter = null,
+            string orderBy = null,
+            int? pageSize = null,
+            string nextPageToken = null,
+            CancellationToken cancelToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns a list of log names of current Google Cloud project.
+        /// Only logs that have entries are listed.
+        /// The size of entire set of log names is small.
+        /// Batch all in one request in unlikely case it spans multiple pages.
+        /// </summary>
+        /// <param name="resourceType">The resource type, i.e gce_instance.</param>
+        /// <param name="resourcePrefixList">
+        /// Optional, can be null.
+        /// A list of resource prefixes.
+        /// i.e,  for resource type app engine, the prefixe can be the module ids.
+        /// </param>
+        Task<IList<string>> ListProjectLogNamesAsync(
+            string resourceType,
+            IEnumerable<string> resourcePrefixList = null);
+
+        /// <summary>
+        /// List all resource keys for the project.
+        /// </summary>
+        Task<IList<ResourceKeys>> ListResourceKeysAsync();
+
+        /// <summary>
+        /// List all resource type values for the given resource type and resource key.
+        /// </summary>
+        /// <param name="resourceType">Required, the resource type.</param>
+        /// <param name="resourceKey">Optional, the resource key as prefix.</param>
+        /// <returns>
+        /// A task with result of a list of resource keys.
+        /// </returns>
+        Task<IList<string>> ListResourceTypeValuesAsync(string resourceType, string resourceKey = null);
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/LoggingDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/LoggingDataSource.cs
@@ -31,7 +31,7 @@ namespace GoogleCloudExtension.DataSources
     /// Data source that returns data from Stackdriver Logging API.
     /// The API is described at https://cloud.google.com/logging/docs/api/reference/rest
     /// </summary>
-    public class LoggingDataSource : DataSourceBase<LoggingService>
+    public class LoggingDataSource : DataSourceBase<LoggingService>, ILoggingDataSource
     {
         /// <summary>
         /// Google cloud uses format of projects/{project_id} as projects filter.
@@ -103,7 +103,7 @@ namespace GoogleCloudExtension.DataSources
 
         /// <summary>
         /// Returns the list of MonitoredResourceDescriptor.
-        /// The size of entire set of MonitoredResourceDescriptor is small. 
+        /// The size of entire set of MonitoredResourceDescriptor is small.
         /// Batch all in one request in case it spans multiple pages.
         /// </summary>
         public Task<IList<MonitoredResourceDescriptor>> GetResourceDescriptorsAsync()

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerResources.xaml
@@ -13,6 +13,7 @@
     <!-- DataGrid cell style. 
         Note: Add padding to text, padding at row style does not work. -->
     <Style x:Key="cellStyle" TargetType="DataGridCell">
+        <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="DataGridCell">

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml
@@ -6,13 +6,14 @@
              xmlns:utils="clr-namespace:GoogleCloudExtension.Utils;assembly=GoogleCloudExtension.Utils"
              xmlns:ext="clr-namespace:GoogleCloudExtension"
              xmlns:local="clr-namespace:GoogleCloudExtension.StackdriverLogsViewer"
-             xmlns:controls="clr-namespace:GoogleCloudExtension.Controls"             
+             xmlns:controls="clr-namespace:GoogleCloudExtension.Controls"
              xmlns:mp="clr-namespace:GoogleCloudExtension.Extensions"
              xmlns:tb="clr-namespace:GoogleCloudExtension.TitleBar"
              Background="{DynamicResource VsBrush.Window}"
              Foreground="{DynamicResource VsBrush.WindowText}"
              mc:Ignorable="d"
-             d:DesignHeight="1024" d:DesignWidth="860"             
+             d:DesignHeight="1024" d:DesignWidth="860"
+             d:DataContext="{d:DesignInstance local:LogsViewerViewModel}"
              Name="_logsViewerToolWindow" >
     <UserControl.Resources>
         <ResourceDictionary>
@@ -23,48 +24,112 @@
                 <ResourceDictionary Source="../Controls/DotsProgressIndicatorResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <utils:VisibilityConverter x:Key="visibilityConverter" />
-            <utils:VisibilityConverter x:Key="visibilityConverterNegated" IsNegated="True" />
-            <utils:NullEmptyInvisibleConverter x:Key="nullEmptyInvisibleConverter" />
+            <ControlTemplate x:Key="EllipsisBlockTemplate" TargetType="TextBox">
+                <TextBlock
+                    Text="{TemplateBinding Text}"
+                    TextWrapping="{TemplateBinding TextWrapping}"
+                    TextTrimming="CharacterEllipsis"
+                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                    Style="{StaticResource CommonTextStyle}" />
+            </ControlTemplate>
 
-            <DataGridTemplateColumn
-                x:Key="MessageColumn" 
-                Width="*">
-                <DataGridTemplateColumn.CellTemplate>
-                    <DataTemplate>
-                        <DockPanel LastChildFill="True" >
-                            <Grid DockPanel.Dock="Left">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock 
-                                    Text="{Binding Message}"
-                                    TextWrapping="NoWrap"
-                                    TextTrimming="CharacterEllipsis" />
+            <!-- This style makes a Text Box look like a Text Block when not focused.-->
+            <Style x:Key="EllipsisBoxStyle" TargetType="TextBox">
+                <Style.Triggers>
+                    <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsKeyboardFocused}" Value="False">
+                        <Setter Property="Template" Value="{StaticResource EllipsisBlockTemplate}"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
 
-                                <controls:IconButton
-                                    Grid.Column="1"
-                                    x:Name="_sourceLinkButton"
-                                    Margin="6,0,12,0"
-                                    Style="{StaticResource MouseOverLinkButtonStyle}"
-                                    Command="{Binding OnNavigateToSourceCommand}"
-                                    Visibility="{Binding SourceLinkVisible, Converter={StaticResource visibilityConverter}}"
-                                    Content="{Binding SourceLinkCaption}">
-                                    <controls:IconButton.ToolTip>
-                                        <ToolTip Content="{Binding SourceFilePath}" 
-                                                    Style="{StaticResource CommonTooltipStyle}" />
-                                    </controls:IconButton.ToolTip>
-                                </controls:IconButton>
-                            </Grid>
+            <DataTemplate x:Key="SeverityLevelColumnTemplate" DataType="local:LogItem">
+                <Image Source="{Binding SeverityLevel}"
+                       Width="12"
+                       Height="12"
+                       Margin="9,1,8,1">
+                    <Image.ToolTip>
+                        <ToolTip Content="{Binding SeverityTip}" Style="{StaticResource CommonTooltipStyle}" />
+                    </Image.ToolTip>
+                </Image>
+            </DataTemplate>
 
-                            <TextBlock DockPanel.Dock="Right"/>
-                            
-                        </DockPanel>
-                    </DataTemplate>
-                </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
-            
+            <DataTemplate x:Key="TimeColumnTemplate" DataType="local:LogItem">
+                <TextBox
+                    IsReadOnly="True"
+                    Text="{Binding Time, Mode=OneWay}"
+                    TextWrapping="NoWrap"
+                    Margin="6,0,6,0"
+                    Style="{StaticResource EllipsisBoxStyle}">
+
+                    <TextBox.ToolTip>
+                        <ToolTip Content="{Binding Date}" Style="{StaticResource CommonTooltipStyle}" />
+                    </TextBox.ToolTip>
+                </TextBox>
+            </DataTemplate>
+
+            <DataTemplate x:Key="MessageColumnTemplate" DataType="local:LogItem">
+                <DockPanel LastChildFill="True">
+                    <Grid DockPanel.Dock="Left">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBox
+                            Text="{Binding Message, Mode=OneWay}"
+                            TextWrapping="NoWrap"
+                            IsReadOnly="True"
+                            Style="{StaticResource EllipsisBoxStyle}"/>
+
+                        <controls:IconButton
+                            Grid.Column="1"
+                            x:Name="_sourceLinkButton"
+                            Margin="6,0,12,0"
+                            Style="{StaticResource MouseOverLinkButtonStyle}"
+                            Command="{Binding OnNavigateToSourceCommand}"
+                            Visibility="{Binding SourceLinkVisible, Converter={utils:VisibilityConverter}}"
+                            Content="{Binding SourceLinkCaption}">
+                            <controls:IconButton.ToolTip>
+                                <ToolTip Content="{Binding SourceFilePath}"
+                                         Style="{StaticResource CommonTooltipStyle}" />
+                            </controls:IconButton.ToolTip>
+                        </controls:IconButton>
+                    </Grid>
+
+                    <TextBlock DockPanel.Dock="Right"/>
+
+                </DockPanel>
+            </DataTemplate>
+
+            <DataTemplate x:Key="LogItemDetailsTemplate"  DataType="local:LogItem">
+                <!-- Use a border to make the background right. -->
+                <Border Background="White" Padding="30,0,0,2">
+
+                    <TreeView BorderThickness="0"
+                              ItemsSource="{Binding TreeViewObjects}"
+                              SelectedValuePath="NodeValue"
+                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                              ScrollViewer.VerticalScrollBarVisibility="Disabled">
+                        <TreeView.CommandBindings>
+                            <CommandBinding Command="ApplicationCommands.Copy" Executed="DetailsTreeView_OnCopy"/>
+                        </TreeView.CommandBindings>
+                        <TreeView.ItemContainerStyle>
+                            <Style TargetType="{x:Type TreeViewItem}">
+                                <Setter Property="IsExpanded" Value="True" />
+                                <Setter Property="ContextMenu">
+                                    <Setter.Value>
+                                        <ContextMenu d:DataContext="{d:DesignInstance local:ObjectNodeTree}">
+                                            <MenuItem Header="Copy" Command="{Binding CopyCommand}" />
+                                        </ContextMenu>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </TreeView.ItemContainerStyle>
+                    </TreeView>
+                </Border>
+            </DataTemplate>
+
             <HierarchicalDataTemplate DataType="{x:Type local:ObjectNodeTree}" 
                                       ItemsSource="{Binding Children}">
                 <StackPanel Orientation="Horizontal">
@@ -83,19 +148,19 @@
             </HierarchicalDataTemplate>
 
             <!-- data grid group item. -->
-            <ControlTemplate x:Key="groupItemTemplate" TargetType="{x:Type GroupItem}">
-                <StackPanel>
+            <ControlTemplate x:Key="GroupItemTemplate" TargetType="{x:Type GroupItem}">
+                <StackPanel d:DataContext="{d:DesignInstance CollectionViewGroup}">
                     <StackPanel 
                         Orientation="Horizontal" 
                         Background="#E0E0E0">
 
                         <TextBlock 
-                            Text="{Binding Name}"  
+                            Text="{Binding Name}"
                             Padding="6" 
                             FontWeight="DemiBold"
                             Style="{StaticResource CommonTextStyle}"/>
 
-                        <controls:FixBackgroundComboBox                         
+                        <controls:FixBackgroundComboBox
                             DockPanel.Dock="Left"
                             x:Name="comboTimeZone" 
                             Margin="6,0,0,0" 
@@ -130,7 +195,7 @@
         
         <Grid 
             Grid.Row="1"
-            Visibility="{Binding Project, Converter={StaticResource nullEmptyInvisibleConverter}}">
+            Visibility="{Binding Project, Converter={utils:NullEmptyInvisibleConverter}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -147,7 +212,7 @@
                     x:Name="_autoReloadButton"
                     Style="{StaticResource AutoReloadButtonStyle}" 
                     AutoReloadCommand="{Binding OnAutoReloadCommand}"
-                    Content="{x:Static ext:Resources.LogViewerAutoReloadButtonCaption}"                    
+                    Content="{x:Static ext:Resources.LogViewerAutoReloadButtonCaption}"
                     IntervalSeconds="{Binding AutoReloadIntervalSeconds}"
                     IsChecked="{Binding IsAutoReloadChecked}"/>
             </Border>
@@ -160,10 +225,10 @@
                 VerticalAlignment="Center" 
                 HorizontalAlignment="Stretch" 
                 Orientation="Vertical"
-                Visibility="{Binding IsChecked, ElementName=_autoReloadButton, Converter={StaticResource visibilityConverterNegated}}">
+                Visibility="{Binding IsChecked, ElementName=_autoReloadButton, Converter={utils:VisibilityConverter IsNegated=True}}">
 
                 <!-- Advanced Filter -->
-                <Grid Visibility="{Binding ShowAdvancedFilter, Converter={StaticResource visibilityConverter}}">
+                <Grid Visibility="{Binding ShowAdvancedFilter, Converter={utils:VisibilityConverter}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />
@@ -186,7 +251,7 @@
                         MaxLines="6"
                         VerticalScrollBarVisibility="Auto" />
 
-                    <Button 
+                    <Button
                         Grid.Column="2" 
                         Margin="6,0,0,0" 
                         HorizontalAlignment="Right"
@@ -226,7 +291,7 @@
 
                 <!-- Basic Filters. -->
                 <StackPanel 
-                    Visibility="{Binding ShowAdvancedFilter, Converter={StaticResource visibilityConverterNegated}}">
+                    Visibility="{Binding ShowAdvancedFilter, Converter={utils:VisibilityConverter IsNegated=True}}">
                     <StackPanel 
                         Orientation="Horizontal" 
                         HorizontalAlignment="Left" 
@@ -365,37 +430,35 @@
                   IsEnabled="{Binding IsControlEnabled}">
 
                 <!-- DataGrid, displays all log entries. -->
-                <DataGrid 
+                <DataGrid
                     Panel.ZIndex="10" 
-                    x:Name="_dataGridLogEntries"
-                    HorizontalAlignment="Stretch" 
-                    VerticalAlignment="Stretch" 
-                    Background="White" 
-                    BorderThickness="1" 
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="White"
+                    BorderThickness="1"
                     BorderBrush="LightGray"
-                    GridLinesVisibility="None" 
-                    CanUserResizeRows="False"                  
-                    RowStyle="{StaticResource rowStyle}" 
+                    GridLinesVisibility="None"
+                    CanUserResizeRows="False"
+                    RowStyle="{StaticResource rowStyle}"
                     CellStyle="{StaticResource cellStyle}"
-                    AutoGenerateColumns="False" 
-                    IsReadOnly="True" 
-                    HeadersVisibility="Column" 
-                    ColumnHeaderHeight="22" 
-                    ItemsSource="{Binding LogItemCollection}"   
-                    ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                    AutoGenerateColumns="False"
+                    IsReadOnly="True"
+                    HeadersVisibility="Column"
+                    ColumnHeaderHeight="22"
+                    ItemsSource="{Binding LogItemCollection}"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                     AlternationCount="2"
-                    ScrollViewer.ScrollChanged="dataGrid_ScrollChanged"
-                    PreviewMouseDown="dataGrid_PreviewMouseDown">
+                    ScrollViewer.ScrollChanged="DataGrid_ScrollChanged"
+                    RowDetailsVisibilityMode="VisibleWhenSelected"
+                    RowDetailsTemplate="{StaticResource LogItemDetailsTemplate}">
 
                     <!-- Override the text highlight color. -->
                     <DataGrid.Resources>
-                        <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" 
-                                         Color="Black"/>
+                        <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black"/>
                     </DataGrid.Resources>
 
                     <DataGrid.Style>
                         <Style TargetType="DataGrid">
-                            <Setter Property="RowDetailsVisibilityMode" Value="Collapsed"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsExpanded, ElementName=_allExpander}" Value="True">
                                     <Setter Property="RowDetailsVisibilityMode" Value="Visible" />
@@ -405,10 +468,10 @@
                     </DataGrid.Style>
 
                     <DataGrid.GroupStyle>
-                        <GroupStyle >
-                            <GroupStyle.ContainerStyle >
+                        <GroupStyle>
+                            <GroupStyle.ContainerStyle>
                                 <Style TargetType="{x:Type GroupItem}" >
-                                    <Setter Property="Template" Value="{StaticResource groupItemTemplate}" />
+                                    <Setter Property="Template" Value="{StaticResource GroupItemTemplate}" />
                                 </Style>
                             </GroupStyle.ContainerStyle>
                             <GroupStyle.Panel>
@@ -420,67 +483,17 @@
                     </DataGrid.GroupStyle>
 
                     <DataGrid.Columns>
-                        <DataGridTemplateColumn 
-                            IsReadOnly="True" >
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Image Source="{Binding SeverityLevel}" 
-                                           Width="12" 
-                                           Height="12"
-                                           Margin="9,1,8,1" >
-                                        <Image.ToolTip>
-                                            <ToolTip Content="{Binding SeverityTip}" 
-                                                     Style="{StaticResource CommonTooltipStyle}"/>
-                                        </Image.ToolTip>
-                                    </Image>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn
+                            IsReadOnly="True"
+                            CellTemplate="{StaticResource SeverityLevelColumnTemplate}"/>
 
                         <DataGridTemplateColumn
-                            IsReadOnly="True" 
-                            SortMemberPath="TimeStamp" >
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <TextBlock 
-                                        Text="{Binding Time}" 
-                                        TextWrapping="NoWrap"
-                                        TextTrimming="CharacterEllipsis" 
-                                        Margin="6,0,6,0">
-                                        <TextBlock.ToolTip>
-                                            <ToolTip Content="{Binding Date}" 
-                                                     Style="{StaticResource CommonTooltipStyle}" />
-                                        </TextBlock.ToolTip>
-                                    </TextBlock>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
+                            IsReadOnly="True"
+                            SortMemberPath="TimeStamp"
+                            CellTemplate="{StaticResource TimeColumnTemplate}" />
 
-                        <StaticResource ResourceKey="MessageColumn" />
+                        <DataGridTemplateColumn Width="*" CellTemplate="{StaticResource MessageColumnTemplate}" />
                     </DataGrid.Columns>
-
-                    <DataGrid.RowDetailsTemplate>
-                        <DataTemplate>
-                            <!-- Use a border to make the background right. -->
-                            <Border Background="White" Padding="30,0,0,2">
-
-                                <!-- Override the template to disable inner scrollbar -->
-                                <TreeView BorderThickness="0" 
-                                          ItemsSource="{Binding TreeViewObjects}">
-                                    <TreeView.Template>
-                                        <ControlTemplate>
-                                            <ItemsPresenter />
-                                        </ControlTemplate>
-                                    </TreeView.Template>
-                                    <TreeView.ItemContainerStyle>
-                                        <Style TargetType="{x:Type TreeViewItem}" >
-                                            <Setter Property="IsExpanded" Value="True" />
-                                        </Style>
-                                    </TreeView.ItemContainerStyle>
-                                </TreeView>
-                            </Border>
-                        </DataTemplate>
-                    </DataGrid.RowDetailsTemplate>
                 </DataGrid>
             </Grid>
 
@@ -496,7 +509,7 @@
                     MaxHeight="360" 
                     Foreground="Red" 
                     Text="{Binding RequestErrorMessage, Mode=OneWay}" 
-                    Visibility="{Binding ShowRequestErrorMessage, Converter={StaticResource visibilityConverter}}" 
+                    Visibility="{Binding ShowRequestErrorMessage, Converter={utils:VisibilityConverter}}" 
                     IsReadOnly="True"
                     VerticalScrollBarVisibility="Auto" />
 
@@ -504,9 +517,9 @@
                     Margin="0,0,0,12" 
                     Orientation="Horizontal" 
                     HorizontalAlignment="Center"
-                    Visibility="{Binding ShowRequestStatus, Converter={StaticResource visibilityConverter}}">
+                    Visibility="{Binding ShowRequestStatus, Converter={utils:VisibilityConverter}}">
 
-                    <TextBlock 
+                    <TextBlock
                         Padding="8,5,3,5" 
                         Text="{Binding RequestStatusText}"
                         Style="{StaticResource CommonTextStyle}" />
@@ -514,13 +527,13 @@
                     <controls:DotsProgressIndicator 
                         Padding="0,5,8,5" />
 
-                    <Button 
+                    <Button
                         Margin="12,0,12,0" 
                         VerticalAlignment="Center"
                         IsEnabled="True"
                         Content="{x:Static ext:Resources.UiCancelButtonCaption}" 
                         Command="{Binding CancelRequestCommand}" 
-                        Visibility="{Binding ShowCancelRequestButton, Converter={StaticResource visibilityConverter}}" 
+                        Visibility="{Binding ShowCancelRequestButton, Converter={utils:VisibilityConverter}}" 
                         Style="{StaticResource CommonButtonStandardStyle}" />
                 </StackPanel>
             </Grid>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindowControl.xaml.cs
@@ -14,9 +14,7 @@
 
 using GoogleCloudExtension.Utils;
 using System.Diagnostics;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 
 namespace GoogleCloudExtension.StackdriverLogsViewer
@@ -34,17 +32,16 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public LogsViewerToolWindowControl()
         {
             PackageUtils.ReferenceType(typeof(VisibilityConverter));
-            this.InitializeComponent();
+            InitializeComponent();
         }
 
         /// <summary>
         /// Response to data grid scroll change event.
         /// Auto load more logs when it scrolls down to bottom.
         /// </summary>
-        private void dataGrid_ScrollChanged(object sender, ScrollChangedEventArgs e)
+        private void DataGrid_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
-            var grid = sender as DataGrid;
-            ScrollViewer sv = e.OriginalSource as ScrollViewer;
+            var sv = e.OriginalSource as ScrollViewer;
             if (sv == null || !sv.IsMouseOver)
             {
                 return;
@@ -58,53 +55,14 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         }
 
         /// <summary>
-        /// When mouse clicks on source link text, execute the button command.
-        /// When mouse clicks on a row, toggle display the row detail.
-        /// If the mouse is clikcing on detail panel, does not collapse it.        
+        /// Implements the <see cref="ApplicationCommands.Copy"/> routed event on a details TreeView.
+        /// Executes the CopyCommand of the selected ObjectNodeTree item.
         /// </summary>
-        private void dataGrid_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        private void DetailsTreeView_OnCopy(object sender, ExecutedRoutedEventArgs e)
         {
-            var dependencyObj = e.OriginalSource as DependencyObject;
-            if (OriginFromSourceLink(e.OriginalSource))
-            {
-                e.Handled = true;
-                return;
-            }
-
-            DataGridRow row = DataGridUtils.FindAncestorControl<DataGridRow>(dependencyObj);
-            if (row != null)
-            {
-                if (null == DataGridUtils.FindAncestorControl<DataGridDetailsPresenter>(dependencyObj))
-                {
-                    row.DetailsVisibility =
-                        row.DetailsVisibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
-                }
-            }
-        }
-
-        /// <summary>
-        /// (1) When the button is clicked, skip toggling detail view action.
-        /// (2) Sometimes button does not respond to click event. This method fixes the problem.        
-        /// </summary>
-        private bool OriginFromSourceLink(object originalSource)
-        {
-            Debug.WriteLine($"Original source is {originalSource.ToString()}, type is {originalSource.GetType().Name}");
-            if (originalSource is TextBlock)
-            {
-                var textBlock = originalSource as TextBlock;
-                var button = DataGridUtils.FindAncestorControl<Controls.IconButton>(originalSource as DependencyObject);
-                if (button?.Name != "_sourceLinkButton")
-                {
-                    return false;
-                }
-                if (button.Command != null && button.Command.CanExecute(null))
-                {
-                    button.Command.Execute(null);
-                }
-                return true;
-            }
-
-            return false;
+            var detailsTreeView = sender as TreeView;
+            var treeNodeViewModel = detailsTreeView?.SelectedItem as ObjectNodeTree;
+            treeNodeViewModel?.CopyCommand.Execute(null);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeItemViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeItemViewModel.cs
@@ -29,7 +29,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
     /// </summary>
     public class ResourceTypeItemViewModel : MenuItemViewModel
     {
-        private readonly Lazy<LoggingDataSource> _dataSource;
+        private readonly Func<ILoggingDataSource> _dataSource;
 
         /// <summary>
         /// The <seealso cref="ResourceTypeKeys"/> object that this menu item represents.
@@ -48,7 +48,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// <param name="resourceKeys"><seealso cref="ResourceTypeKeys"/> object.</param>
         /// <param name="dataSource">The logging data source.</param>
         /// <param name="parent">The parent menu item view model object.</param>
-        public ResourceTypeItemViewModel(ResourceKeys resourceKeys, Lazy<LoggingDataSource> dataSource, MenuItemViewModel parent) : base(parent)
+        public ResourceTypeItemViewModel(ResourceKeys resourceKeys, Func<ILoggingDataSource> dataSource, MenuItemViewModel parent) : base(parent)
         {
             _dataSource = dataSource;
             ResourceTypeKeys = resourceKeys;
@@ -75,7 +75,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// </summary>
         protected override async Task LoadSubMenu()
         {
-            var values = await _dataSource.Value.ListResourceTypeValuesAsync(ResourceTypeKeys.Type);
+            var values = await _dataSource().ListResourceTypeValuesAsync(ResourceTypeKeys.Type);
             var trimedValues = values?.Select(x => x.Trim(new char[] { '/' })).Where(y => !String.IsNullOrWhiteSpace(y));
             if (trimedValues?.FirstOrDefault() == null)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeMenuViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeMenuViewModel.cs
@@ -103,10 +103,13 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 Enumerable.Empty<MonitoredResourceDescriptor>());
 
             _resourceKeys = await _dataSource().ListResourceKeysAsync();
-            var items = _resourceKeys?.Join(
-                newOrderDescriptors, keys => keys.Type, desc => desc.Type,
-                (keys, desc) => new ResourceTypeItemViewModel(keys, _dataSource, this) { Header = desc.DisplayName });
-            foreach (ResourceTypeItemViewModel item in items ?? Enumerable.Empty<ResourceTypeItemViewModel>())
+            var items =
+                from desc in newOrderDescriptors
+                join keys in _resourceKeys ?? Enumerable.Empty<ResourceKeys>()
+                    on desc.Type equals keys.Type
+                select new ResourceTypeItemViewModel(keys, _dataSource, this) { Header = desc.DisplayName };
+
+            foreach (ResourceTypeItemViewModel item in items)
             {
                 MenuItems.Add(item);
             }

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeMenuViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/SearchMenuItem/ResourceTypeMenuViewModel.cs
@@ -41,7 +41,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 ResourceTypeNameConsts.GlobalType
             };
 
-        private readonly Lazy<LoggingDataSource> _dataSource;
+        private readonly Func<ILoggingDataSource> _dataSource;
         private MenuItemViewModel _selectedMenuItem;
         private IList<ResourceKeys> _resourceKeys;
 
@@ -69,7 +69,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         /// Initializes an instance of <seealso cref="ResourceTypeMenuViewModel"/> class.
         /// </summary>
         /// <param name="dataSource">Logging data source.</param>
-        public ResourceTypeMenuViewModel(Lazy<LoggingDataSource> dataSource) : base(null)
+        public ResourceTypeMenuViewModel(Func<ILoggingDataSource> dataSource) : base(null)
         {
             IsSubmenuPopulated = false;
             _dataSource = dataSource;
@@ -86,7 +86,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                 return;
             }
 
-            var descriptors = await _dataSource.Value.GetResourceDescriptorsAsync();
+            var descriptors = await _dataSource().GetResourceDescriptorsAsync();
             var newOrderDescriptors = new List<MonitoredResourceDescriptor>();
             // Keep the order.
             foreach (var defaultSelection in s_defaultResourceSelections)
@@ -97,15 +97,20 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
                     newOrderDescriptors.Add(desc);
                 }
             }
-            newOrderDescriptors.AddRange(descriptors.Where(x => !s_defaultResourceSelections.Contains(x.Type)).OrderBy(x => x.DisplayName));
 
-            _resourceKeys = await _dataSource.Value.ListResourceKeysAsync();
-            var items =
-                from desc in newOrderDescriptors
-                join keys in _resourceKeys
-                    on desc.Type equals keys.Type
-                select new ResourceTypeItemViewModel(keys, _dataSource, this) { Header = desc.DisplayName };
-            items.ToList().ForEach(x => MenuItems.Add(x));
+            newOrderDescriptors.AddRange(
+                descriptors?.Where(x => !s_defaultResourceSelections.Contains(x.Type)).OrderBy(x => x.DisplayName) ??
+                Enumerable.Empty<MonitoredResourceDescriptor>());
+
+            _resourceKeys = await _dataSource().ListResourceKeysAsync();
+            var items = _resourceKeys?.Join(
+                newOrderDescriptors, keys => keys.Type, desc => desc.Type,
+                (keys, desc) => new ResourceTypeItemViewModel(keys, _dataSource, this) { Header = desc.DisplayName });
+            foreach (ResourceTypeItemViewModel item in items ?? Enumerable.Empty<ResourceTypeItemViewModel>())
+            {
+                MenuItems.Add(item);
+            }
+
             if (MenuItems.Count != 0)
             {
                 CommandBubblingHandler(MenuItems.FirstOrDefault());

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/TreeViewConverters/ObjectNodeTree.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/TreeViewConverters/ObjectNodeTree.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Google.Apis.Logging.v2.Data;
+using GoogleCloudExtension.Utils;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections;
@@ -20,6 +22,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Windows;
 
 namespace GoogleCloudExtension.StackdriverLogsViewer
 {
@@ -92,6 +95,11 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
         public ObjectNodeTree Parent { get; }
 
         /// <summary>
+        /// Copies the node to the clipboard.
+        /// </summary>
+        public ProtectedCommand CopyCommand { get; }
+
+        /// <summary>
         /// Create an instance of the <seealso cref="ObjectNodeTree"/> class.
         /// </summary>
         /// <param name="name">object name</param>
@@ -107,6 +115,7 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             }
 
             ParseObjectTree(obj);
+            CopyCommand = new ProtectedCommand(() => Clipboard.SetText(NodeValue ?? JsonConvert.SerializeObject(obj)));
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/Theming/CommonResources.xaml
@@ -606,13 +606,16 @@
         <Setter Property="MouseOverForeground" Value="#8A2BE2" />
     </Style>
 
+    <!-- Refer to these as DynamicResources to avoid breaking the designer. -->
+    <mp:ImageResource x:Key="PlayIconResource" Path="StackdriverErrorReporting/Resources/play_icon.png"/>
+    <mp:ImageResource x:Key="PauseIconResource" Path="StackdriverErrorReporting/Resources/pause_icon.png" />
     <!-- Style for auto reload button -->
     <Style x:Key="AutoReloadButtonStyle" 
            TargetType="{x:Type controls:AutoReloadButton}" 
            BasedOn="{StaticResource ImageToggleButtonStyle}">
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="UncheckedImage" Value="{mp:ImageResource StackdriverErrorReporting/Resources/play_icon.png}" />
-        <Setter Property="CheckedImage" Value="{mp:ImageResource StackdriverErrorReporting/Resources/pause_icon.png}" />
+        <Setter Property="UncheckedImage" Value="{DynamicResource PlayIconResource}" />
+        <Setter Property="CheckedImage" Value="{DynamicResource PauseIconResource}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Padding" Value="6" />

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -88,6 +88,9 @@
       <HintPath>..\packages\Google.Apis.Core.1.29.1\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Google.Apis.Logging.v2, Version=1.29.1.991, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Logging.v2.1.29.1.991\lib\net45\Google.Apis.Logging.v2.dll</HintPath>
+    </Reference>
     <Reference Include="Google.Apis.PlatformServices, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.1.29.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
@@ -254,6 +257,8 @@
     <Compile Include="PublishDialogSteps\GkeStep\GkeStepViewModelTests.cs" />
     <Compile Include="PublishDialog\PublishDialogStepBaseTests.cs" />
     <Compile Include="SplitStringBySpaceOrQuoteTests.cs" />
+    <Compile Include="StackdriverLogsViewer\LogsViewerViewModelTests.cs" />
+    <Compile Include="StackdriverLogsViewer\TreeViewConverters\ObjectNodeTreeTests.cs" />
     <Compile Include="StackframeParserTests.cs" />
     <Compile Include="SolutionUserOptionsTests.cs" />
     <Compile Include="StringFormatUtilsTests.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverLogsViewer/LogsViewerViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverLogsViewer/LogsViewerViewModelTests.cs
@@ -1,0 +1,253 @@
+﻿using Google.Apis.Logging.v2.Data;
+using Google.Apis.Logging.v2.Data.Extensions;
+using GoogleCloudExtension;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.DataSources;
+using GoogleCloudExtension.StackdriverLogsViewer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Process = System.Diagnostics.Process;
+using Project = Google.Apis.CloudResourceManager.v1.Data.Project;
+
+namespace GoogleCloudExtensionUnitTests.StackdriverLogsViewer
+{
+    [TestClass]
+    public class LogsViewerViewModelTests
+    {
+        private ILoggingDataSource _mockedLoggingDataSource;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            const string defaultAccountName = "default-account";
+            const string defaultProjectId = "default-project";
+            const string defaultProjectName = "default-project";
+            _mockedLoggingDataSource = Mock.Of<ILoggingDataSource>();
+            CredentialsStore.Default.UpdateCurrentAccount(new UserAccount { AccountName = defaultAccountName });
+            CredentialsStore.Default.UpdateCurrentProject(
+                new Project { Name = defaultProjectName, ProjectId = defaultProjectId });
+        }
+
+        [TestMethod]
+        public void TestInitalConditions()
+        {
+            const string testAccountName = "test-account";
+            const string testProjectName = "test-project";
+            const string testProjectId = "test-project";
+            CredentialsStore.Default.UpdateCurrentAccount(new UserAccount { AccountName = testAccountName });
+            CredentialsStore.Default.UpdateCurrentProject(
+                new Project { Name = testProjectName, ProjectId = testProjectId });
+            var objectUnderTest = new LogsViewerViewModel(_mockedLoggingDataSource);
+
+            Assert.IsNull(objectUnderTest.LogIdList);
+            Assert.IsNotNull(objectUnderTest.DateTimePickerModel);
+            Assert.IsTrue(objectUnderTest.AdvancedFilterHelpCommand.CanExecuteCommand);
+            Assert.IsTrue(objectUnderTest.SubmitAdvancedFilterCommand.CanExecuteCommand);
+            Assert.IsTrue(objectUnderTest.SimpleTextSearchCommand.CanExecuteCommand);
+            Assert.IsTrue(objectUnderTest.FilterSwitchCommand.CanExecuteCommand);
+            Assert.IsTrue(objectUnderTest.OnDetailTreeNodeFilterCommand.CanExecuteCommand);
+            Assert.IsNull(objectUnderTest.AdvancedFilterText);
+            Assert.IsFalse(objectUnderTest.ShowAdvancedFilter);
+            Assert.IsNull(objectUnderTest.SimpleSearchText);
+            Assert.AreEqual(7, objectUnderTest.LogSeverityList.Count);
+            Assert.IsNotNull(objectUnderTest.ResourceTypeSelector);
+            Assert.AreEqual(LogSeverity.All, objectUnderTest.SelectedLogSeverity.Severity);
+            Assert.AreEqual(TimeZoneInfo.GetSystemTimeZones(), objectUnderTest.SystemTimeZones);
+            Assert.AreEqual(TimeZoneInfo.Local, objectUnderTest.SelectedTimeZone);
+            Assert.IsTrue(objectUnderTest.RefreshCommand.CanExecuteCommand);
+            Assert.AreEqual(testAccountName, objectUnderTest.Account);
+            Assert.AreEqual(testProjectName, objectUnderTest.Project);
+            Assert.IsFalse(objectUnderTest.ToggleExpandAllExpanded);
+            Assert.AreEqual(Resources.LogViewerExpandAllTip, objectUnderTest.ToggleExapandAllToolTip);
+            Assert.IsNotNull(objectUnderTest.LogItemCollection);
+            Assert.IsTrue(objectUnderTest.CancelRequestCommand.CanExecuteCommand);
+            Assert.IsFalse(objectUnderTest.ShowCancelRequestButton);
+            Assert.IsFalse(objectUnderTest.ShowRequestErrorMessage);
+            Assert.IsNull(objectUnderTest.RequestErrorMessage);
+            Assert.IsNull(objectUnderTest.RequestStatusText);
+            Assert.IsFalse(objectUnderTest.ShowRequestStatus);
+            Assert.IsTrue(objectUnderTest.IsControlEnabled);
+            Assert.IsTrue(objectUnderTest.OnAutoReloadCommand.CanExecuteCommand);
+            Assert.IsFalse(objectUnderTest.IsAutoReloadChecked);
+            Assert.AreEqual((uint)3, objectUnderTest.AutoReloadIntervalSeconds);
+        }
+
+        [TestMethod]
+        public void TestToggleExpandAll()
+        {
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+
+            objectUnderTests.ToggleExpandAllExpanded = true;
+
+            Assert.IsTrue(objectUnderTests.ToggleExpandAllExpanded);
+            Assert.AreEqual(Resources.LogViewerCollapseAllTip, objectUnderTests.ToggleExapandAllToolTip);
+        }
+
+        [TestMethod]
+        public void TestToggleCollapseAll()
+        {
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+            objectUnderTests.ToggleExpandAllExpanded = true;
+
+            objectUnderTests.ToggleExpandAllExpanded = false;
+
+            Assert.IsFalse(objectUnderTests.ToggleExpandAllExpanded);
+            Assert.AreEqual(Resources.LogViewerExpandAllTip, objectUnderTests.ToggleExapandAllToolTip);
+        }
+
+        [TestMethod]
+        public void TestSimplePageLoading()
+        {
+            Mock<ILoggingDataSource> dataSourceMock = Mock.Get(_mockedLoggingDataSource);
+            dataSourceMock.Setup(ds => ds.GetResourceDescriptorsAsync())
+                .Returns(
+                    Task.FromResult<IList<MonitoredResourceDescriptor>>(
+                        new List<MonitoredResourceDescriptor>
+                        {
+                            new MonitoredResourceDescriptor {Type = ResourceTypeNameConsts.GlobalType}
+                        }));
+            dataSourceMock.Setup(ds => ds.ListResourceKeysAsync())
+                .Returns(
+                    Task.FromResult<IList<ResourceKeys>>(
+                        new List<ResourceKeys> { new ResourceKeys { Type = ResourceTypeNameConsts.GlobalType } }));
+            dataSourceMock
+                .Setup(
+                    ds => ds.ListProjectLogNamesAsync(
+                        ResourceTypeNameConsts.GlobalType, It.IsAny<IEnumerable<string>>()))
+                .Returns(Task.FromResult<IList<string>>(new[] { "log-id" }));
+            var tcs = new TaskCompletionSource<LogEntryRequestResult>();
+            dataSourceMock.Setup(
+                ds => ds.ListLogEntriesAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+
+            objectUnderTests.SimpleTextSearchCommand.Execute(null);
+            objectUnderTests.SimpleTextSearchCommand.Execute(null);
+
+            Assert.IsFalse(objectUnderTests.IsControlEnabled);
+            Assert.IsNull(objectUnderTests.RequestErrorMessage);
+            Assert.IsFalse(objectUnderTests.ShowRequestErrorMessage);
+            Assert.AreEqual(Resources.LogViewerRequestProgressMessage, objectUnderTests.RequestStatusText);
+            Assert.IsTrue(objectUnderTests.ShowRequestStatus);
+            Assert.IsTrue(objectUnderTests.ShowCancelRequestButton);
+        }
+
+        [TestMethod]
+        public void TestAdvancedPageLoading()
+        {
+            Mock<ILoggingDataSource> dataSourceMock = Mock.Get(_mockedLoggingDataSource);
+            dataSourceMock.Setup(ds => ds.GetResourceDescriptorsAsync())
+                .Returns(
+                    Task.FromResult<IList<MonitoredResourceDescriptor>>(
+                        new List<MonitoredResourceDescriptor>
+                        {
+                            new MonitoredResourceDescriptor {Type = ResourceTypeNameConsts.GlobalType}
+                        }));
+            dataSourceMock.Setup(ds => ds.ListResourceKeysAsync())
+                .Returns(
+                    Task.FromResult<IList<ResourceKeys>>(
+                        new List<ResourceKeys> { new ResourceKeys { Type = ResourceTypeNameConsts.GlobalType } }));
+            dataSourceMock
+                .Setup(
+                    ds => ds.ListProjectLogNamesAsync(
+                        ResourceTypeNameConsts.GlobalType, It.IsAny<IEnumerable<string>>()))
+                .Returns(Task.FromResult<IList<string>>(new[] { "log-id" }));
+            var tcs = new TaskCompletionSource<LogEntryRequestResult>();
+            dataSourceMock.Setup(
+                ds => ds.ListLogEntriesAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+
+            objectUnderTests.SubmitAdvancedFilterCommand.Execute(null);
+            objectUnderTests.SubmitAdvancedFilterCommand.Execute(null);
+
+            Assert.IsFalse(objectUnderTests.IsControlEnabled);
+            Assert.IsNull(objectUnderTests.RequestErrorMessage);
+            Assert.IsFalse(objectUnderTests.ShowRequestErrorMessage);
+            Assert.AreEqual(Resources.LogViewerRequestProgressMessage, objectUnderTests.RequestStatusText);
+            Assert.IsTrue(objectUnderTests.ShowRequestStatus);
+            Assert.IsTrue(objectUnderTests.ShowCancelRequestButton);
+        }
+
+        [TestMethod]
+        public void TestShowAdvancedFilterHelp()
+        {
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+            objectUnderTests.StartProcess = Mock.Of<Func<string, Process>>();
+
+            objectUnderTests.AdvancedFilterHelpCommand.Execute(null);
+
+            Mock.Get(objectUnderTests.StartProcess).Verify(f => f(LogsViewerViewModel.AdvancedHelpLink));
+        }
+
+        [TestMethod]
+        public void TestSetAdvancedFilterText()
+        {
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+
+            const string testFilterText = "filter text";
+            objectUnderTests.AdvancedFilterText = testFilterText;
+
+            Assert.AreEqual(testFilterText, objectUnderTests.AdvancedFilterText);
+        }
+
+        [TestMethod]
+        public void TestSwapFilter()
+        {
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+            var tcs = new TaskCompletionSource<IList<MonitoredResourceDescriptor>>();
+            Mock<ILoggingDataSource> dataSourceMock = Mock.Get(_mockedLoggingDataSource);
+            dataSourceMock.Setup(ds => ds.GetResourceDescriptorsAsync())
+                .Returns(tcs.Task);
+
+            objectUnderTests.FilterSwitchCommand.Execute(null);
+
+            Assert.IsTrue(objectUnderTests.ShowAdvancedFilter);
+        }
+
+        [TestMethod]
+        public void TestFilterLog()
+        {
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+            var tcs = new TaskCompletionSource<IList<MonitoredResourceDescriptor>>();
+            Mock<ILoggingDataSource> dataSourceMock = Mock.Get(_mockedLoggingDataSource);
+            dataSourceMock.Setup(ds => ds.GetResourceDescriptorsAsync())
+                .Returns(tcs.Task);
+
+            const string testFilterText = "test filter";
+            objectUnderTests.FilterLog(testFilterText);
+
+            Assert.IsFalse(objectUnderTests.IsAutoReloadChecked);
+            Assert.IsTrue(objectUnderTests.ShowAdvancedFilter);
+            Assert.IsTrue(objectUnderTests.AdvancedFilterText.StartsWith(testFilterText, StringComparison.Ordinal));
+        }
+
+        [TestMethod]
+        public void TestFilterTreeNode()
+        {
+            const string testNodeName = "test-node";
+            const string testNodeValue = "test-value";
+            var objectUnderTests = new LogsViewerViewModel(_mockedLoggingDataSource);
+            var tcs = new TaskCompletionSource<IList<MonitoredResourceDescriptor>>();
+            Mock<ILoggingDataSource> dataSourceMock = Mock.Get(_mockedLoggingDataSource);
+            dataSourceMock.Setup(ds => ds.GetResourceDescriptorsAsync())
+                .Returns(tcs.Task);
+
+            var treeNode = new ObjectNodeTree(testNodeName, testNodeValue, null);
+            objectUnderTests.OnDetailTreeNodeFilterCommand.Execute(treeNode);
+
+            Assert.IsFalse(objectUnderTests.IsAutoReloadChecked);
+            Assert.IsTrue(objectUnderTests.ShowAdvancedFilter);
+            Assert.IsTrue(objectUnderTests.AdvancedFilterText.Contains(testNodeName));
+            Assert.IsTrue(objectUnderTests.AdvancedFilterText.Contains(testNodeValue));
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverLogsViewer/TreeViewConverters/ObjectNodeTreeTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverLogsViewer/TreeViewConverters/ObjectNodeTreeTests.cs
@@ -1,0 +1,168 @@
+﻿using Google.Apis.Logging.v2.Data;
+using GoogleCloudExtension.StackdriverLogsViewer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace GoogleCloudExtensionUnitTests.StackdriverLogsViewer.TreeViewConverters
+{
+    /// <summary>
+    /// Summary description for ObjectNodeTreeTests
+    /// </summary>
+    [TestClass]
+    public class ObjectNodeTreeTests
+    {
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            Clipboard.Clear();
+        }
+
+        [TestMethod]
+        public void TestStringValueInitialConditions()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeName = "test name :";
+            const string nodeValue = "test value";
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            Assert.AreEqual(expectedNodeName, objectUnderTest.Name);
+            Assert.AreEqual(nodeValue, objectUnderTest.NodeValue);
+            Assert.IsNull(objectUnderTest.Parent);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.AreEqual(nodeValue, objectUnderTest.FilterValue);
+            CollectionAssert.AreEqual(new ObjectNodeTree[0], objectUnderTest.Children);
+        }
+
+        [TestMethod]
+        public void TestNullValueInitialConditions()
+        {
+            const string nodeName = "test name";
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, null, null);
+
+            Assert.AreEqual(nodeName, objectUnderTest.Name);
+            Assert.IsNull(objectUnderTest.NodeValue);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.IsNull(objectUnderTest.FilterValue);
+            CollectionAssert.AreEqual(new ObjectNodeTree[0], objectUnderTest.Children);
+        }
+
+        [TestMethod]
+        public void TestNumberValueInitialConditions()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeName = "test name :";
+            const ushort nodeValue = 3;
+            const string expectedNodeValue = "3";
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            Assert.AreEqual(expectedNodeName, objectUnderTest.Name);
+            Assert.AreEqual(expectedNodeValue, objectUnderTest.NodeValue);
+            Assert.IsNull(objectUnderTest.Parent);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.AreEqual(expectedNodeValue, objectUnderTest.FilterValue);
+            CollectionAssert.AreEqual(new ObjectNodeTree[0], objectUnderTest.Children);
+        }
+
+        [TestMethod]
+        public void TestDateTimeValueInitialConditions()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeName = "test name :";
+            const string expectedNodeValue = "12-13-1999 00:00:00.000";
+            const string expectedNodeFilterValue = "1999-12-13T08:00:00.0000000Z";
+            var nodeValue = new DateTime(1999, 12, 13);
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            Assert.AreEqual(expectedNodeName, objectUnderTest.Name);
+            Assert.AreEqual(expectedNodeValue, objectUnderTest.NodeValue);
+            Assert.IsNull(objectUnderTest.Parent);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.AreEqual(expectedNodeFilterValue, objectUnderTest.FilterValue);
+            CollectionAssert.AreEqual(new ObjectNodeTree[0], objectUnderTest.Children);
+        }
+
+        [TestMethod]
+        public void TestArrayValueInitialConditions()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeName = "test name";
+            var nodeValue = new[] { "a", "b", "c" };
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            Assert.AreEqual(expectedNodeName, objectUnderTest.Name);
+            Assert.IsNull(objectUnderTest.NodeValue);
+            Assert.IsNull(objectUnderTest.Parent);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.IsNull(objectUnderTest.FilterValue);
+            Assert.AreEqual(3, objectUnderTest.Children.Count);
+        }
+
+        [TestMethod]
+        public void TestDictionaryValueInitialConditions()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeName = "test name";
+            var nodeValue = new Dictionary<string, string> { { "a", "1" }, { "b", "2" }, { "c", "3" } };
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            Assert.AreEqual(expectedNodeName, objectUnderTest.Name);
+            Assert.IsNull(objectUnderTest.NodeValue);
+            Assert.IsNull(objectUnderTest.Parent);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.IsNull(objectUnderTest.FilterValue);
+            Assert.AreEqual(3, objectUnderTest.Children.Count);
+        }
+
+        [TestMethod]
+        public void TestMonitoredResourceValueInitialConditions()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeName = "test name";
+            var nodeValue =
+                new MonitoredResource { Labels = new Dictionary<string, string> { { "a", "1" } }, Type = "test type" };
+
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            Assert.AreEqual(expectedNodeName, objectUnderTest.Name);
+            Assert.IsNull(objectUnderTest.NodeValue);
+            Assert.IsNull(objectUnderTest.Parent);
+            Assert.AreEqual(nodeName, objectUnderTest.FilterLabel);
+            Assert.IsNull(objectUnderTest.FilterValue);
+            Assert.AreEqual(2, objectUnderTest.Children.Count);
+        }
+
+        [TestMethod]
+        public void TestCopyLeafToClipboard()
+        {
+            const string nodeName = "test name";
+            const ushort nodeValue = 3;
+            const string expectedNodeClipboard = "3";
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            objectUnderTest.CopyCommand.Execute(null);
+
+            Assert.AreEqual(expectedNodeClipboard, Clipboard.GetText());
+        }
+
+        [TestMethod]
+        public void TestCopyBranchToClipboard()
+        {
+            const string nodeName = "test name";
+            const string expectedNodeClipboard = "[\"a\",\"b\",\"c\"]";
+            var nodeValue = new[] { "a", "b", "c" };
+            var objectUnderTest = new ObjectNodeTree(nodeName, nodeValue, null);
+
+            objectUnderTest.CopyCommand.Execute(null);
+
+            Assert.AreEqual(expectedNodeClipboard, Clipboard.GetText());
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/packages.config
@@ -9,6 +9,7 @@
   <package id="Google.Apis.Compute.v1" version="1.29.1.981" targetFramework="net452" />
   <package id="Google.Apis.Container.v1" version="1.29.1.981" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.29.1" targetFramework="net452" />
+  <package id="Google.Apis.Logging.v2" version="1.29.1.991" targetFramework="net452" />
   <package id="Google.Apis.Pubsub.v1" version="1.29.1.971" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Imaging" version="14.3.25407" targetFramework="net452" />


### PR DESCRIPTION
* Replace Logs viewer text blocks with uneditable text boxes that look like text blocks when not focused.
* Add `Copy` popup menu item and ctrl+c handler to log tree details.
* Fixes #872.