### PR TITLE
Fixing #895. Just adding a null check before accessing ProjectHelper.ParsedProject

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GenerateConfigurationCommand/GenerateConfigurationContextMenuCommand.cs
@@ -160,7 +160,7 @@ namespace GoogleCloudExtension.GenerateConfigurationCommand
             }
 
             // Ensure that the menu entry is only available for ASP.NET Core projects.
-            var selectedProject = SolutionHelper.CurrentSolution.SelectedProject.ParsedProject;
+            var selectedProject = SolutionHelper.CurrentSolution.SelectedProject?.ParsedProject;
             if (selectedProject == null || !selectedProject.IsAspNetCoreProject())
             {
                 menuCommand.Visible = false;

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishProjectContextMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishProjectContextMenuCommand.cs
@@ -115,7 +115,7 @@ namespace GoogleCloudExtension.PublishDialog
                 return;
             }
 
-            var selectedProject = SolutionHelper.CurrentSolution.SelectedProject.ParsedProject;
+            var selectedProject = SolutionHelper.CurrentSolution.SelectedProject?.ParsedProject;
             if (selectedProject == null || !PublishDialogWindow.CanPublish(selectedProject))
             {
                 menuCommand.Visible = false;

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishProjectMainMenuCommand.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishProjectMainMenuCommand.cs
@@ -118,7 +118,7 @@ namespace GoogleCloudExtension.PublishDialog
 
             menuCommand.Visible = true;
 
-            var startupProject = SolutionHelper.CurrentSolution.StartupProject.ParsedProject;
+            var startupProject = SolutionHelper.CurrentSolution.StartupProject?.ParsedProject;
             if (startupProject == null)
             {
                 menuCommand.Enabled = false;


### PR DESCRIPTION
Quick PR so as to avoid this bug interfering with everyone else's work. Will add tests at a later PR.