### PR TITLE
Improving diagnostics info we get, specially when vstest crashes.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ build_script:
 artifacts:
   - path: GoogleCloudExtension\GoogleCloudExtension\bin\Release\GoogleCloudExtension.vsix
   - path: GoogleCloudExtension\GoogleCloudExtension\bin\Debug\GoogleCloudExtension.vsix
+  - path: logs
 
 # Run the analytics tests with code coverage report.
 test_script:


### PR DESCRIPTION
Working towards #906.

- Configuring tests to run in isolation, we get more diagnostics info that way.

- Pushing dump files (and pdbs and dlls) as artifacts when vstest crashes for better diagnostics info.