### PR TITLE
Only pushing the crash dump files when vstest actually crashes.

### DIFF
--- a/TestScript.ps1
+++ b/TestScript.ps1
@@ -40,10 +40,14 @@ OpenCover.Console.exe -register:user -target:vstest.console.exe -targetargs:$tes
 
 if ($LASTEXITCODE) {
     Get-ChildItem logs -Include *.txt -Force -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-	Get-ChildItem -Path C:/Users/appveyor/AppData/Local/CrashDumps -Force | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-	# Add the .pdbs and .dlls when it crashes so as to be able to debug the .dmp properly.
-	Get-ChildItem -Path C:/projects/google-cloud-visualstudio/TestResults/Deploy_appveyor*/Out *.dll -Force -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-	Get-ChildItem -Path C:/projects/google-cloud-visualstudio/TestResults/Deploy_appveyor*/Out *.pdb -Force -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+	# Only if vstest crashed push the dumps and symbols files.
+	# $LASTEXITCODE is 1 when tests fail, but that doesn't mean that vstest crashed.
+	if (Test-Path -Path C:/Users/appveyor/AppData/Local/CrashDumps){
+		Get-ChildItem -Path C:/Users/appveyor/AppData/Local/CrashDumps -Force | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+		# Add the .pdbs and .dlls when it crashes so as to be able to debug the .dmp properly.
+		Get-ChildItem -Path C:/projects/google-cloud-visualstudio/TestResults/Deploy_appveyor*/Out *.dll -Force -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+		Get-ChildItem -Path C:/projects/google-cloud-visualstudio/TestResults/Deploy_appveyor*/Out *.pdb -Force -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+	}
     throw "Test failed with code $LASTEXITCODE"
 }
 Write-Host "Finished code coverage."


### PR DESCRIPTION
Exit code is 1 when tests fail but that doesn't neccesarily means that vstest crashed.
Towards solving #906 