### PR TITLE
Deactivating flaky test.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
@@ -53,7 +53,7 @@ namespace GoogleCloudExtensionUnitTests.GcsFileProgressDialog
             });
         }
 
-        [TestMethod]
+        [TestMethod, TestCategory("OFF")]
         public async Task TestBindingsLoadCorrectly()
         {
             var objectUnderTest = new GcsFileProgressDialogWindow(

--- a/TestScript.ps1
+++ b/TestScript.ps1
@@ -18,10 +18,10 @@ $testDlls = ls -r -include $testDllNames | ? FullName -Like *\bin\$Configuration
 
 $testContainerArgs = $testDlls.FullName -join " "
 
+$testArgs = "$testContainerArgs /inisolation /diag:logs\log.txt /TestCaseFilter:`"TestCategory=OFF`""
+
 if ($env:APPVEYOR) {
-    $testArgs = $testArgs = "$testContainerArgs /logger:Appveyor /inisolation /diag:logs\log.txt"
-} else {
-    $testArgs = $testContainerArgs
+    $testArgs = "$testArgs /logger:Appveyor"
 }
 
 $testFilters = ($testDlls.BaseName | % { "-[$_]*"}) -join " "

--- a/TestScript.ps1
+++ b/TestScript.ps1
@@ -18,7 +18,7 @@ $testDlls = ls -r -include $testDllNames | ? FullName -Like *\bin\$Configuration
 
 $testContainerArgs = $testDlls.FullName -join " "
 
-$testArgs = "$testContainerArgs /inisolation /diag:logs\log.txt /TestCaseFilter:`"TestCategory=OFF`""
+$testArgs = "$testContainerArgs /inisolation /diag:logs\log.txt /TestCaseFilter:`"TestCategory!=OFF`""
 
 if ($env:APPVEYOR) {
     $testArgs = "$testArgs /logger:Appveyor"


### PR DESCRIPTION
Adding OFF Test Category to the test that is provoking #906.
Excluding OFF Test category from Appveyor execution.
For excluding this test on VisualStudio, group test by traits on the Test Explorer window and execute the ones that are not "OFF".
