### PR TITLE
Update version of BundlerMinifier.Core.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeList.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/GkeList.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 namespace GoogleCloudExtension.GCloud.Models
 {
     /// <summary>
-    /// Common class for all of the lists returned from Kuberentes.
+    /// Common class for all of the lists returned from Kubernetes.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public class GkeList<T>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.0.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.0.csproj
@@ -28,7 +28,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />
   </ItemGroup>
 
 </Project>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.1.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/1.1.csproj
@@ -28,7 +28,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />
   </ItemGroup>
 
 </Project>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/2.0.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/2.0.csproj
@@ -25,7 +25,7 @@
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.2.301" />
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />
   </ItemGroup>
 
 </Project>

--- a/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/project.json
+++ b/GoogleCloudExtension/ProjectTemplates/GcpProjectTemplate/Core/MVC/project.json
@@ -22,7 +22,7 @@
   },
 
   "tools": {
-    "BundlerMinifier.Core": "2.0.238",
+    "BundlerMinifier.Core": "2.6.362",
     "Microsoft.AspNetCore.Razor.Tools": "1.0.0-preview4-final",
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
   },


### PR DESCRIPTION
BundlerMinifier.Core version 2.2.301 had a dependency on .NET Core 1.0. Updating lets it run on .NET Core 2.0.
Fixes #850.