### PR TITLE
Fix the flakiness of GcsFileProgressDialogWindowTest.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/AssemblyInitialize.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/AssemblyInitialize.cs
@@ -16,6 +16,7 @@ using GoogleCloudExtension;
 using GoogleCloudExtension.Analytics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace GoogleCloudExtensionUnitTests
 {
@@ -39,6 +40,8 @@ namespace GoogleCloudExtensionUnitTests
         {
             GoogleCloudExtensionPackage.Instance = s_packageToRestore;
             Application.Current.Shutdown();
+            Dispatcher.CurrentDispatcher.InvokeShutdown();
+
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GcsFileProgressDialog/GcsFileProgressDialogWindowTest.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace GoogleCloudExtensionUnitTests.GcsFileProgressDialog
 {
@@ -63,16 +64,20 @@ namespace GoogleCloudExtensionUnitTests.GcsFileProgressDialog
         public async Task TestBindingsLoadCorrectly()
         {
             var tcs = new TaskCompletionSource<bool>();
-            var objectUnderTest = new GcsFileProgressDialogWindow(
-                "test-caption", "test-message", "test-progress-message", new GcsOperation[0],
-                new CancellationTokenSource());
-            objectUnderTest.SourceInitialized += (sender, args) =>
-            {
-                objectUnderTest.Close();
-                tcs.SetResult(true);
-            };
+            Dispatcher.CurrentDispatcher.Invoke(
+                () =>
+                {
+                    var objectUnderTest = new GcsFileProgressDialogWindow(
+                        "test-caption", "test-message", "test-progress-message", new GcsOperation[0],
+                        new CancellationTokenSource());
+                    objectUnderTest.SourceInitialized += (sender, args) =>
+                    {
+                        objectUnderTest.Close();
+                        tcs.SetResult(true);
+                    };
 
-            objectUnderTest.ShowModal();
+                    objectUnderTest.ShowModal();
+                });
             await tcs.Task;
         }
     }


### PR DESCRIPTION
GcsFileProgressDialogWindowTest.TestBindingsLoadCorrectly can be flaky, crashing vstest.executionengine.x86.exe. 

[Example of the error](https://ci.appveyor.com/project/ILMTitan/google-cloud-visualstudio/build/1.0.219-more-tests#L3969)

This looks similar to [this vstest github issue](https://github.com/Microsoft/vstest/issues/1437) and [this msdn forum issue](https://social.msdn.microsoft.com/Forums/en-us/bb990ddb-ecde-4161-8915-e66e913e3a3b/invalidoperationexception-localdatastoreslot-storage-has-been-freed?forum=exceldev). This PR implements the solutions from both of them.
