### PR TITLE
Copyable command when component missing in k8s publishing.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindow.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension.Theming;
+
+namespace GoogleCloudExtension.CopyablePrompt
+{
+    public class CopyablePromptDialogWindow : CommonDialogWindowBase
+    {
+        private CopyablePromptDialogWindow(string title, string text, string copyableText) : base(title)
+        {
+            var viewModel = new CopyablePromptDialogWindowViewModel(text, copyableText);
+            Content = new CopyablePromptDialogWindowContent
+            {
+                DataContext = viewModel,
+            };
+        }
+
+        public static void PromptUser(string title, string message, string copyableText)
+        {
+            var window = new CopyablePromptDialogWindow(title, message, copyableText);
+            window.ShowModal();
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowContent.xaml
@@ -1,0 +1,45 @@
+﻿<UserControl x:Class="GoogleCloudExtension.CopyablePrompt.CopyablePromptDialogWindowContent"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:GoogleCloudExtension.CopyablePrompt"
+             xmlns:controls="clr-namespace:GoogleCloudExtension.Controls"
+             xmlns:theming="clr-namespace:GoogleCloudExtension.Theming"
+             xmlns:ext="clr-namespace:GoogleCloudExtension"
+             xmlns:mp="clr-namespace:GoogleCloudExtension.Extensions;assembly=GoogleCloudExtension"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance {x:Type local:CopyablePromptDialogWindowContent}}">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Theming/CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Style>
+        <Binding Source="{StaticResource CommonDialogStyleDynamicSmall}" />
+    </UserControl.Style>
+
+    <theming:CommonDialogWindowBaseContent>
+        <theming:CommonDialogWindowBaseContent.Buttons>
+            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiOkButtonCaption}" IsDefault="True" IsCancel="True"/>
+        </theming:CommonDialogWindowBaseContent.Buttons>
+
+        <StackPanel>
+            <TextBlock Text="{Binding Message}" TextWrapping="Wrap" Style="{StaticResource CommonTextStyle}"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="{Binding CopyableText}" TextWrapping="Wrap" Style="{StaticResource CommonTextStyle}" />
+                <controls:IconButton
+                    Margin="5,0,0,0"
+                    Command="{Binding CopyCommand}"
+                    NormalIcon="{mp:ImageResource Theming/Resources/ic_copy_black_14px.png}"
+                    MouseOverIcon="{mp:ImageResource Theming/Resources/ic_copy_blue_14px.png}"
+                    ToolTip="{x:Static ext:Resources.UiCopyMenuHeader}"/>
+            </StackPanel>
+        </StackPanel>
+    </theming:CommonDialogWindowBaseContent>
+
+</UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowContent.xaml
@@ -31,7 +31,13 @@
         <StackPanel>
             <TextBlock Text="{Binding Message}" TextWrapping="Wrap" Style="{StaticResource CommonTextStyle}"/>
             <StackPanel Orientation="Horizontal">
-                <TextBlock Text="{Binding CopyableText}" TextWrapping="Wrap" Style="{StaticResource CommonTextStyle}" />
+                <TextBox 
+                    Text="{Binding CopyableText, Mode=OneTime}" 
+                    IsReadOnly="True" 
+                    TextWrapping="Wrap" 
+                    BorderThickness="0" 
+                    Background="Transparent"
+                    Style="{StaticResource CommonTextBoxStyle}" />
                 <controls:IconButton
                     Margin="5,0,0,0"
                     Command="{Binding CopyCommand}"

--- a/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowContent.xaml.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowContent.xaml.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Windows.Controls;
+
+namespace GoogleCloudExtension.CopyablePrompt
+{
+    /// <summary>
+    /// Interaction logic for CopyablePromptDialogWindowContent.xaml
+    /// </summary>
+    public partial class CopyablePromptDialogWindowContent : UserControl
+    {
+        public CopyablePromptDialogWindowContent()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CopyablePrompt/CopyablePromptDialogWindowViewModel.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension.Utils;
+using System.Windows;
+using System.Windows.Input;
+
+namespace GoogleCloudExtension.CopyablePrompt
+{
+    public class CopyablePromptDialogWindowViewModel : ViewModelBase
+    {
+        public string Message { get; }
+
+        public string CopyableText { get; }
+
+        public ICommand CopyCommand { get; }
+
+        public CopyablePromptDialogWindowViewModel(string message, string copyableText)
+        {
+            Message = message;
+            CopyableText = copyableText;
+            CopyCommand = new ProtectedCommand(OnCopyCommand);
+        }
+
+        private void OnCopyCommand()
+        {
+            Clipboard.SetText(CopyableText);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -213,6 +213,11 @@
     <Compile Include="CloudExplorer\SampleData\SampleDataBase.cs" />
     <Compile Include="CloudExplorer\SampleData\WithDataState.cs" />
     <Compile Include="CloudExplorer\Options\ICloudExplorerOptions.cs" />
+    <Compile Include="CopyablePrompt\CopyablePromptDialogWindow.cs" />
+    <Compile Include="CopyablePrompt\CopyablePromptDialogWindowContent.xaml.cs">
+      <DependentUpon>CopyablePromptDialogWindowContent.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="CopyablePrompt\CopyablePromptDialogWindowViewModel.cs" />
     <Compile Include="IGoogleCloudExtensionPackage.cs" />
     <Compile Include="StackdriverLogsViewer\ILogsViewerViewModel.cs" />
     <Compile Include="TemplateWizards\Dialogs\TemplateChooserDialog\AppTypeSelectorControl.xaml.cs">
@@ -1047,6 +1052,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Controls\ProgressIndicator.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="CopyablePrompt\CopyablePromptDialogWindowContent.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -3409,11 +3409,20 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To use this feature you need to have the &quot;{0}&quot; component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install {0}..
+        ///   Looks up a localized string similar to To use this feature you need to have the &quot;{0}&quot; component of the Google Cloud SDK installed. Please do so by running the command:.
         /// </summary>
         public static string GcloudMissingComponentErrorMessage {
             get {
                 return ResourceManager.GetString("GcloudMissingComponentErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to gcloud components install {0}.
+        /// </summary>
+        public static string GcloudMissingComponentInstallCommand {
+            get {
+                return ResourceManager.GetString("GcloudMissingComponentInstallCommand", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2012,7 +2012,7 @@
     <comment>Caption for the install link.</comment>
   </data>
   <data name="GcloudMissingComponentErrorMessage" xml:space="preserve">
-    <value>To use this feature you need to have the "{0}" component of the Google Cloud SDK installed. Please do so by running the command: gcloud components install {0}.</value>
+    <value>To use this feature you need to have the "{0}" component of the Google Cloud SDK installed. Please do so by running the command:</value>
     <comment>Message shown when the a component is not installed. {0} is the name of the component.</comment>
   </data>
   <data name="GcloudMissingCloudSdkErrorMessage" xml:space="preserve">
@@ -2989,5 +2989,9 @@
   <data name="UiCopyMenuHeader" xml:space="preserve">
     <value>Copy</value>
     <comment>Header for a standard "Copy" menu item.</comment>
+  </data>
+  <data name="GcloudMissingComponentInstallCommand" xml:space="preserve">
+    <value>gcloud components install {0}</value>
+    <comment>Command to install a missing component. {0} is the name of the component and should be in lower case.</comment>
   </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CopyablePrompt/CopyablePromptDialogWindowViewModelTest.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/CopyablePrompt/CopyablePromptDialogWindowViewModelTest.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension.CopyablePrompt;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Windows;
+
+namespace GoogleCloudExtensionUnitTests.CopyablePrompt
+{
+    [TestClass]
+    public class CopyablePromptDialogWindowViewModelTest
+    {
+        private const string Message = "Message that cannot be copied";
+        private const string CopyableText = "Text that can be copied";
+
+        [TestMethod]
+        public void TestConstructor()
+        {
+            var objectUnderTest = new CopyablePromptDialogWindowViewModel(Message, CopyableText);
+
+            Assert.AreEqual(Message, objectUnderTest.Message);
+            Assert.AreEqual(CopyableText, objectUnderTest.CopyableText);
+        }
+
+        [TestMethod]
+        public void TestCopyCommand()
+        {
+            var objectUnderTest = new CopyablePromptDialogWindowViewModel(Message, CopyableText);
+
+            objectUnderTest.CopyCommand.Execute(null);
+
+            Assert.AreEqual(CopyableText, Clipboard.GetText());
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -249,6 +249,7 @@
     <Compile Include="CloudSourceRepository\CsrAddRepoWindowViewModelTests.cs" />
     <Compile Include="CloudSourceRepository\CsrCloneWindowViewModelTests.cs" />
     <Compile Include="CloudSourceRepository\RepoNameConverterTests.cs" />
+    <Compile Include="CopyablePrompt\CopyablePromptDialogWindowViewModelTest.cs" />
     <Compile Include="GcsFileProgressDialog\GcsFileProgressDialogWindowTest.cs" />
     <Compile Include="GoogleCloudExtensionPackageTests.cs" />
     <Compile Include="Options\AnalyticsOptionsTests.cs" />
@@ -289,6 +290,7 @@
       <DependentUpon>UnitTestResources.resx</DependentUpon>
     </Compile>
     <Compile Include="Utils\EditableModelTests.cs" />
+    <Compile Include="Utils\GCloudWrapperUtilsTests.cs" />
     <Compile Include="Utils\StringUtilTests.cs" />
     <Compile Include="Utils\ToolWindowCommandUtilsTests.cs" />
     <Compile Include="Utils\Validation\StringValidationResultTests.cs" />
@@ -308,6 +310,10 @@
     <ProjectReference Include="..\GoogleCloudExtension.Deployment\GoogleCloudExtension.Deployment.csproj">
       <Project>{92c6e0d0-41d8-4ecc-87e1-ae72fca891fc}</Project>
       <Name>GoogleCloudExtension.Deployment</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GoogleCloudExtension.GCloud\GoogleCloudExtension.GCloud.csproj">
+      <Project>{95EFAC7E-4F6E-46F0-BCC8-90EE1487E1E1}</Project>
+      <Name>GoogleCloudExtension.GCloud</Name>
     </ProjectReference>
     <ProjectReference Include="..\GoogleCloudExtension.GcsUtils\GoogleCloudExtension.GcsUtils.csproj">
       <Project>{0C891356-CCD7-4A10-BA27-C4A4359EA825}</Project>

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/GCloudWrapperUtilsTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/GCloudWrapperUtilsTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GoogleCloudExtension;
+using GoogleCloudExtension.GCloud;
+using GoogleCloudExtension.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtensionUnitTests.Utils
+{
+    [TestClass]
+    public class GCloudWrapperUtilsTests
+    {
+        private static readonly string MissingComponentTitle = Resources.GcloudMissingComponentTitle;
+        private static readonly string MissingComponentMessage = string.Format(Resources.GcloudMissingComponentErrorMessage, "Kubectl");
+        private static readonly string MissingComponentInstallCommand = string.Format(Resources.GcloudMissingComponentInstallCommand, "kubectl").ToLower();
+
+        private Mock<Func<GCloudComponent, Task<GCloudValidationResult>>> _validateGCloudAsyncMock;
+        private TaskCompletionSource<GCloudValidationResult> _validateGCloudAsyncSource;
+        private Mock<Action<string, string, string>> _showCopyablePromptMock;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            _validateGCloudAsyncSource = new TaskCompletionSource<GCloudValidationResult>();
+            _validateGCloudAsyncMock = new Mock<Func<GCloudComponent, Task<GCloudValidationResult>>>();
+            _validateGCloudAsyncMock.Setup(f => f(It.IsAny<GCloudComponent>())).Returns(_validateGCloudAsyncSource.Task);
+
+            _showCopyablePromptMock = new Mock<Action<string, string, string>>();
+
+            GCloudWrapperUtils.ValidateGCloudAsyncOverride = _validateGCloudAsyncMock.Object;
+            GCloudWrapperUtils.ShowCopyablePromptOverride = _showCopyablePromptMock.Object;
+
+        }
+
+        [TestCleanup]
+        public void AfterEach()
+        {
+            GCloudWrapperUtils.ValidateGCloudAsyncOverride = null;
+            GCloudWrapperUtils.ShowCopyablePromptOverride = null;
+        }
+
+        [TestMethod]
+        public async Task TestMissingComponentPrompt()
+        {
+            _validateGCloudAsyncSource.SetResult(new GCloudValidationResult(
+                        isCloudSdkInstalled: true,
+                        isCloudSdkUpdated: true,
+                        isRequiredComponentInstalled: false));
+
+            _showCopyablePromptMock
+                .Setup(a => a(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string, string>((title, message, copyableMessage) =>
+                {
+                    Assert.AreEqual(MissingComponentTitle, title);
+                    Assert.AreEqual(MissingComponentMessage, message);
+                    Assert.AreEqual(MissingComponentInstallCommand, copyableMessage, false);
+                });
+
+            await GCloudWrapperUtils.VerifyGCloudDependencies(GCloudComponent.Kubectl);
+
+            _showCopyablePromptMock.Verify(a => a(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/GCloudWrapperUtilsTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/GCloudWrapperUtilsTests.cs
@@ -25,9 +25,9 @@ namespace GoogleCloudExtensionUnitTests.Utils
     [TestClass]
     public class GCloudWrapperUtilsTests
     {
-        private static readonly string MissingComponentTitle = Resources.GcloudMissingComponentTitle;
-        private static readonly string MissingComponentMessage = string.Format(Resources.GcloudMissingComponentErrorMessage, "Kubectl");
-        private static readonly string MissingComponentInstallCommand = string.Format(Resources.GcloudMissingComponentInstallCommand, "kubectl").ToLower();
+        private static readonly string s_missingComponentTitle = Resources.GcloudMissingComponentTitle;
+        private static readonly string s_missingComponentMessage = string.Format(Resources.GcloudMissingComponentErrorMessage, "Kubectl");
+        private static readonly string s_missingComponentInstallCommand = string.Format(Resources.GcloudMissingComponentInstallCommand, "kubectl").ToLower();
 
         private Mock<Func<GCloudComponent, Task<GCloudValidationResult>>> _validateGCloudAsyncMock;
         private TaskCompletionSource<GCloudValidationResult> _validateGCloudAsyncSource;
@@ -66,9 +66,9 @@ namespace GoogleCloudExtensionUnitTests.Utils
                 .Setup(a => a(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Callback<string, string, string>((title, message, copyableMessage) =>
                 {
-                    Assert.AreEqual(MissingComponentTitle, title);
-                    Assert.AreEqual(MissingComponentMessage, message);
-                    Assert.AreEqual(MissingComponentInstallCommand, copyableMessage, false);
+                    Assert.AreEqual(s_missingComponentTitle, title);
+                    Assert.AreEqual(s_missingComponentMessage, message);
+                    Assert.AreEqual(s_missingComponentInstallCommand, copyableMessage, false);
                 });
 
             await GCloudWrapperUtils.VerifyGCloudDependencies(GCloudComponent.Kubectl);


### PR DESCRIPTION
Fixes #933 and #841 
- Adding a CopyablePrompt to allow commands and other texts to be copied from the prompt.
- Showing the command to install missing components when publishing to k8s in said CopyablePrompt.
- Turning the name of the missing component to lower case so the comand works as copied.