### PR TITLE
Show an error when the template will inexplicably fail.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -5182,6 +5182,16 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find a 1.0.0-preview version of .Net Core SDK.
+        ///Either intall the Visual Studio 2015 DotNetCore tooling, or upgrade to Visual Studio 2017..
+        /// </summary>
+        public static string NoDotNetCorePreviewFoundError {
+            get {
+                return ResourceManager.GetString("NoDotNetCorePreviewFoundError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A browser window has been open to login into your account. To cancel this operation close the browser window and press Cancel to close this window. When the login finishes this window will close automatically..
         /// </summary>
         public static string OAuthFlowWindowMessage {
@@ -6483,6 +6493,15 @@ namespace GoogleCloudExtension {
         public static string ValidationStartWithLetterMessage {
             get {
                 return ResourceManager.GetString("ValidationStartWithLetterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .NET Core Tools for Visual Studio 2015 Download Archive.
+        /// </summary>
+        public static string VisualStudio2015DotNetCoreToolingLinkTitle {
+            get {
+                return ResourceManager.GetString("VisualStudio2015DotNetCoreToolingLinkTitle", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2995,9 +2995,9 @@
     <comment>Command to install a missing component. {0} is the name of the component and should be in lower case.</comment>
   </data>
   <data name="NoDotNetCorePreviewFoundError" xml:space="preserve">
-    <value>Could not find a 1.0.0-preview version of .Net Core SDK.
-Either intall the Visual Studio 2015 DotNetCore tooling, or upgrade to Visual Studio 2017.</value>
-    <comment>The dialog error message shown when dotnet core SDK version 1.0.0-preview is not found.</comment>
+    <value>Could not find a 1.0.0-preview version of .NET Core SDK.
+Either intall the .NET Core tools for Visual Studio 2015, or upgrade to Visual Studio 2017.</value>
+    <comment>The dialog error message shown when .NET Core SDK version 1.0.0-preview is not found.</comment>
   </data>
   <data name="VisualStudio2015DotNetCoreToolingLinkTitle" xml:space="preserve">
     <value>.NET Core Tools for Visual Studio 2015 Download Archive</value>

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -2990,4 +2990,13 @@
     <value>Copy</value>
     <comment>Header for a standard "Copy" menu item.</comment>
   </data>
+  <data name="NoDotNetCorePreviewFoundError" xml:space="preserve">
+    <value>Could not find a 1.0.0-preview version of .Net Core SDK.
+Either intall the Visual Studio 2015 DotNetCore tooling, or upgrade to Visual Studio 2017.</value>
+    <comment>The dialog error message shown when dotnet core SDK version 1.0.0-preview is not found.</comment>
+  </data>
+  <data name="VisualStudio2015DotNetCoreToolingLinkTitle" xml:space="preserve">
+    <value>.NET Core Tools for Visual Studio 2015 Download Archive</value>
+    <comment>Title for the link to the .NET Core Tools for Visual Studio 2015 section of the .NET Core Runtime and SDK download archive.</comment>
+  </data>
 </root>

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/AspNetCoreTemplateChooserWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/AspNetCoreTemplateChooserWindowContent.xaml
@@ -49,32 +49,55 @@ limitations under the License.
                 Caption="{x:Static ext:Resources.UiCancelButtonCaption}"
                 IsCancel="True"/>
         </theming:CommonDialogWindowBaseContent.Buttons>
-        <StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <StackPanel>
-                    <Label
-                        Content="{x:Static ext:Resources.WizardTemplateChooserTargetNetFrameworkLabel}"
-                        Target="{Binding ElementName=_targetFramework}"
-                        Margin="0" />
-                    <ComboBox
-                        x:Name="_targetFramework"
-                        ItemsSource="{Binding AvailableFrameworks}"
-                        SelectedValue="{Binding SelectedFramework}"
-                        ItemTemplate="{StaticResource FrameworkTypeTemplate}"
-                        MinWidth="150px"/>
+        <ContentControl>
+            <ContentControl.Resources>
+                <StackPanel x:Key="SelectPanel">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel>
+                            <Label
+                                Content="{x:Static ext:Resources.WizardTemplateChooserTargetNetFrameworkLabel}"
+                                Target="{Binding ElementName=_targetFramework}"
+                                Margin="0" />
+                            <ComboBox
+                                x:Name="_targetFramework"
+                                ItemsSource="{Binding AvailableFrameworks}"
+                                SelectedValue="{Binding SelectedFramework}"
+                                ItemTemplate="{StaticResource FrameworkTypeTemplate}"
+                                MinWidth="150px"/>
+                        </StackPanel>
+                        <StackPanel>
+                            <Label
+                                Content="{x:Static ext:Resources.WizardTemplateChooserTargetAspFrameworkLabel}"
+                                Target="{Binding ElementName=_targetAspNetFramework}" />
+                            <ComboBox
+                                x:Name="_targetAspNetFramework"
+                                ItemsSource="{Binding AvailableVersions}"
+                                SelectedItem="{Binding SelectedVersion}"
+                                MinWidth="180px" />
+                        </StackPanel>
+                    </StackPanel>
+                    <local:AppTypeSelectorControl/>
                 </StackPanel>
-                <StackPanel>
-                    <Label
-                        Content="{x:Static ext:Resources.WizardTemplateChooserTargetAspFrameworkLabel}"
-                        Target="{Binding ElementName=_targetAspNetFramework}" />
-                    <ComboBox
-                        x:Name="_targetAspNetFramework"
-                        ItemsSource="{Binding AvailableVersions}"
-                        SelectedItem="{Binding SelectedVersion}"
-                        MinWidth="180px" />
+                <StackPanel x:Key="ErrorPanel">
+                    <TextBlock Text="{x:Static ext:Resources.NoDotNetCorePreviewFoundError}"/>
+                    <Button Style="{StaticResource ButtonLikeHyperlinkStyle}"
+                            Command="{Binding OpenVisualStudio2015DotNetCoreToolingDownloadLink}"
+                            Content="{x:Static ext:Resources.VisualStudio2015DotNetCoreToolingLinkTitle}"
+                            Margin="6,0,0,0"/>
                 </StackPanel>
-            </StackPanel>
-            <local:AppTypeSelectorControl/>
-        </StackPanel>
+            </ContentControl.Resources>
+            <ContentControl.Style>
+                <Style TargetType="ContentControl">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding NetCoreMissingError}" Value="True">
+                            <Setter Property="Content" Value="{StaticResource ErrorPanel}"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding NetCoreMissingError}" Value="False">
+                            <Setter Property="Content" Value="{StaticResource SelectPanel}" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ContentControl.Style>
+        </ContentControl>
     </theming:CommonDialogWindowBaseContent>
 </UserControl>

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/AspNetVersion.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/Dialogs/TemplateChooserDialog/AspNetVersion.cs
@@ -81,7 +81,7 @@ namespace GoogleCloudExtension.TemplateWizards.Dialogs.TemplateChooserDialog
         /// </summary>
         private static IList<AspNetVersion> GetVs2015AspNetCoreVersions()
         {
-            if (NetCoreSdkVersions.Any(sdkVersion => sdkVersion.StartsWith("1.0.0-preview")))
+            if (NetCoreSdkVersions.Any(sdkVersion => sdkVersion.StartsWith("1.0.0-preview", StringComparison.Ordinal)))
             {
                 return new List<AspNetVersion>
                 {

--- a/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/GoogleProjectTemplateSelectorWizard.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TemplateWizards/GoogleProjectTemplateSelectorWizard.cs
@@ -37,7 +37,7 @@ namespace GoogleCloudExtension.TemplateWizards
     [Export(typeof(IGoogleProjectTemplateSelectorWizard))]
     public class GoogleProjectTemplateSelectorWizard : IGoogleProjectTemplateSelectorWizard
     {
-        // Find the AspNet part of c:\path\to\template\Gcp.AspNet.vstemplate
+        // Find the AspNet or AspNetCore part of c:\path\to\template\Gcp.AspNet.vstemplate
         private static readonly Regex s_templateTypeRegex = new Regex(@"(?<=Gcp\.)[^.]*(?=\.vstemplate$)");
         // Mockable static methods for unit testing.
         internal Func<string, TemplateType, TemplateChooserViewModelResult> PromptUser = TemplateChooserWindow.PromptUser;

--- a/GoogleCloudExtension/GoogleCloudExtension/VsVersion/ToolsPathProviderBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/VsVersion/ToolsPathProviderBase.cs
@@ -58,7 +58,8 @@ namespace GoogleCloudExtension.VsVersion
                 .Select(Path.GetFileName)
                 .Where(
                     sdkVersion =>
-                        sdkVersion.StartsWith("1.0.0-preview") || Version.TryParse(sdkVersion, out dummy));
+                        sdkVersion.StartsWith("1.0.0-preview", StringComparison.Ordinal) ||
+                        Version.TryParse(sdkVersion, out dummy));
         }
     }
 }

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ComHelper.cs
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ComHelper.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Microsoft.VisualStudio;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -28,12 +28,6 @@ namespace ProjectTemplate.Tests
     /// <seealso href="http://www.helixoft.com/blog/creating-envdte-dte-for-vs-2017-from-outside-of-the-devenv-exe.html"/>
     public static class ComHelper
     {
-        [SuppressMessage("ReSharper", "InconsistentNaming")]
-        private static class HRESULT
-        {
-            public const int S_OK = 0;
-        }
-
         ///<see href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms678542"/>
         [DllImport("ole32.dll")]
         private static extern int CreateBindCtx(uint zero, out IBindCtx ctx);
@@ -74,7 +68,7 @@ namespace ProjectTemplate.Tests
             var monikers = new IMoniker[fetchSize];
             IntPtr fetchedCount = IntPtr.Zero;
             int hResult;
-            while ((hResult = monikersEnum.Next(fetchSize, monikers, fetchedCount)) == HRESULT.S_OK)
+            while ((hResult = monikersEnum.Next(fetchSize, monikers, fetchedCount)) == VSConstants.S_OK)
             {
                 IMoniker currentMoniker = monikers[0];
                 if (currentMoniker != null)

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplate.Tests.csproj
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplate.Tests.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -130,12 +131,6 @@
     <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
-    </None>
-    <None Include="Templates2015.csv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Templates2017.csv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplatesTests.cs
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplatesTests.cs
@@ -198,16 +198,15 @@ namespace ProjectTemplate.Tests
             string projectPath = Path.Combine(SolutionFolderPath, projectName);
             Directory.CreateDirectory(projectPath);
             string templatePath = Solution.GetProjectTemplate(choserTemplateName, "CSharp");
-            var isp = Dte as IServiceProvider;
-            var vsSolution = (IVsSolution6)isp.QueryService<SVsSolution>();
-            var resultObject = new JObject(
-                new JProperty("GcpProjectId", "fake-gcp-project-id"),
-                new JProperty("SelectedFramework", framework),
-                new JProperty("AppType", appType),
-                new JProperty(
-                    "SelectedVersion",
-                    new JObject(
-                        new JProperty("Version", version))));
+            var serviceProvider = Dte as IServiceProvider;
+            var vsSolution = (IVsSolution6)serviceProvider.QueryService<SVsSolution>();
+            var resultObject = new JObject
+            {
+                ["GcpProjectId"] = "fake-gcp-project-id",
+                ["SelectedFramework"] = framework,
+                ["AppType"] = appType,
+                ["SelectedVersion"] = new JObject { ["Version"] = version }
+            };
             Array customParams = new object[]
             {
                 $"$templateChooserResult$={resultObject}"

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplatesTests.cs
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplatesTests.cs
@@ -152,35 +152,23 @@ namespace ProjectTemplate.Tests
         {
             if (Directory.Exists(SolutionFolderPath))
             {
-                var watcher = new FileSystemWatcher(SolutionFolderPath);
-                try
+                while (Directory.EnumerateFileSystemEntries(SolutionFolderPath).Any())
                 {
-                    Directory.Delete(SolutionFolderPath, true);
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    // MSBuild sometimes persists and holds a handle on a file in the solution package directory.
-                    KillMsBuild();
-                    Directory.Delete(SolutionFolderPath, true);
-                }
-                if (Directory.Exists(SolutionFolderPath))
-                {
-                    // Allow Directory.Delete to finish before creating.
-                    try
+                    foreach (string directory in Directory.EnumerateDirectories(SolutionFolderPath))
                     {
-                        WaitForChangedResult result = watcher.WaitForChanged(WatcherChangeTypes.Deleted, 1000);
-                        if (result.TimedOut && Directory.Exists(SolutionFolderPath))
-                        {
-                            throw new TimeoutException($"Time out waiting for deletion of {SolutionFolderPath}");
-                        }
+                        Directory.Delete(directory, true);
                     }
-                    catch (FileNotFoundException)
+
+                    foreach (string file in Directory.EnumerateFiles(SolutionFolderPath))
                     {
-                        // Directory was deleted between the "if(exists)" and the "watcher.WaitForChanged".
+                        File.Delete(file);
                     }
                 }
             }
-            Directory.CreateDirectory(SolutionFolderPath);
+            else
+            {
+                Directory.CreateDirectory(SolutionFolderPath);
+            }
         }
 
         private static void KillMsBuild()

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplatesTests.cs
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/ProjectTemplatesTests.cs
@@ -144,7 +144,7 @@ namespace ProjectTemplate.Tests
         private static void RestorePackages(string projectDirectory)
         {
             var dotNetRestoreInfo =
-                new ProcessStartInfo("dotnet", "restore") { WorkingDirectory = projectDirectory };
+                new ProcessStartInfo("dotnet", "restore") { WorkingDirectory = projectDirectory, CreateNoWindow = true, UseShellExecute = false };
             Process.Start(dotNetRestoreInfo)?.WaitForExit();
         }
 

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/Templates2015.csv
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/Templates2015.csv
@@ -1,5 +1,0 @@
-TemplateName, Framework, IsCoreTemplate, Version, AppType
-GcpAspNetCoreMvc, NetCore, true, v1.0-preview, Mvc
-GcpAspNetMvc, NetFramework, false, v4, Mvc
-GcpAspNetCoreWebApi, NetCore, true, v1.0-preview, WebApi
-GcpAspNetWebApi, NetFramework, false, v4, WebApi

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/Templates2017.csv
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/Templates2017.csv
@@ -1,9 +1,0 @@
-﻿TemplateName, Framework, IsCoreTemplate, Version, AppType
-GcpAspNetCoreMvc10, NetCore, true, "v1.0", Mvc
-GcpAspNetCoreMvc11, NetCore, true, "v1.1", Mvc
-GcpAspNetCoreMvc20, NetCore, true, "v2.0", Mvc
-GcpAspNetMvc, NetFramework, false, v4, Mvc
-GcpAspNetCoreWebApi10, NetCore, true, "v1.0", WebApi
-GcpAspNetCoreWebApi11, NetCore, true, "v1.1", WebApi
-GcpAspNetCoreWebApi20, NetCore, true, "v2.0", WebApi
-GcpAspNetWebApi, NetFramework, false, v4, WebApi

--- a/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/VisualStudioWrapper.cs
+++ b/GoogleCloudExtension/ProjectTemplates/ProjectTemplate.Tests/VisualStudioWrapper.cs
@@ -152,7 +152,11 @@ namespace ProjectTemplate.Tests
             return new VisualStudioWrapper("devenv", "/rootSuffix Exp");
         }
 
-        private static VisualStudioWrapper CreateExperimentalInstance(string version)
+        /// <summary>
+        /// Factory method for creating a new <see cref="VisualStudioWrapper"/> linked to an experimental instance.
+        /// </summary>
+        /// <returns>A new <see cref="VisualStudioWrapper"/> of the given version.</returns>
+        public static VisualStudioWrapper CreateExperimentalInstance(string version)
         {
             string devEnvPath = GetDevEnvPath(version);
             return new VisualStudioWrapper(devEnvPath, "/rootSuffix Exp");
@@ -195,8 +199,8 @@ namespace ProjectTemplate.Tests
                 string name;
                 moniker.GetDisplayName(bindCtx, null, out name);
                 return !string.IsNullOrWhiteSpace(name) &&
-                    name.StartsWith("!VisualStudio.DTE") &&
-                    name.EndsWith(":" + _devEnvProcess.Id);
+                    name.StartsWith("!VisualStudio.DTE", StringComparison.Ordinal) &&
+                    name.EndsWith($":{_devEnvProcess.Id}", StringComparison.Ordinal);
             }
             catch (NotImplementedException)
             {


### PR DESCRIPTION
Disable the template dialog and show an error when no 1.0.0-preview version of .Net Core SDK is found.

Fixes #930 
![pr-943-example](https://user-images.githubusercontent.com/16388858/39427683-91034412-4c39-11e8-8b0f-01c644ff7efd.png)
