### PR TITLE
Enable refreshing instances from within the GCE publish dialog.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/IPublishDialogStep.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/IPublishDialogStep.cs
@@ -24,16 +24,6 @@ namespace GoogleCloudExtension.PublishDialog
     public interface IPublishDialogStep : INotifyDataErrorInfo, INotifyPropertyChanged
     {
         /// <summary>
-        /// Returns whether the step can go to a next step.
-        /// </summary>
-        bool CanGoNext { get; }
-
-        /// <summary>
-        /// Event raised whenever <seealso cref="CanGoNext"/> value changes.
-        /// </summary>
-        event EventHandler CanGoNextChanged;
-
-        /// <summary>
         /// Returns whether the step can perform the publish operation.
         /// </summary>
         bool CanPublish { get; }
@@ -47,12 +37,6 @@ namespace GoogleCloudExtension.PublishDialog
         /// Returns the content of the publish step.
         /// </summary>
         FrameworkElement Content { get; }
-
-        /// <summary>
-        /// Returns the next step to navigate to when the next button is pressed.
-        /// </summary>
-        /// <returns>The next step to navigate to.</returns>
-        IPublishDialogStep Next();
 
         /// <summary>
         /// Performs the publish step action, will only be called if <seealso cref="CanPublish"/> return true.

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowContent.xaml
@@ -25,8 +25,6 @@
         <theming:CommonDialogWindowBaseContent.Buttons>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.PublishDialogPrevButtonCaption}"
                                       Command="{Binding PrevCommand}"/>
-            <theming:DialogButtonInfo Caption="{x:Static ext:Resources.PublishDialogNextButtonCaption}"
-                                      Command="{Binding NextCommand}"/>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.PublishDialogPublishButtonCaption}"
                                       Command="{Binding PublishCommand}"/>
             <theming:DialogButtonInfo Caption="{x:Static ext:Resources.UiCloseButtonCaption}"

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialog/PublishDialogWindowViewModel.cs
@@ -50,11 +50,6 @@ namespace GoogleCloudExtension.PublishDialog
         public ProtectedCommand PrevCommand { get; }
 
         /// <summary>
-        /// The command to execute when pressing the "Next" button.
-        /// </summary>
-        public ProtectedCommand NextCommand { get; }
-
-        /// <summary>
         /// The command to execute when presing the "Publish" button.
         /// </summary>
         public ProtectedCommand PublishCommand { get; }
@@ -79,16 +74,9 @@ namespace GoogleCloudExtension.PublishDialog
             _project = project;
 
             PrevCommand = new ProtectedCommand(OnPrevCommand);
-            NextCommand = new ProtectedCommand(OnNextCommand);
             PublishCommand = new ProtectedCommand(OnPublishCommand);
 
             PushStep(initialStep);
-        }
-
-        private void OnNextCommand()
-        {
-            var nextStep = CurrentStep.Next();
-            PushStep(nextStep);
         }
 
         private void OnPrevCommand()
@@ -114,7 +102,7 @@ namespace GoogleCloudExtension.PublishDialog
         private void AddStepEvents()
         {
             var top = _stack.Peek();
-            top.CanGoNextChanged += OnCanGoNextChanged;
+
             top.CanPublishChanged += OnCanPublishChanged;
             top.ErrorsChanged += OnErrorsChanged;
         }
@@ -124,7 +112,6 @@ namespace GoogleCloudExtension.PublishDialog
             if (_stack.Count > 0)
             {
                 var top = _stack.Peek();
-                top.CanGoNextChanged -= OnCanGoNextChanged;
                 top.CanPublishChanged -= OnCanPublishChanged;
                 top.ErrorsChanged -= OnErrorsChanged;
             }
@@ -145,18 +132,12 @@ namespace GoogleCloudExtension.PublishDialog
         {
             Content = CurrentStep.Content;
             PrevCommand.CanExecuteCommand = _stack.Count > 1;
-            NextCommand.CanExecuteCommand = CurrentStep.CanGoNext;
             PublishCommand.CanExecuteCommand = CurrentStep.CanPublish;
         }
 
         private void OnCanPublishChanged(object sender, EventArgs e)
         {
             PublishCommand.CanExecuteCommand = CurrentStep.CanPublish;
-        }
-
-        private void OnCanGoNextChanged(object sender, EventArgs e)
-        {
-            NextCommand.CanExecuteCommand = CurrentStep.CanGoNext;
         }
 
         private void OnErrorsChanged(object sender, DataErrorsChangedEventArgs e)

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/ChoiceStep/ChoiceStepViewModel.cs
@@ -46,11 +46,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         private IEnumerable<Choice> _choices = Enumerable.Empty<Choice>();
 
         // Disable compiler error CS0067.
-        public event EventHandler CanGoNextChanged
-        {
-            add { }
-            remove { }
-        }
         public event EventHandler CanPublishChanged
         {
             add { }
@@ -72,9 +67,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
         public FrameworkElement Content => _content;
 
         /// <inheritdoc />
-        public bool CanGoNext => false;
-
-        /// <inheritdoc />
         public bool CanPublish => false;
 
         private ChoiceStepViewModel(ChoiceStepContent content)
@@ -87,14 +79,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.ChoiceStep
             PublishDialog = dialog;
             AddHandlers();
             Choices = GetChoicesForCurrentProject();
-        }
-
-        /// <summary>
-        /// This step never goes next. <see cref="IPublishDialogStep.CanGoNext"/> is always <code>false</code>
-        /// </summary>
-        public IPublishDialogStep Next()
-        {
-            throw new NotSupportedException();
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/FlexStep/FlexStepViewModel.cs
@@ -269,14 +269,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.FlexStep
             }
         }
 
-        /// <summary>
-        /// This step never goes next. <see cref="IPublishDialogStep.CanGoNext"/> is always <code>false</code>
-        /// </summary>
-        public override IPublishDialogStep Next()
-        {
-            throw new NotSupportedException();
-        }
-
         protected internal override void OnFlowFinished()
         {
             base.OnFlowFinished();

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GceStep/GceStepContent.xaml
@@ -7,6 +7,7 @@
              xmlns:ext="clr-namespace:GoogleCloudExtension"
              xmlns:utils="clr-namespace:GoogleCloudExtension.Utils;assembly=GoogleCloudExtension.Utils"
              xmlns:controls="clr-namespace:GoogleCloudExtension.Controls"
+             xmlns:extensions="clr-namespace:GoogleCloudExtension.Extensions"
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance local:GceStepViewModel}">
 
@@ -51,12 +52,19 @@
             <Label Content="{x:Static ext:Resources.PublishDialogGceStepSelectInstanceMessage}"
                    Target="{Binding ElementName=_instances}"
                    Style="{StaticResource CommonLabelStyle}"/>
-            <ComboBox x:Name="_instances"
+            <DockPanel Margin="0,0,0,15">
+                <Button DockPanel.Dock="Right"
+                        Command="{Binding RefreshInstancesCommand}"
+                        Style="{StaticResource CommonButtonDynamicStyle}">
+                    <Image Source="{extensions:ImageResource Theming/Resources/refresh.png}" />
+                </Button>
+                <ComboBox x:Name="_instances"
                       ItemsSource="{Binding Instances}"
                       DisplayMemberPath="Name"
                       IsSynchronizedWithCurrentItem="True"
-                      Margin="0,0,0,15"
-                      SelectedItem="{Binding SelectedInstance, Mode=TwoWay}" />
+                      SelectedItem="{Binding SelectedInstance, Mode=TwoWay}"
+                          Margin="0,0,5,0"/>
+            </DockPanel>
 
             <Label Content="{x:Static ext:Resources.PublishDialogGceStepSelectCredentialsMessage}"
                    Target="{Binding ElementName=_credentials}"
@@ -104,3 +112,4 @@
 
     </StackPanel>
 </UserControl>
+

--- a/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/PublishDialogSteps/GkeStep/GkeStepViewModel.cs
@@ -229,14 +229,6 @@ namespace GoogleCloudExtension.PublishDialogSteps.GkeStep
 
         public override FrameworkElement Content => _content;
 
-        /// <summary>
-        /// This step never goes next. <see cref="IPublishDialogStep.CanGoNext"/> is always <code>false</code>
-        /// </summary>
-        public override IPublishDialogStep Next()
-        {
-            throw new NotSupportedException();
-        }
-
         protected override async Task InitializeDialogAsync()
         {
             // Start the task that initializes the dialog, mainly loads the GCP project.

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GoogleCloudExtension {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -5128,8 +5128,8 @@ namespace GoogleCloudExtension {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find a 1.0.0-preview version of .Net Core SDK.
-        ///Either intall the Visual Studio 2015 DotNetCore tooling, or upgrade to Visual Studio 2017..
+        ///   Looks up a localized string similar to Could not find a 1.0.0-preview version of .NET Core SDK.
+        ///Either intall the .NET Core tools for Visual Studio 2015, or upgrade to Visual Studio 2017..
         /// </summary>
         public static string NoDotNetCorePreviewFoundError {
             get {
@@ -5476,15 +5476,6 @@ namespace GoogleCloudExtension {
         public static string PublishDialogLoadingProjectMessage {
             get {
                 return ResourceManager.GetString("PublishDialogLoadingProjectMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Next.
-        /// </summary>
-        public static string PublishDialogNextButtonCaption {
-            get {
-                return ResourceManager.GetString("PublishDialogNextButtonCaption", resourceCulture);
             }
         }
         

--- a/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
+++ b/GoogleCloudExtension/GoogleCloudExtension/Resources.resx
@@ -845,10 +845,6 @@
     <value>_VM instance:</value>
     <comment>The message shown to select an instance.</comment>
   </data>
-  <data name="PublishDialogNextButtonCaption" xml:space="preserve">
-    <value>_Next</value>
-    <comment>The caption for the next button.</comment>
-  </data>
   <data name="PublishDialogPrevButtonCaption" xml:space="preserve">
     <value>_Prev</value>
     <comment>The caption for the prev button.</comment>

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/ChoiceStep/ChoiceStepViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/ChoiceStep/ChoiceStepViewModelTests.cs
@@ -56,7 +56,6 @@ namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.ChoiceStep
         [TestMethod]
         public void TestInitialState()
         {
-            Assert.IsFalse(_objectUnderTest.CanGoNext);
             Assert.IsFalse(_objectUnderTest.CanPublish);
             Assert.IsNull(_objectUnderTest.PublishDialog);
             CollectionAssert.That.IsEmpty(_objectUnderTest.Choices);
@@ -139,13 +138,6 @@ namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.ChoiceStep
                 },
                 _objectUnderTest.Choices.Select(c => Tuple.Create(c.Name, c.ToolTip, c.Command.CanExecute(null)))
                     .ToList());
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
-        public void TestNext_Throws()
-        {
-            _objectUnderTest.Next();
         }
 
         [TestMethod]

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/FlexStep/FlexStepViewModelTests.cs
@@ -245,12 +245,5 @@ namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.FlexStep
             Assert.IsFalse(_objectUnderTest.NeedsAppCreated);
             Assert.AreEqual(GcpPublishStepsUtils.GetDefaultVersion(), _objectUnderTest.Version);
         }
-
-        [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
-        public void TestNext_NotSupported()
-        {
-            _objectUnderTest.Next();
-        }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/GkeStep/GkeStepViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/PublishDialogSteps/GkeStep/GkeStepViewModelTests.cs
@@ -351,14 +351,6 @@ namespace GoogleCloudExtensionUnitTests.PublishDialogSteps.GkeStep
             Assert.AreEqual(s_aCluster, _objectUnderTest.SelectedCluster);
         }
 
-
-        [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
-        public void TestNext_ThrowsNotSupportedException()
-        {
-            _objectUnderTest.Next();
-        }
-
         [TestMethod]
         public void TestInitializeDialogAsync_SetsDeploymentName()
         {


### PR DESCRIPTION
Add GceStepViewModel.RefreshInstancesCommand with tests.
Add refresh instances button to GceStepContent.
Remove Next button and related members, as it was never enabled.
Fixes #938 