### PR TITLE
Don't crash for user file corruption.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
@@ -99,7 +99,7 @@ namespace GoogleCloudExtension.Accounts
         /// Deletes the given <paramref name="userAccount"/> from the store.
         /// </summary>
         /// <param name="userAccount"></param>
-        public static void DeleteAccount(UserAccount userAccount) => CredentialsStore.Default.DeleteAccount(userAccount);
+        public static void DeleteAccount(IUserAccount userAccount) => CredentialsStore.Default.DeleteAccount(userAccount);
 
         private static async Task<UserAccount> GetUserAccountForRefreshToken(string refreshToken)
         {

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
@@ -72,6 +72,7 @@ namespace GoogleCloudExtension.Accounts
                 var existingUserAccount = CredentialsStore.Default.GetAccount(credentials.AccountName);
                 if (existingUserAccount != null)
                 {
+                    CredentialsStore.Default.UpdateCurrentAccount(credentials);
                     Debug.WriteLine($"Duplicate account {credentials.AccountName}");
                     UserPromptUtils.ErrorPrompt(
                         string.Format(Resources.ManageAccountsAccountAlreadyExistsPromptMessage, credentials.AccountName),

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/AccountsManager.cs
@@ -109,7 +109,8 @@ namespace GoogleCloudExtension.Accounts
                 ClientId = s_extensionCredentials.ClientId,
                 ClientSecret = s_extensionCredentials.ClientSecret
             };
-            var plusDataSource = new GPlusDataSource(result.GetGoogleCredential(), GoogleCloudExtensionPackage.Instance.VersionedApplicationName);
+            var plusDataSource = new GPlusDataSource(
+                result.GetGoogleCredential(), GoogleCloudExtensionPackage.Instance.VersionedApplicationName);
             var person = await plusDataSource.GetProfileAsync();
             result.AccountName = person.Emails.FirstOrDefault()?.Value;
             return result;

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
@@ -127,7 +127,7 @@ namespace GoogleCloudExtension.Accounts
         /// This method will also invalidate the project.
         /// It is up to the caller to select an appropriate one.
         /// </summary>
-        public void UpdateCurrentAccount(UserAccount account)
+        public void UpdateCurrentAccount(IUserAccount account)
         {
             if (CurrentAccount?.AccountName != account?.AccountName)
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
@@ -65,7 +65,7 @@ namespace GoogleCloudExtension.Accounts
         /// <summary>
         /// The current <see cref="UserAccount"/> selected.
         /// </summary>
-        public UserAccount CurrentAccount { get; private set; }
+        public IUserAccount CurrentAccount { get; private set; }
 
         /// <summary>
         /// Returns the path for the current account.
@@ -129,7 +129,7 @@ namespace GoogleCloudExtension.Accounts
         /// it is up to the caller to select an appropriate one.
         /// </summary>
         /// <param name="account"></param>
-        public void UpdateCurrentAccount(UserAccount account)
+        public void UpdateCurrentAccount(IUserAccount account)
         {
             if (CurrentAccount?.AccountName != account?.AccountName)
             {
@@ -188,7 +188,7 @@ namespace GoogleCloudExtension.Accounts
         /// </summary>
         /// <param name="account">The accound to delete.</param>
         /// <returns>True if the current account was deleted, false otherwise.</returns>
-        public void DeleteAccount(UserAccount account)
+        public void DeleteAccount(IUserAccount account)
         {
             var accountFilePath = GetUserAccountPath(account.AccountName);
             if (accountFilePath == null)

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/ICredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/ICredentialsStore.cs
@@ -30,7 +30,7 @@ namespace GoogleCloudExtension.Accounts
         /// <summary>
         /// The current <see cref="UserAccount"/> selected.
         /// </summary>
-        UserAccount CurrentAccount { get; }
+        IUserAccount CurrentAccount { get; }
 
         /// <summary>
         /// Returns the path for the current account.
@@ -72,7 +72,7 @@ namespace GoogleCloudExtension.Accounts
         /// </summary>
         /// <param name="account">The accound to delete.</param>
         /// <returns>True if the current account was deleted, false otherwise.</returns>
-        void DeleteAccount(UserAccount account);
+        void DeleteAccount(IUserAccount account);
 
         /// <summary>
         /// Returns the account given the account name.
@@ -102,7 +102,7 @@ namespace GoogleCloudExtension.Accounts
         /// This method will also invalidate the project.
         /// It is up to the caller to select an appropriate one.
         /// </summary>
-        void UpdateCurrentAccount(UserAccount account);
+        void UpdateCurrentAccount(IUserAccount account);
 
         /// <summary>
         /// Updates the current project data from the given <paramref name="project"/>.

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/IUserAccount.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/IUserAccount.cs
@@ -1,11 +1,11 @@
-﻿// Copyright 2018 Google Inc. All Rights Reserved.
-// 
+﻿// Copyright 2016 Google Inc. All Rights Reserved.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,16 +13,17 @@
 // limitations under the License.
 
 using Google.Apis.Auth.OAuth2;
-using GoogleCloudExtension.DataSources;
 
-namespace GoogleCloudExtension.Utils
+namespace GoogleCloudExtension.Accounts
 {
-    public interface IDataSourceFactory
+    public interface IUserAccount
     {
-        ResourceManagerDataSource CreateResourceManagerDataSource();
+        string AccountName { get; }
+        string ClientId { get; }
+        string ClientSecret { get; }
+        string RefreshToken { get; }
+        string Type { get; }
 
-        IGPlusDataSource CreatePlusDataSource();
-
-        IGPlusDataSource CreatePlusDataSource(GoogleCredential credential);
+        GoogleCredential GetGoogleCredential();
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/UserAccount.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/UserAccount.cs
@@ -26,7 +26,7 @@ namespace GoogleCloudExtension.Accounts
     /// The serialize form can also be consumed as the "application default credentials" by apps using
     /// Google's client NuGet packages.
     /// </summary>
-    public class UserAccount
+    public class UserAccount : IUserAccount
     {
         [JsonProperty("account")]
         public string AccountName { get; set; }

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Accounts\CredentialsStore.cs" />
     <Compile Include="Accounts\CredentialsStoreException.cs" />
     <Compile Include="Accounts\DefaultCredentials.cs" />
+    <Compile Include="Accounts\IUserAccount.cs" />
     <Compile Include="Accounts\IWindowsCredentialsStore.cs" />
     <Compile Include="AddTrafficSplit\AddTrafficSplitResult.cs" />
     <Compile Include="AddTrafficSplit\AddTrafficSplitViewModel.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
@@ -30,11 +30,11 @@ namespace GoogleCloudExtension.ManageAccounts
 
         public string AccountName { get; }
 
-        public UserAccount UserAccount { get; }
+        public IUserAccount UserAccount { get; }
 
         public bool IsCurrentAccount => CredentialsStore.Default.CurrentAccount?.AccountName == UserAccount.AccountName;
 
-        public UserAccountViewModel(UserAccount userAccount)
+        public UserAccountViewModel(IUserAccount userAccount)
         {
             UserAccount = userAccount;
 
@@ -43,8 +43,8 @@ namespace GoogleCloudExtension.ManageAccounts
             Task<Person> personTask;
             try
             {
-                var dataSource = new GPlusDataSource(
-                    userAccount.GetGoogleCredential(), GoogleCloudExtensionPackage.VersionedApplicationName);
+                var dataSourceFactory = GoogleCloudExtensionPackage.Instance.GetService<IDataSourceFactory>();
+                IGPlusDataSource dataSource = dataSourceFactory.CreatePlusDataSource(userAccount.GetGoogleCredential());
                 personTask = dataSource.GetProfileAsync();
             }
             catch (Exception)

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
@@ -17,10 +17,8 @@ using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Async;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Threading.Tasks;
-using Task = System.Threading.Tasks.Task;
 
 namespace GoogleCloudExtension.ManageAccounts
 {
@@ -49,10 +47,8 @@ namespace GoogleCloudExtension.ManageAccounts
                 IGPlusDataSource dataSource = dataSourceFactory.CreatePlusDataSource(userAccount.GetGoogleCredential());
                 personTask = dataSource.GetProfileAsync();
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                GoogleCloudExtensionPackage.Instance.GetService<SVsActivityLog, IVsActivityLog>().LogEntry(
-                    (uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, nameof(UserAccountViewModel), e.Message);
                 personTask = Task.FromResult<Person>(null);
             }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.Plus.v1.Data;
 using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Async;
+using System;
+using System.Threading.Tasks;
 
 namespace GoogleCloudExtension.ManageAccounts
 {
@@ -37,8 +40,18 @@ namespace GoogleCloudExtension.ManageAccounts
 
             AccountName = userAccount.AccountName;
 
-            var dataSource = new GPlusDataSource(userAccount.GetGoogleCredential(), GoogleCloudExtensionPackage.VersionedApplicationName);
-            var personTask = dataSource.GetProfileAsync();
+            Task<Person> personTask;
+            try
+            {
+                var dataSource = new GPlusDataSource(
+                    userAccount.GetGoogleCredential(), GoogleCloudExtensionPackage.VersionedApplicationName);
+                personTask = dataSource.GetProfileAsync();
+            }
+            catch (Exception)
+            {
+                personTask = Task.FromResult<Person>(null);
+            }
+
 
             // TODO: Show the default image while it is being loaded.
             ProfilePictureAsync = AsyncPropertyUtils.CreateAsyncProperty(personTask, x => x?.Image.Url);

--- a/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ManageAccounts/UserAccountViewModel.cs
@@ -17,8 +17,10 @@ using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.Utils;
 using GoogleCloudExtension.Utils.Async;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Threading.Tasks;
+using Task = System.Threading.Tasks.Task;
 
 namespace GoogleCloudExtension.ManageAccounts
 {
@@ -47,8 +49,10 @@ namespace GoogleCloudExtension.ManageAccounts
                 IGPlusDataSource dataSource = dataSourceFactory.CreatePlusDataSource(userAccount.GetGoogleCredential());
                 personTask = dataSource.GetProfileAsync();
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                GoogleCloudExtensionPackage.Instance.GetService<SVsActivityLog, IVsActivityLog>().LogEntry(
+                    (uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, nameof(UserAccountViewModel), e.Message);
                 personTask = Task.FromResult<Person>(null);
             }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/DataSourceFactory.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/DataSourceFactory.cs
@@ -16,19 +16,18 @@ using Google.Apis.Auth.OAuth2;
 using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using System;
+using System.ComponentModel.Composition;
 
 namespace GoogleCloudExtension.Utils
 {
     /// <summary>
     ///  Holder of data source factory methods.
     /// </summary>
+    [Export(typeof(IDataSourceFactory))]
     public class DataSourceFactory : IDataSourceFactory
     {
-        private static readonly Lazy<DataSourceFactory> s_lazyDefault = new Lazy<DataSourceFactory>(() => new DataSourceFactory());
-        internal static IDataSourceFactory DefaultOverride { private get; set; } = null;
-        public static IDataSourceFactory Default => DefaultOverride ?? s_lazyDefault.Value;
-
-        private DataSourceFactory() { }
+        [Obsolete("This makes a call to MEF every time. Instead, import IDataSourceFactory from MEF and save to an instance member.")]
+        public static IDataSourceFactory Default => GoogleCloudExtensionPackage.Instance.GetService<IDataSourceFactory>();
 
         public ResourceManagerDataSource CreateResourceManagerDataSource()
         {
@@ -47,9 +46,14 @@ namespace GoogleCloudExtension.Utils
         public IGPlusDataSource CreatePlusDataSource()
         {
             GoogleCredential currentCredential = CredentialsStore.Default.CurrentGoogleCredential;
-            if (currentCredential != null)
+            return CreatePlusDataSource(currentCredential);
+        }
+
+        public IGPlusDataSource CreatePlusDataSource(GoogleCredential credential)
+        {
+            if (credential != null)
             {
-                return new GPlusDataSource(currentCredential, GoogleCloudExtensionPackage.VersionedApplicationName);
+                return new GPlusDataSource(credential, GoogleCloudExtensionPackage.VersionedApplicationName);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/DataSourceFactory.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/DataSourceFactory.cs
@@ -53,7 +53,7 @@ namespace GoogleCloudExtension.Utils
         {
             if (credential != null)
             {
-                return new GPlusDataSource(currentCredential, GoogleCloudExtensionPackage.Instance.VersionedApplicationName);
+                return new GPlusDataSource(credential, GoogleCloudExtensionPackage.Instance.VersionedApplicationName);
             }
             else
             {

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ExtensionTestBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ExtensionTestBase.cs
@@ -35,15 +35,14 @@ namespace GoogleCloudExtensionUnitTests
         public void IntializeGlobalsForTest()
         {
             CredentialsStore.CreateNewOverride();
-            PackageMock = new Mock<IGoogleCloudExtensionPackage>(MockBehavior.Strict);
+            PackageMock = new Mock<IGoogleCloudExtensionPackage> { DefaultValue = DefaultValue.Mock };
             GoogleCloudExtensionPackage.Instance = PackageMock.Object;
 
             PackageMock.Setup(p => p.VsVersion).Returns(VsVersionUtils.VisualStudio2017Version);
             PromptUserMock = new Mock<Func<UserPromptWindow.Options, bool>>();
             UserPromptUtils.PromptUserOverride = PromptUserMock.Object;
 
-            DataSourceFactoryMock = new Mock<IDataSourceFactory>();
-            DataSourceFactory.DefaultOverride = DataSourceFactoryMock.Object;
+            DataSourceFactoryMock = Mock.Get(GoogleCloudExtensionPackage.Instance.GetService<IDataSourceFactory>());
             EventsReporterWrapper.DisableReporting();
             BeforeEach();
         }
@@ -56,7 +55,6 @@ namespace GoogleCloudExtensionUnitTests
             AfterEach();
             UserPromptUtils.PromptUserOverride = null;
             GoogleCloudExtensionPackage.Instance = null;
-            DataSourceFactory.DefaultOverride = null;
             CredentialsStore.ClearOverride();
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -251,6 +251,7 @@
     <Compile Include="Analytics\EventsReporterWrapperTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="GoogleCloudExtensionPackageTests.cs" />
+    <Compile Include="ManageAccounts\UserAccountViewModelTests.cs" />
     <Compile Include="MockedGlobalServiceProviderTestsBase.cs" />
     <Compile Include="Options\AnalyticsOptionsTests.cs" />
     <Compile Include="Options\AnalyticsOptionsPageViewModelTests.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
@@ -17,6 +17,7 @@ using Google.Apis.Plus.v1.Data;
 using GoogleCloudExtension;
 using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.ManageAccounts;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -99,6 +100,20 @@ namespace GoogleCloudExtensionUnitTests.ManageAccounts
 
             Assert.IsTrue(objectUnderTest.NameAsync.IsCompleted);
             Assert.IsNull(objectUnderTest.NameAsync.Value);
+        }
+
+        [TestMethod]
+        public void TestConstructor_LogsToActivityLogForExceptionCreatingDataSource()
+        {
+            var exceptionMessage = "exception message";
+            DataSourceFactoryMock.Setup(dsf => dsf.CreatePlusDataSource(It.IsAny<GoogleCredential>()))
+                .Throws(new Exception(exceptionMessage));
+
+            _ = new UserAccountViewModel(s_defaultUserAccount);
+
+            Mock.Get(GoogleCloudExtensionPackage.Instance.GetService<SVsActivityLog, IVsActivityLog>()).Verify(
+                al => al.LogEntry(
+                    (uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, nameof(UserAccountViewModel), exceptionMessage));
         }
 
         [TestMethod]

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
@@ -144,7 +144,7 @@ namespace GoogleCloudExtensionUnitTests.ManageAccounts
             var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
 
             _getProfileTaskSource.SetResult(new Person { DisplayName = profileDisplayName });
-            await objectUnderTest.ProfilePictureAsync.SafeTask;
+            await objectUnderTest.NameAsync.SafeTask;
 
             Assert.AreEqual(profileDisplayName, objectUnderTest.NameAsync.Value);
         }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
@@ -17,7 +17,6 @@ using Google.Apis.Plus.v1.Data;
 using GoogleCloudExtension;
 using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.ManageAccounts;
-using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -100,20 +99,6 @@ namespace GoogleCloudExtensionUnitTests.ManageAccounts
 
             Assert.IsTrue(objectUnderTest.NameAsync.IsCompleted);
             Assert.IsNull(objectUnderTest.NameAsync.Value);
-        }
-
-        [TestMethod]
-        public void TestConstructor_LogsToActivityLogForExceptionCreatingDataSource()
-        {
-            var exceptionMessage = "exception message";
-            DataSourceFactoryMock.Setup(dsf => dsf.CreatePlusDataSource(It.IsAny<GoogleCredential>()))
-                .Throws(new Exception(exceptionMessage));
-
-            _ = new UserAccountViewModel(s_defaultUserAccount);
-
-            Mock.Get(GoogleCloudExtensionPackage.Instance.GetService<SVsActivityLog, IVsActivityLog>()).Verify(
-                al => al.LogEntry(
-                    (uint)__ACTIVITYLOG_ENTRYTYPE.ALE_ERROR, nameof(UserAccountViewModel), exceptionMessage));
         }
 
         [TestMethod]

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/ManageAccounts/UserAccountViewModelTests.cs
@@ -1,0 +1,152 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Plus.v1.Data;
+using GoogleCloudExtension;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.ManageAccounts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Threading.Tasks;
+
+namespace GoogleCloudExtensionUnitTests.ManageAccounts
+{
+    [TestClass]
+    public class UserAccountViewModelTests : ExtensionTestBase
+    {
+        private TaskCompletionSource<Person> _getProfileTaskSource;
+
+        private static readonly UserAccount s_defaultUserAccount = new UserAccount
+        {
+            AccountName = "DefaultName",
+            ClientId = "default-client-id",
+            ClientSecret = "DefaultSecret",
+            RefreshToken = "DefautRefreshToken"
+        };
+
+        protected override void BeforeEach()
+        {
+            _getProfileTaskSource = new TaskCompletionSource<Person>();
+            DataSourceFactoryMock.Setup(dsf => dsf.CreatePlusDataSource(It.IsAny<GoogleCredential>()).GetProfileAsync())
+                .Returns(_getProfileTaskSource.Task);
+        }
+
+
+        [TestMethod]
+        public void TestConstructor_SetsUserAccount()
+        {
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+
+            Assert.AreEqual(s_defaultUserAccount, objectUnderTest.UserAccount);
+        }
+
+        [TestMethod]
+        public void TestConstructor_SetsAccountName()
+        {
+            const string testAccountName = "TestAccountName";
+            var userAccount = new UserAccount { AccountName = testAccountName };
+
+            var objectUnderTest = new UserAccountViewModel(userAccount);
+
+            Assert.AreEqual(testAccountName, objectUnderTest.AccountName);
+        }
+
+        [TestMethod]
+        public void TestConstructor_GetsDataSourceFromGivenAccountCredential()
+        {
+            GoogleCredential expectedCredential = s_defaultUserAccount.GetGoogleCredential();
+            var mockedUserAccount = Mock.Of<IUserAccount>(a => a.GetGoogleCredential() == expectedCredential);
+
+            _ = new UserAccountViewModel(mockedUserAccount);
+
+            DataSourceFactoryMock.Verify(dsf => dsf.CreatePlusDataSource(expectedCredential));
+        }
+
+        [TestMethod]
+        public async Task TestConstructor_ReturnsNullProfilePictureForExceptionCreatingDataSource()
+        {
+            DataSourceFactoryMock.Setup(dsf => dsf.CreatePlusDataSource(It.IsAny<GoogleCredential>()))
+                .Throws<Exception>();
+
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+            await objectUnderTest.ProfilePictureAsync.SafeTask;
+
+            Assert.IsTrue(objectUnderTest.ProfilePictureAsync.IsCompleted);
+            Assert.IsNull(objectUnderTest.ProfilePictureAsync.Value);
+        }
+
+        [TestMethod]
+        public async Task TestConstructor_ReturnsNullNameForExceptionCreatingDataSource()
+        {
+            DataSourceFactoryMock.Setup(dsf => dsf.CreatePlusDataSource(It.IsAny<GoogleCredential>()))
+                .Throws<Exception>();
+
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+            await objectUnderTest.NameAsync.SafeTask;
+
+            Assert.IsTrue(objectUnderTest.NameAsync.IsCompleted);
+            Assert.IsNull(objectUnderTest.NameAsync.Value);
+        }
+
+        [TestMethod]
+        public void TestConstructor_StartsLoadingProfilePicture()
+        {
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+
+            Assert.IsTrue(objectUnderTest.ProfilePictureAsync.IsPending);
+        }
+
+        [TestMethod]
+        public void TestConstructor_StartsLoadingName()
+        {
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+
+            Assert.IsTrue(objectUnderTest.NameAsync.IsPending);
+        }
+
+        [TestMethod]
+        public void TestConstructor_ShowsDefaultNameWhileLoading()
+        {
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+
+            Assert.AreEqual(Resources.CloudExplorerLoadingMessage, objectUnderTest.NameAsync.Value);
+        }
+
+        [TestMethod]
+        public async Task TestConstructor_LoadsProfilePictureUrl()
+        {
+            const string profilePictureUrl = "profile-picture-url";
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+
+            _getProfileTaskSource.SetResult(new Person { Image = new Person.ImageData { Url = profilePictureUrl } });
+            await objectUnderTest.ProfilePictureAsync.SafeTask;
+
+            Assert.AreEqual(profilePictureUrl, objectUnderTest.ProfilePictureAsync.Value);
+        }
+
+        [TestMethod]
+        public async Task TestConstructor_LoadsName()
+        {
+            const string profileDisplayName = "Profile Display Name";
+            var objectUnderTest = new UserAccountViewModel(s_defaultUserAccount);
+
+            _getProfileTaskSource.SetResult(new Person { DisplayName = profileDisplayName });
+            await objectUnderTest.ProfilePictureAsync.SafeTask;
+
+            Assert.AreEqual(profileDisplayName, objectUnderTest.NameAsync.Value);
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/DataSourceFactoryTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/DataSourceFactoryTests.cs
@@ -25,9 +25,11 @@ namespace GoogleCloudExtensionUnitTests.Utils
     [TestClass]
     public class DataSourceFactoryTests : ExtensionTestBase
     {
+        private IDataSourceFactory _objectUnderTest;
+
         protected override void BeforeEach()
         {
-            DataSourceFactory.DefaultOverride = null;
+            _objectUnderTest = new DataSourceFactory();
         }
 
         [TestMethod]
@@ -35,17 +37,17 @@ namespace GoogleCloudExtensionUnitTests.Utils
         {
             CredentialsStore.Default.UpdateCurrentAccount(null);
 
-            ResourceManagerDataSource result = DataSourceFactory.Default.CreateResourceManagerDataSource();
+            ResourceManagerDataSource result = _objectUnderTest.CreateResourceManagerDataSource();
 
             Assert.IsNull(result);
         }
 
         [TestMethod]
-        public void TestCreatePlusDataSource_ReturnsNullForNoCredentials()
+        public void Test0ArgCreatePlusDataSource_ReturnsNullForNoCredentials()
         {
             CredentialsStore.Default.UpdateCurrentAccount(null);
 
-            IGPlusDataSource result = DataSourceFactory.Default.CreatePlusDataSource();
+            IGPlusDataSource result = _objectUnderTest.CreatePlusDataSource();
 
             Assert.IsNull(result);
         }
@@ -62,7 +64,7 @@ namespace GoogleCloudExtensionUnitTests.Utils
             };
             CredentialsStore.Default.UpdateCurrentAccount(userAccount);
 
-            ResourceManagerDataSource result = DataSourceFactory.Default.CreateResourceManagerDataSource();
+            ResourceManagerDataSource result = _objectUnderTest.CreateResourceManagerDataSource();
 
             var googleCredential = (GoogleCredential)result.Service.HttpClientInitializer;
             var userCredential = (UserCredential)googleCredential.UnderlyingCredential;
@@ -74,7 +76,7 @@ namespace GoogleCloudExtensionUnitTests.Utils
         }
 
         [TestMethod]
-        public void TestCreatePlusDataSource_Returns()
+        public void Test0ArgCreatePlusDataSource_Returns()
         {
             var userAccount = new UserAccount
             {
@@ -86,7 +88,7 @@ namespace GoogleCloudExtensionUnitTests.Utils
             CredentialsStore.Default.UpdateCurrentAccount(
                 userAccount);
 
-            IGPlusDataSource result = DataSourceFactory.Default.CreatePlusDataSource();
+            IGPlusDataSource result = _objectUnderTest.CreatePlusDataSource();
 
             var dataSource = (GPlusDataSource)result;
             var googleCredential = (GoogleCredential)dataSource.Service.HttpClientInitializer;
@@ -96,6 +98,37 @@ namespace GoogleCloudExtensionUnitTests.Utils
             Assert.AreEqual(userAccount.ClientId, flow.ClientSecrets.ClientId);
             Assert.AreEqual(userAccount.RefreshToken, userCredential.Token.RefreshToken);
             Assert.AreEqual(GoogleCloudExtensionPackage.VersionedApplicationName, dataSource.Service.ApplicationName);
+        }
+
+        [TestMethod]
+        public void Test1ArgCreatePlusDataSource_Returns()
+        {
+            var userAccount = new UserAccount
+            {
+                AccountName = "TestAccountName",
+                ClientId = "TestClientId",
+                ClientSecret = "TestClientSecret",
+                RefreshToken = "TestRefreshToken"
+            };
+
+            IGPlusDataSource result = _objectUnderTest.CreatePlusDataSource(userAccount.GetGoogleCredential());
+
+            var dataSource = (GPlusDataSource)result;
+            var googleCredential = (GoogleCredential)dataSource.Service.HttpClientInitializer;
+            var userCredential = (UserCredential)googleCredential.UnderlyingCredential;
+            var flow = (GoogleAuthorizationCodeFlow)userCredential.Flow;
+            Assert.AreEqual(userAccount.ClientSecret, flow.ClientSecrets.ClientSecret);
+            Assert.AreEqual(userAccount.ClientId, flow.ClientSecrets.ClientId);
+            Assert.AreEqual(userAccount.RefreshToken, userCredential.Token.RefreshToken);
+            Assert.AreEqual(GoogleCloudExtensionPackage.VersionedApplicationName, dataSource.Service.ApplicationName);
+        }
+
+        [TestMethod]
+        public void Test1ArgCreatePlusDataSource_ReturnsNullForNoCredentials()
+        {
+            IGPlusDataSource result = _objectUnderTest.CreatePlusDataSource(null);
+
+            Assert.IsNull(result);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/DataSourceFactoryTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/DataSourceFactoryTests.cs
@@ -97,7 +97,7 @@ namespace GoogleCloudExtensionUnitTests.Utils
             Assert.AreEqual(userAccount.ClientSecret, flow.ClientSecrets.ClientSecret);
             Assert.AreEqual(userAccount.ClientId, flow.ClientSecrets.ClientId);
             Assert.AreEqual(userAccount.RefreshToken, userCredential.Token.RefreshToken);
-            Assert.AreEqual(GoogleCloudExtensionPackage.VersionedApplicationName, dataSource.Service.ApplicationName);
+            Assert.AreEqual(GoogleCloudExtensionPackage.Instance.VersionedApplicationName, dataSource.Service.ApplicationName);
         }
 
         [TestMethod]


### PR DESCRIPTION
These changes keep the User Account dialog window from crashing when there are invalid credentials files stored on the computer, and enable recovery from a state where there is an invalid file for a user.