### PR TITLE
Fix flakey PowerShell test.

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/RemotePowerShellUtilsTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/RemotePowerShellUtilsTests.cs
@@ -33,8 +33,6 @@ namespace GoogleCloudExtension.PowerShellUtils.Tests
         private const string DefaultUser = "DefaultUser";
         private const string DefaultPassword = "DefaultPassword";
 
-        public TestContext TestContext { get; set; }
-
         [TestMethod]
         public void TestGetEmbeddedFile_ThrowsForUnknownFile()
         {
@@ -94,6 +92,8 @@ namespace GoogleCloudExtension.PowerShellUtils.Tests
         {
             using (PowerShell powerShell = PowerShell.Create())
             {
+                powerShell.AddScript("Start-Sleep -Seconds 30");
+
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
                     () => powerShell.InvokeAsync(new CancellationToken(true)));
 

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/RemotePowerShellUtilsTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/RemotePowerShellUtilsTests.cs
@@ -92,6 +92,8 @@ namespace GoogleCloudExtension.PowerShellUtils.Tests
         {
             using (PowerShell powerShell = PowerShell.Create())
             {
+                // PowerShell can not start without a command to execute.
+                // Adding this script helps avoid false positives.
                 powerShell.AddScript("Start-Sleep -Seconds 30");
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(


### PR DESCRIPTION
Don't register `powershell.Stop` with the CancellationToken until powershell is actually running.

Fixes #1025 