### PR TITLE
Remove CredentialsStore.Reset

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/DataSourceBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/DataSourceBase.cs
@@ -28,7 +28,7 @@ namespace GoogleCloudExtension.DataSources
     /// the common routines that most source will need, such as pagination.
     /// </summary>
     /// <typeparam name="TService">The type of the service that ultimately performs the API calls.</typeparam>
-    public abstract class DataSourceBase<TService> where TService : BaseClientService
+    public abstract class DataSourceBase<TService> : IDataSourceBase<TService> where TService : BaseClientService
     {
         /// <summary>
         /// The projects/{ProjectId} string commonly used by Google Cloud APIs as project name.

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/GoogleCloudExtension.DataSources.csproj
@@ -123,6 +123,7 @@
     <Compile Include="DataSourceBase.cs" />
     <Compile Include="DataSourceException.cs" />
     <Compile Include="GaeLocationExtensions.cs" />
+    <Compile Include="IDataSourceBase.cs" />
     <Compile Include="IGaeDataSource.cs" />
     <Compile Include="IGceDataSource.cs" />
     <Compile Include="IGkeDataSource.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/IDataSourceBase.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/IDataSourceBase.cs
@@ -1,32 +1,26 @@
 ﻿// Copyright 2018 Google Inc. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Google.Apis.Auth.OAuth2;
-using GoogleCloudExtension.DataSources;
+using Google.Apis.Services;
 
-namespace GoogleCloudExtension.Utils
+namespace GoogleCloudExtension.DataSources
 {
-    public interface IDataSourceFactory
+    public interface IDataSourceBase<out TService> where TService : BaseClientService
     {
-        IResourceManagerDataSource CreateResourceManagerDataSource();
-
-        IGPlusDataSource CreatePlusDataSource();
-
-        IGPlusDataSource CreatePlusDataSource(GoogleCredential credential);
-
-        IGkeDataSource CreateGkeDataSource();
-
-        //TODO(jimwp) Add GCE and GAE data sources.
+        /// <summary>
+        /// The service wrapped by this data source.
+        /// </summary>
+        TService Service { get; }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension.DataSources/IResourceManagerDataSource.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.DataSources/IResourceManagerDataSource.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.CloudResourceManager.v1.Data;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace GoogleCloudExtension.DataSources
     /// <summary>
     /// The interface of the ResourceManagerDataSource. Mock this object in unit tests.
     /// </summary>
-    public interface IResourceManagerDataSource
+    public interface IResourceManagerDataSource : IDataSourceBase<CloudResourceManagerService>
     {
         /// <summary>
         /// Returns the project given its <paramref name="projectId"/>.

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
@@ -146,9 +146,9 @@ namespace GoogleCloudExtension.Accounts
                 CurrentProjectId = null;
                 CurrentProjectNumericId = null;
 
-                InvalidateProjectList();
-
+                RefreshProjects();
                 UpdateDefaultCredentials();
+
                 CurrentAccountChanged?.Invoke(this, EventArgs.Empty);
                 CurrentProjectIdChanged?.Invoke(this, EventArgs.Empty);
             }
@@ -179,18 +179,11 @@ namespace GoogleCloudExtension.Accounts
                 CurrentProjectNumericId = null;
             }
 
-            InvalidateProjectList();
+            RefreshProjects();
+            UpdateDefaultCredentials();
 
             CurrentAccountChanged?.Invoke(this, EventArgs.Empty);
             CurrentProjectIdChanged?.Invoke(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Refreshes the list of projects for the current account.
-        /// </summary>
-        public void RefreshProjects()
-        {
-            InvalidateProjectList();
         }
 
         /// <summary>
@@ -247,7 +240,7 @@ namespace GoogleCloudExtension.Accounts
             return result?.UserAccount;
         }
 
-        private void InvalidateProjectList()
+        public void RefreshProjects()
         {
             Debug.WriteLine("Starting to load projects.");
             CurrentAccountProjects = LoadCurrentAccountProjectsAsync();

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/CredentialsStore.cs
@@ -14,7 +14,7 @@
 
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1.Data;
-using GoogleCloudExtension.DataSources;
+using GoogleCloudExtension.Services.FileSystem;
 using GoogleCloudExtension.Utils;
 using Newtonsoft.Json;
 using System;
@@ -38,6 +38,9 @@ namespace GoogleCloudExtension.Accounts
     [Export(typeof(ICredentialsStore))]
     public class CredentialsStore : ICredentialsStore
     {
+        private readonly Lazy<IFileSystem> _fileSystem;
+        private readonly Lazy<IDataSourceFactory> _dataSourceFactory;
+
         /// <summary>
         /// Remembers the file name used to serialize a particular <see cref="UserAccount"/>.
         /// </summary>
@@ -45,11 +48,11 @@ namespace GoogleCloudExtension.Accounts
         {
             public string FileName { get; set; }
 
-            public UserAccount UserAccount { get; set; }
+            public IUserAccount UserAccount { get; set; }
         }
 
         private const string AccountsStorePath = @"googlecloudvsextension\accounts";
-        private const string DefaultCredentialsFileName = "default_credentials";
+        public const string DefaultCredentialsFileName = "default_credentials";
 
         private static readonly string s_credentialsStoreRoot = GetCredentialsStoreRoot();
 
@@ -59,7 +62,6 @@ namespace GoogleCloudExtension.Accounts
 
         public event EventHandler CurrentAccountChanged;
         public event EventHandler CurrentProjectIdChanged;
-        public event EventHandler Reset;
 
         /// <summary>
         /// The current <see cref="UserAccount"/> selected.
@@ -94,13 +96,22 @@ namespace GoogleCloudExtension.Accounts
         /// <summary>
         /// The list of accounts known to the store.
         /// </summary>
-        public IEnumerable<UserAccount> AccountsList => _cachedCredentials.Values.Select(x => x.UserAccount);
+        public IEnumerable<IUserAccount> AccountsList => _cachedCredentials.Values.Select(x => x.UserAccount);
 
-        private CredentialsStore()
+        private IFileSystem FileSystem => _fileSystem.Value;
+        private IDirectory Directory => FileSystem.Directory;
+        private IFile File => FileSystem.File;
+        private IDataSourceFactory DataSourceFactory => _dataSourceFactory.Value;
+
+        [ImportingConstructor]
+        public CredentialsStore(Lazy<IFileSystem> fileSystem, Lazy<IDataSourceFactory> dataSourceFactory)
         {
+            _fileSystem = fileSystem;
+            _dataSourceFactory = dataSourceFactory;
+
             _cachedCredentials = LoadAccounts();
 
-            var defaultCredentials = LoadDefaultCredentials();
+            DefaultCredentials defaultCredentials = LoadDefaultCredentials();
             if (defaultCredentials != null)
             {
                 ResetCredentials(defaultCredentials.AccountName, defaultCredentials.ProjectId);
@@ -139,13 +150,13 @@ namespace GoogleCloudExtension.Accounts
 
                 UpdateDefaultCredentials();
                 CurrentAccountChanged?.Invoke(this, EventArgs.Empty);
+                CurrentProjectIdChanged?.Invoke(this, EventArgs.Empty);
             }
         }
 
         /// <summary>
         /// Resets the credentials state to the account with the given <paramref name="accountName"/> and the
-        /// given <paramref name="projectId"/>. The <seealso cref="Reset"/> event will be raised to notify
-        /// listeners on this.
+        /// given <paramref name="projectId"/>.
         /// If <paramref name="accountName"/> cannot be found in the store then the credentials will be reset
         /// to empty.
         /// </summary>
@@ -153,7 +164,7 @@ namespace GoogleCloudExtension.Accounts
         /// <param name="projectId">The projectId to make current.</param>
         public void ResetCredentials(string accountName, string projectId)
         {
-            var newCurrentAccount = GetAccount(accountName);
+            IUserAccount newCurrentAccount = GetAccount(accountName);
             if (newCurrentAccount != null)
             {
                 CurrentAccount = newCurrentAccount;
@@ -167,9 +178,11 @@ namespace GoogleCloudExtension.Accounts
                 CurrentProjectId = null;
                 CurrentProjectNumericId = null;
             }
-            Reset?.Invoke(this, EventArgs.Empty);
 
             InvalidateProjectList();
+
+            CurrentAccountChanged?.Invoke(this, EventArgs.Empty);
+            CurrentProjectIdChanged?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -188,7 +201,7 @@ namespace GoogleCloudExtension.Accounts
         /// <returns>True if the current account was deleted, false otherwise.</returns>
         public void DeleteAccount(IUserAccount account)
         {
-            var accountFilePath = GetUserAccountPath(account.AccountName);
+            string accountFilePath = GetUserAccountPath(account.AccountName);
             if (accountFilePath == null)
             {
                 Debug.WriteLine($"Should not be here, unknown account name: {account.AccountName}");
@@ -196,7 +209,7 @@ namespace GoogleCloudExtension.Accounts
             }
 
             File.Delete(accountFilePath);
-            var isCurrentAccount = account.AccountName == CurrentAccount?.AccountName;
+            bool isCurrentAccount = account.AccountName == CurrentAccount?.AccountName;
             _cachedCredentials = LoadAccounts();
             if (isCurrentAccount)
             {
@@ -207,14 +220,14 @@ namespace GoogleCloudExtension.Accounts
         /// <summary>
         /// Stores a new set of user credentials in the credentials store.
         /// </summary>
-        public void AddAccount(UserAccount userAccount)
+        public void AddAccount(IUserAccount userAccount)
         {
             EnsureCredentialsRootExist();
-            var name = SaveUserAccount(userAccount);
+            string name = SaveUserAccount(userAccount);
             _cachedCredentials[userAccount.AccountName] = new StoredUserAccount
             {
                 FileName = name,
-                UserAccount = userAccount,
+                UserAccount = userAccount
             };
         }
 
@@ -223,15 +236,14 @@ namespace GoogleCloudExtension.Accounts
         /// </summary>
         /// <param name="accountName">The name to look.</param>
         /// <returns>The account if found, null otherwise.</returns>
-        public UserAccount GetAccount(string accountName)
+        public IUserAccount GetAccount(string accountName)
         {
             if (accountName == null)
             {
                 return null;
             }
 
-            StoredUserAccount result = null;
-            _cachedCredentials.TryGetValue(accountName, out result);
+            _cachedCredentials.TryGetValue(accountName, out StoredUserAccount result);
             return result?.UserAccount;
         }
 
@@ -245,10 +257,7 @@ namespace GoogleCloudExtension.Accounts
         {
             try
             {
-                var dataSource = new ResourceManagerDataSource(
-                    CurrentGoogleCredential,
-                    GoogleCloudExtensionPackage.Instance.VersionedApplicationName);
-                return await dataSource.GetProjectsListAsync();
+                return await DataSourceFactory.CreateResourceManagerDataSource().GetProjectsListAsync();
             }
             catch (Exception ex) when (!ErrorHandlerUtils.IsCriticalException(ex))
             {
@@ -258,15 +267,17 @@ namespace GoogleCloudExtension.Accounts
 
         private string GetUserAccountPath(string accountName)
         {
-            StoredUserAccount stored;
-            if (_cachedCredentials.TryGetValue(accountName, out stored))
+            if (_cachedCredentials.TryGetValue(accountName, out StoredUserAccount stored))
             {
                 return Path.Combine(s_credentialsStoreRoot, stored.FileName);
             }
-            return null;
+            else
+            {
+                return null;
+            }
         }
 
-        private static Dictionary<string, StoredUserAccount> LoadAccounts()
+        private Dictionary<string, StoredUserAccount> LoadAccounts()
         {
             Debug.WriteLine($"Listing credentials in directory: {s_credentialsStoreRoot}");
             if (!Directory.Exists(s_credentialsStoreRoot))
@@ -279,7 +290,7 @@ namespace GoogleCloudExtension.Accounts
                 .ToDictionary(x => x.UserAccount.AccountName);
         }
 
-        private static void EnsureCredentialsRootExist()
+        private void EnsureCredentialsRootExist()
         {
             if (Directory.Exists(s_credentialsStoreRoot))
             {
@@ -291,15 +302,15 @@ namespace GoogleCloudExtension.Accounts
 
         private static string GetCredentialsStoreRoot()
         {
-            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             return Path.Combine(localAppData, AccountsStorePath);
         }
 
-        private static UserAccount LoadUserAccount(string path)
+        private UserAccount LoadUserAccount(string path)
         {
             try
             {
-                var contents = AtomicFileRead(path);
+                string contents = File.ReadAllText(path);
                 return JsonConvert.DeserializeObject<UserAccount>(contents);
             }
             catch (JsonException ex)
@@ -314,12 +325,12 @@ namespace GoogleCloudExtension.Accounts
             }
         }
 
-        private static void SaveUserAccount(UserAccount userAccount, string path)
+        private void SaveUserAccount(IUserAccount userAccount, string path)
         {
             try
             {
-                var serialized = JsonConvert.SerializeObject(userAccount);
-                AtomicFileWrite(path, serialized);
+                string serialized = JsonConvert.SerializeObject(userAccount);
+                File.WriteAllText(path, serialized);
             }
             catch (IOException ex)
             {
@@ -328,21 +339,21 @@ namespace GoogleCloudExtension.Accounts
             }
         }
 
-        private static string SaveUserAccount(UserAccount userAccount)
+        private string SaveUserAccount(IUserAccount userAccount)
         {
-            var name = GetFileName(userAccount);
-            var savePath = Path.Combine(s_credentialsStoreRoot, name);
+            string name = GetFileName(userAccount);
+            string savePath = Path.Combine(s_credentialsStoreRoot, name);
             SaveUserAccount(userAccount, savePath);
             return name;
         }
 
-        private static string GetFileName(UserAccount userAccount)
+        private static string GetFileName(IUserAccount userAccount)
         {
-            var serialized = JsonConvert.SerializeObject(userAccount);
-            var sha1 = SHA1.Create();
-            var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(serialized));
+            string serialized = JsonConvert.SerializeObject(userAccount);
+            SHA1 sha1 = SHA1.Create();
+            byte[] hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(serialized));
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             foreach (byte b in hash)
             {
                 sb.AppendFormat("{0:x2}", b);
@@ -353,20 +364,19 @@ namespace GoogleCloudExtension.Accounts
 
         private void UpdateDefaultCredentials()
         {
-            var path = Path.Combine(s_credentialsStoreRoot, DefaultCredentialsFileName);
+            string path = Path.Combine(s_credentialsStoreRoot, DefaultCredentialsFileName);
 
             if (CurrentAccount?.AccountName != null)
             {
                 var defaultCredentials = new DefaultCredentials
                 {
                     ProjectId = CurrentProjectId,
-                    AccountName = CurrentAccount?.AccountName,
+                    AccountName = CurrentAccount.AccountName
                 };
 
                 try
                 {
-                    Debug.WriteLine($"Updating default account: {path}");
-                    AtomicFileWrite(path, JsonConvert.SerializeObject(defaultCredentials));
+                    File.WriteAllText(path, JsonConvert.SerializeObject(defaultCredentials));
                 }
                 catch (IOException ex)
                 {
@@ -389,7 +399,7 @@ namespace GoogleCloudExtension.Accounts
 
         private DefaultCredentials LoadDefaultCredentials()
         {
-            var path = Path.Combine(s_credentialsStoreRoot, DefaultCredentialsFileName);
+            string path = Path.Combine(s_credentialsStoreRoot, DefaultCredentialsFileName);
             if (!File.Exists(path))
             {
                 return null;
@@ -398,7 +408,7 @@ namespace GoogleCloudExtension.Accounts
             DefaultCredentials result = null;
             try
             {
-                var contents = AtomicFileRead(path);
+                string contents = File.ReadAllText(path);
                 result = JsonConvert.DeserializeObject<DefaultCredentials>(contents);
             }
             catch (JsonException ex)
@@ -410,40 +420,6 @@ namespace GoogleCloudExtension.Accounts
                 Debug.WriteLine($"Failed to read default credentials: {ex.Message}");
             }
             return result;
-        }
-
-        private static void AtomicFileWrite(string path, string contents)
-        {
-            try
-            {
-                using (var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
-                using (var stream = new StreamWriter(file))
-                {
-                    stream.Write(contents);
-                }
-            }
-            catch (IOException ex)
-            {
-                Debug.WriteLine($"Failed to write the file {path}: {ex.Message}");
-                throw;
-            }
-        }
-
-        private static string AtomicFileRead(string path)
-        {
-            try
-            {
-                using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-                using (var stream = new StreamReader(file))
-                {
-                    return stream.ReadToEnd();
-                }
-            }
-            catch (IOException ex)
-            {
-                Debug.WriteLine($"Failed to read the file {path}: {ex.Message}");
-                throw;
-            }
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Accounts/ICredentialsStore.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Accounts/ICredentialsStore.cs
@@ -25,7 +25,7 @@ namespace GoogleCloudExtension.Accounts
         /// <summary>
         /// The list of accounts known to the store.
         /// </summary>
-        IEnumerable<UserAccount> AccountsList { get; }
+        IEnumerable<IUserAccount> AccountsList { get; }
 
         /// <summary>
         /// The current <see cref="UserAccount"/> selected.
@@ -59,12 +59,11 @@ namespace GoogleCloudExtension.Accounts
 
         event EventHandler CurrentAccountChanged;
         event EventHandler CurrentProjectIdChanged;
-        event EventHandler Reset;
 
         /// <summary>
         /// Stores a new set of user credentials in the credentials store.
         /// </summary>
-        void AddAccount(UserAccount userAccount);
+        void AddAccount(IUserAccount userAccount);
 
         /// <summary>
         /// Deletes the <paramref name="account"/> from the store. The account must exist in the store
@@ -79,7 +78,7 @@ namespace GoogleCloudExtension.Accounts
         /// </summary>
         /// <param name="accountName">The name to look.</param>
         /// <returns>The account if found, null otherwise.</returns>
-        UserAccount GetAccount(string accountName);
+        IUserAccount GetAccount(string accountName);
 
         /// <summary>
         /// Refreshes the list of projects for the current account.

--- a/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/ApiManagement/ApiManager.cs
@@ -47,7 +47,6 @@ namespace GoogleCloudExtension.ApiManagement
         {
             CredentialsStore.Default.CurrentAccountChanged += OnCurrentCredentialsChanged;
             CredentialsStore.Default.CurrentProjectIdChanged += OnCurrentCredentialsChanged;
-            CredentialsStore.Default.Reset += OnCurrentCredentialsChanged;
             _dataSource = new Lazy<ServiceManagementDataSource>(CreateDataSource);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerToolWindow.cs
@@ -54,7 +54,6 @@ namespace GoogleCloudExtension.CloudExplorer
             };
 
             CredentialsStore.Default.CurrentAccountChanged += OnCurrentAccountChanged;
-            CredentialsStore.Default.Reset += OnCurrentAccountChanged;
 
             EventsReporterWrapper.ReportEvent(CloudExplorerInteractionEvent.Create());
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudExplorer/CloudExplorerViewModel.cs
@@ -48,7 +48,7 @@ namespace GoogleCloudExtension.CloudExplorer
         private AsyncProperty<string> _profilePictureAsync;
         private AsyncProperty<string> _profileNameAsync;
         private Project _currentProject;
-        private Lazy<ResourceManagerDataSource> _resourceManagerDataSource;
+        private Lazy<IResourceManagerDataSource> _resourceManagerDataSource;
         private Lazy<IGPlusDataSource> _plusDataSource;
         private string _emptyStateMessage;
         private string _emptyStateButtonCaption;
@@ -223,7 +223,6 @@ namespace GoogleCloudExtension.CloudExplorer
 
             CredentialsStore.Default.CurrentAccountChanged += OnCredentialsChanged;
             CredentialsStore.Default.CurrentProjectIdChanged += OnCredentialsChanged;
-            CredentialsStore.Default.Reset += OnCredentialsChanged;
 
             ErrorHandlerUtils.HandleExceptionsAsync(ResetCredentialsAsync);
         }
@@ -393,7 +392,7 @@ namespace GoogleCloudExtension.CloudExplorer
 
         private void InvalidateAccountDependentDataSources()
         {
-            _resourceManagerDataSource = new Lazy<ResourceManagerDataSource>(DataSourceFactory.Default.CreateResourceManagerDataSource);
+            _resourceManagerDataSource = new Lazy<IResourceManagerDataSource>(DataSourceFactory.Default.CreateResourceManagerDataSource);
             _plusDataSource = new Lazy<IGPlusDataSource>(DataSourceFactory.Default.CreatePlusDataSource);
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrReposViewModel.cs
@@ -367,7 +367,7 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         /// </summary>
         private async Task<IList<Project>> GetProjectsAsync()
         {
-            ResourceManagerDataSource resourceManager = DataSourceFactory.Default.CreateResourceManagerDataSource();
+            IResourceManagerDataSource resourceManager = DataSourceFactory.Default.CreateResourceManagerDataSource();
             if (resourceManager == null)
             {
                 return new List<Project>();

--- a/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrSectionControlViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/CloudSourceRepositories/CsrSectionControlViewModel.cs
@@ -95,7 +95,6 @@ namespace GoogleCloudExtension.CloudSourceRepositories
 
             _accountChangedHandler = (sender, e) => OnAccountChanged();
             CredentialsStore.Default.CurrentAccountChanged += _accountChangedHandler;
-            CredentialsStore.Default.Reset += _accountChangedHandler;
 
             if (CredentialsStore.Default.CurrentAccount == null)
             {
@@ -176,7 +175,6 @@ namespace GoogleCloudExtension.CloudSourceRepositories
         {
             if (_accountChangedHandler != null)
             {
-                CredentialsStore.Default.Reset -= _accountChangedHandler;
                 CredentialsStore.Default.CurrentAccountChanged -= _accountChangedHandler;
             }
         }

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtensionPackage.cs
@@ -286,7 +286,6 @@ namespace GoogleCloudExtension
             CheckInstallationStatus();
 
             // Ensure the commands UI state is updated when the GCP project changes.
-            CredentialsStore.Default.Reset += (o, e) => ShellUtils.InvalidateCommandsState();
             CredentialsStore.Default.CurrentProjectIdChanged += (o, e) => ShellUtils.InvalidateCommandsState();
 
             // With this setting we allow more concurrent connections from each HttpClient instance created

--- a/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IDirectory.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IDirectory.cs
@@ -31,5 +31,8 @@ namespace GoogleCloudExtension.Services.FileSystem
 
         /// <inheritdoc cref="Directory.CreateDirectory(string)"/>
         DirectoryInfo CreateDirectory(string path);
+
+        /// <inheritdoc cref="Directory.EnumerateFiles(string)"/>
+        IEnumerable<string> EnumerateFiles(string path);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IFile.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IFile.cs
@@ -18,7 +18,7 @@ using System.IO;
 namespace GoogleCloudExtension.Services.FileSystem
 {
     /// <summary>
-    /// Interface for a file service that matches the static members of <see cref="System.IO.File"/>.
+    /// Interface for a file service that matches the static members of <see cref="File"/>.
     /// </summary>
     public interface IFile
     {
@@ -42,5 +42,8 @@ namespace GoogleCloudExtension.Services.FileSystem
 
         /// <inheritdoc cref="File.Delete(string)"/>
         void Delete(string path);
+
+        /// <inheritdoc cref="File.ReadAllText(string)"/>
+        string ReadAllText(string path);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IODirectoryService.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IODirectoryService.cs
@@ -32,5 +32,8 @@ namespace GoogleCloudExtension.Services.FileSystem
 
         /// <inheritdoc cref="Directory.CreateDirectory(string)"/>
         public DirectoryInfo CreateDirectory(string path) => Directory.CreateDirectory(path);
+
+        /// <inheritdoc cref="Directory.EnumerateFiles(string)"/>
+        public IEnumerable<string> EnumerateFiles(string path) => Directory.EnumerateFiles(path);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IoFileService.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Services/FileSystem/IoFileService.cs
@@ -45,5 +45,8 @@ namespace GoogleCloudExtension.Services.FileSystem
 
         /// <inheritdoc cref="File.Delete(string)"/>
         public void Delete(string path) => File.Delete(path);
+
+        /// <inheritdoc cref="File.ReadAllText(string)"/>
+        public string ReadAllText(string path) => File.ReadAllText(path);
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingDetailViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingDetailViewModel.cs
@@ -181,7 +181,6 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
             OnAutoReloadCommand = new ProtectedCommand(() => ErrorHandlerUtils.HandleExceptionsAsync(UpdateGroupAndEventAsync));
             _datasource = new Lazy<IStackdriverErrorReportingDataSource>(CreateDataSource);
 
-            CredentialsStore.Default.Reset += OnCurrentProjectChanged;
             CredentialsStore.Default.CurrentProjectIdChanged += OnCurrentProjectChanged;
         }
 
@@ -191,7 +190,6 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
         public void Dispose()
         {
             OnAutoReloadCommand.CanExecuteCommand = false;
-            CredentialsStore.Default.Reset -= OnCurrentProjectChanged;
             CredentialsStore.Default.CurrentProjectIdChanged -= OnCurrentProjectChanged;
         }
 

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverErrorReporting/ErrorReportingViewModel.cs
@@ -168,7 +168,6 @@ namespace GoogleCloudExtension.StackdriverErrorReporting
             OnAutoReloadCommand = new ProtectedCommand(Reload);
 
             CredentialsStore.Default.CurrentProjectIdChanged += (sender, e) => OnProjectIdChanged();
-            CredentialsStore.Default.Reset += (sender, e) => OnProjectIdChanged();
         }
 
         /// <summary>

--- a/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindow.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/StackdriverLogsViewer/LogsViewerToolWindow.cs
@@ -64,7 +64,6 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             _content = new LogsViewerToolWindowControl();
 
             CredentialsStore.Default.CurrentProjectIdChanged += OnProjectIdChanged;
-            CredentialsStore.Default.Reset += OnProjectIdChanged;
 
             EventsReporterWrapper.ReportEvent(LogsViewerOpenEvent.Create());
         }
@@ -88,7 +87,6 @@ namespace GoogleCloudExtension.StackdriverLogsViewer
             base.OnClose();
             ViewModel?.Dispose();
             CredentialsStore.Default.CurrentProjectIdChanged -= OnProjectIdChanged;
-            CredentialsStore.Default.Reset -= OnProjectIdChanged;
         }
 
         private void CreateNewViewModel()

--- a/GoogleCloudExtension/GoogleCloudExtension/TitleBar/TitleBarViewModel.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/TitleBar/TitleBarViewModel.cs
@@ -57,7 +57,6 @@ namespace GoogleCloudExtension.TitleBar
         {
             OnGotoAccountManagementCommand = new ProtectedCommand(ManageAccountsWindow.PromptUser);
             CredentialsStore.Default.CurrentProjectIdChanged += (sender, e) => OnAccountProjectIdChanged();
-            CredentialsStore.Default.Reset += (sender, e) => OnAccountProjectIdChanged();
         }
 
         private void OnAccountProjectIdChanged()

--- a/GoogleCloudExtension/GoogleCloudExtension/Utils/DataSourceFactory.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/Utils/DataSourceFactory.cs
@@ -29,7 +29,7 @@ namespace GoogleCloudExtension.Utils
         [Obsolete("This makes a call to MEF every time. Instead, import IDataSourceFactory from MEF and save to an instance member.")]
         public static IDataSourceFactory Default => GoogleCloudExtensionPackage.Instance.GetMefService<IDataSourceFactory>();
 
-        public ResourceManagerDataSource CreateResourceManagerDataSource()
+        public IResourceManagerDataSource CreateResourceManagerDataSource()
         {
             GoogleCredential currentCredential = CredentialsStore.Default.CurrentGoogleCredential;
             if (currentCredential != null)

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Accounts/CredentialsStoreTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Accounts/CredentialsStoreTests.cs
@@ -1,0 +1,516 @@
+﻿// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.CloudResourceManager.v1.Data;
+using GoogleCloudExtension.Accounts;
+using GoogleCloudExtension.Services.FileSystem;
+using GoogleCloudExtension.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using TestingHelpers;
+
+namespace GoogleCloudExtensionUnitTests.Accounts
+{
+    [TestClass]
+    public class CredentialsStoreTests
+    {
+        private const string DefaultProjectId = "New Project Id";
+        private const string DefaultAccountName = "Default Account Name";
+        private CredentialsStore _objectUnderTest;
+        private Mock<IFileSystem> _fileSystemMock;
+        private Mock<Action<object, EventArgs>> _projectIdChangedHandlerMock;
+        private Mock<Action<object, EventArgs>> _accountChangedHandlerMock;
+        private IUserAccount _defaultUserAccount;
+        private Project _defaultProject;
+        private Mock<IDataSourceFactory> _dataSourceFactoryMock;
+        private TaskCompletionSource<IList<Project>> _getProjectsSource;
+
+        [TestInitialize]
+        public void BeforeEach()
+        {
+            _getProjectsSource = new TaskCompletionSource<IList<Project>>();
+            _defaultProject = new Project { ProjectId = DefaultProjectId };
+            _defaultUserAccount = Mock.Of<IUserAccount>(ua => ua.AccountName == DefaultAccountName);
+
+            _fileSystemMock = new Mock<IFileSystem> { DefaultValueProvider = DefaultValueProvider.Mock };
+            _dataSourceFactoryMock = new Mock<IDataSourceFactory>();
+            _dataSourceFactoryMock.Setup(dsf => dsf.CreateResourceManagerDataSource().GetProjectsListAsync())
+                .Returns(() => _getProjectsSource.Task);
+
+            _objectUnderTest = new CredentialsStore(_fileSystemMock.ToLazy(), _dataSourceFactoryMock.ToLazy());
+
+            _projectIdChangedHandlerMock = new Mock<Action<object, EventArgs>>();
+            _accountChangedHandlerMock = new Mock<Action<object, EventArgs>>();
+            _objectUnderTest.CurrentProjectIdChanged += new EventHandler(_projectIdChangedHandlerMock.Object);
+            _objectUnderTest.CurrentAccountChanged += new EventHandler(_accountChangedHandlerMock.Object);
+        }
+
+        [TestMethod]
+        public void TestConstructor_LoadsAccounts()
+        {
+            const string account1FilePath = "c:\\account1.json";
+            var account1 = new UserAccount { AccountName = "Account1" };
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystemMock.Setup(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()))
+                .Returns(new[] { account1FilePath });
+            _fileSystemMock.Setup(fs => fs.File.ReadAllText(account1FilePath))
+                .Returns(JsonConvert.SerializeObject(account1));
+
+            _objectUnderTest = new CredentialsStore(_fileSystemMock.ToLazy(), _dataSourceFactoryMock.ToLazy());
+
+            Assert.AreEqual(account1.AccountName, _objectUnderTest.GetAccount(account1.AccountName).AccountName);
+        }
+
+        [TestMethod]
+        public void TestConstructor_SkipsNonJsonFiles()
+        {
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+            const string notAccountFilePath = "c:\\notAnAccount.txt";
+            _fileSystemMock.Setup(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()))
+                .Returns(new[] { notAccountFilePath });
+
+            _objectUnderTest = new CredentialsStore(_fileSystemMock.ToLazy(), _dataSourceFactoryMock.ToLazy());
+
+            _fileSystemMock.Verify(fs => fs.File.ReadAllText(notAccountFilePath), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestConstructor_ThrowsCredentialsStoreExceptionForIOError()
+        {
+            const string account1FilePath = "c:\\account1.json";
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystemMock.Setup(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()))
+                .Returns(new[] { account1FilePath });
+            _fileSystemMock.Setup(fs => fs.File.ReadAllText(account1FilePath)).Throws<IOException>();
+
+            Assert.ThrowsException<CredentialsStoreException>(
+                () => new CredentialsStore(_fileSystemMock.ToLazy(), _dataSourceFactoryMock.ToLazy()));
+        }
+
+        [TestMethod]
+        public void TestConstructor_ThrowsCredentialsStoreExceptionForInvalidJson()
+        {
+            const string account1FilePath = "c:\\account1.json";
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystemMock.Setup(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()))
+                .Returns(new[] { account1FilePath });
+            _fileSystemMock.Setup(fs => fs.File.ReadAllText(account1FilePath)).Returns("This is not Json!");
+
+            Assert.ThrowsException<CredentialsStoreException>(
+                () => new CredentialsStore(_fileSystemMock.ToLazy(), _dataSourceFactoryMock.ToLazy()));
+        }
+
+        [TestMethod]
+        public void TestConstructor_ResetsCredentialsFromDefault()
+        {
+            const string account1Name = "Account1";
+            const string account1FilePath = "c:\\account1.json";
+            const string expectedProjectId = "Expected Project Id";
+            var account1 = new UserAccount { AccountName = account1Name };
+            var defaultCredentials =
+                new DefaultCredentials { AccountName = account1Name, ProjectId = expectedProjectId };
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystemMock.Setup(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()))
+                .Returns(new[] { account1FilePath });
+            _fileSystemMock.Setup(fs => fs.File.ReadAllText(account1FilePath))
+                .Returns(JsonConvert.SerializeObject(account1));
+            _fileSystemMock.Setup(fs => fs.File.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystemMock
+                .Setup(
+                    fs => fs.File.ReadAllText(
+                        It.Is<string>(
+                            s => s.EndsWith(CredentialsStore.DefaultCredentialsFileName, StringComparison.Ordinal))))
+                .Returns(
+                    JsonConvert.SerializeObject(
+                        defaultCredentials));
+
+            _objectUnderTest = new CredentialsStore(_fileSystemMock.ToLazy(), _dataSourceFactoryMock.ToLazy());
+
+            Assert.AreEqual(account1.AccountName, _objectUnderTest.CurrentAccount.AccountName);
+            Assert.AreEqual(expectedProjectId, _objectUnderTest.CurrentProjectId);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_SetsCurrentProjectId()
+        {
+            const string expectedProjectId = "Expected Project Id";
+
+            _objectUnderTest.UpdateCurrentProject(new Project { ProjectId = expectedProjectId });
+
+            Assert.AreEqual(expectedProjectId, _objectUnderTest.CurrentProjectId);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_SetsCurrentProjectNumber()
+        {
+            const int expectedProjectNumber = 10512;
+            _objectUnderTest.UpdateCurrentProject(
+                new Project { ProjectId = DefaultProjectId, ProjectNumber = expectedProjectNumber });
+
+            Assert.AreEqual(expectedProjectNumber.ToString(), _objectUnderTest.CurrentProjectNumericId);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_InvokesCurrentProjetIdChanged()
+        {
+
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+
+            _projectIdChangedHandlerMock.Verify(h => h(_objectUnderTest, EventArgs.Empty));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_WithNoUserAccountDeletesCredentials()
+        {
+            _objectUnderTest.UpdateCurrentAccount(null);
+
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+
+            _fileSystemMock.Verify(
+                fs => fs.File.Delete(
+                    It.Is<string>(
+                        s => s.EndsWith(CredentialsStore.DefaultCredentialsFileName, StringComparison.Ordinal))));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_WithUnNamedUserAccountDeletesCredentials()
+        {
+            _objectUnderTest.UpdateCurrentAccount(Mock.Of<IUserAccount>());
+
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+
+            _fileSystemMock.Verify(
+                fs => fs.File.Delete(
+                    It.Is<string>(
+                        s => s.EndsWith(CredentialsStore.DefaultCredentialsFileName, StringComparison.Ordinal))));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_NamedUserAccountWritesCredentials()
+        {
+
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+
+            _fileSystemMock.Verify(
+                fs => fs.File.WriteAllText(
+                    It.Is<string>(
+                        s => s.EndsWith(CredentialsStore.DefaultCredentialsFileName, StringComparison.Ordinal)),
+                    It.Is<string>(s => IsExpectedCredentialsJson(s, DefaultAccountName, DefaultProjectId))));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_DoesNothingForSameProject()
+        {
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+            Mock.Get(_fileSystemMock.Object.File).ResetCalls();
+            _projectIdChangedHandlerMock.ResetCalls();
+            _accountChangedHandlerMock.ResetCalls();
+
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+
+            _fileSystemMock.Verify(fs => fs.File.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _fileSystemMock.Verify(fs => fs.File.Delete(It.IsAny<string>()), Times.Never);
+            _projectIdChangedHandlerMock.Verify(f => f(It.IsAny<object>(), It.IsAny<EventArgs>()), Times.Never);
+            _accountChangedHandlerMock.Verify(f => f(It.IsAny<object>(), It.IsAny<EventArgs>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_UpdatesCurrentAccount()
+        {
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            Assert.AreEqual(_defaultUserAccount, _objectUnderTest.CurrentAccount);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_ClearsCurrentProjectId()
+        {
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            Assert.IsNull(_objectUnderTest.CurrentProjectId);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_ClearsNumericProjectId()
+        {
+            _objectUnderTest.UpdateCurrentProject(_defaultProject);
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            Assert.IsNull(_objectUnderTest.CurrentProjectNumericId);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_RaisesCurrentAccountChanged()
+        {
+
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            _accountChangedHandlerMock.Verify(f => f(_objectUnderTest, EventArgs.Empty));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_RaisesCurrentProjectIdChanged()
+        {
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            _projectIdChangedHandlerMock.Verify(f => f(_objectUnderTest, EventArgs.Empty));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_StartsCurrentAccountProjectsLoad()
+        {
+            Task<IEnumerable<Project>> originalTask = _objectUnderTest.CurrentAccountProjects;
+
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            Assert.AreNotEqual(originalTask, _objectUnderTest.CurrentAccountProjects);
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentAccount_UpdatesDefaultCredentials()
+        {
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(
+                fs => fs.File.WriteAllText(
+                    It.Is<string>(
+                        s => s.EndsWith(CredentialsStore.DefaultCredentialsFileName, StringComparison.Ordinal)),
+                    It.Is<string>(s => IsExpectedCredentialsJson(s, DefaultAccountName, null))));
+        }
+
+        [TestMethod]
+        public void TestUpdateCurrentProject_DoesNothingForSameAccount()
+        {
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+            Mock.Get(_fileSystemMock.Object.File).ResetCalls();
+            _projectIdChangedHandlerMock.ResetCalls();
+
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(fs => fs.File.WriteAllText(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _fileSystemMock.Verify(fs => fs.File.Delete(It.IsAny<string>()), Times.Never);
+            _projectIdChangedHandlerMock.Verify(f => f(It.IsAny<object>(), It.IsAny<EventArgs>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestResetCredentials_StartsCurrentAccountProjectsLoad()
+        {
+            Task<IEnumerable<Project>> originalTask = _objectUnderTest.CurrentAccountProjects;
+
+            _objectUnderTest.ResetCredentials(null, null);
+
+            Assert.AreNotEqual(originalTask, _objectUnderTest.CurrentAccountProjects);
+        }
+
+        [TestMethod]
+        public void TestResetCredentials_RaisesCurrentAccountChanged()
+        {
+
+            _objectUnderTest.ResetCredentials(null, null);
+
+            _accountChangedHandlerMock.Verify(f => f(_objectUnderTest, EventArgs.Empty));
+        }
+
+        [TestMethod]
+        public void TestResetCredentials_RaisesCurrentProjectIdChanged()
+        {
+
+            _objectUnderTest.ResetCredentials(null, null);
+
+            _projectIdChangedHandlerMock.Verify(f => f(_objectUnderTest, EventArgs.Empty));
+        }
+
+        [TestMethod]
+        public void TestResetCredentials_ClearsPropertiesForMissingAccount()
+        {
+            _objectUnderTest.ResetCredentials(DefaultAccountName, DefaultProjectId);
+
+            Assert.IsNull(_objectUnderTest.CurrentAccount);
+            Assert.IsNull(_objectUnderTest.CurrentProjectId);
+            Assert.IsNull(_objectUnderTest.CurrentProjectNumericId);
+        }
+
+        [TestMethod]
+        public void TestResetCredentials_SetsFieldsForExistingAccount()
+        {
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            _objectUnderTest.ResetCredentials(DefaultAccountName, DefaultProjectId);
+
+            Assert.AreEqual(_defaultUserAccount, _objectUnderTest.CurrentAccount);
+            Assert.AreEqual(DefaultProjectId, _objectUnderTest.CurrentProjectId);
+            Assert.IsNull(_objectUnderTest.CurrentProjectNumericId);
+        }
+
+        [TestMethod]
+        public void TestRefreshProjects_StartsCurrentAccountProjectsLoad()
+        {
+            Task<IEnumerable<Project>> originalTask = _objectUnderTest.CurrentAccountProjects;
+
+            _objectUnderTest.RefreshProjects();
+
+            Assert.AreNotEqual(originalTask, _objectUnderTest.CurrentAccountProjects);
+        }
+
+        [TestMethod]
+        public async Task TestCurrentAccountProjects_LoadsCurrentAccountProjects()
+        {
+            Project[] expectedResult = { new Project(), _defaultProject };
+
+            _objectUnderTest.RefreshProjects();
+            _getProjectsSource.SetResult(expectedResult);
+            IEnumerable<Project> results = await _objectUnderTest.CurrentAccountProjects;
+
+            CollectionAssert.AreEqual(expectedResult, results.ToList());
+        }
+
+        [TestMethod]
+        public async Task TestCurrentAccountProjects_GetsEmptyOnTaskException()
+        {
+            _objectUnderTest.RefreshProjects();
+            _getProjectsSource.SetException(new Exception());
+            IEnumerable<Project> results = await _objectUnderTest.CurrentAccountProjects;
+
+            CollectionAssert.That.IsEmpty(results);
+        }
+
+        [TestMethod]
+        public void TestDeleteAccount_ThrowExceptionForNonExistantAccount()
+        {
+            Assert.ThrowsException<InvalidOperationException>(
+                () => _objectUnderTest.DeleteAccount(_defaultUserAccount));
+        }
+
+        [TestMethod]
+        public void TestDeleteAccount_DeletesAccountFile()
+        {
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            _objectUnderTest.DeleteAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(fs => fs.File.Delete(It.IsAny<string>()));
+        }
+
+        [TestMethod]
+        public void TestDeleteAccount_ReloadsAccountCache()
+        {
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+            _fileSystemMock.Setup(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()))
+                .Returns(Enumerable.Empty<string>());
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            _objectUnderTest.DeleteAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(fs => fs.Directory.EnumerateFiles(It.IsAny<string>()));
+        }
+
+        [TestMethod]
+        public void TestDeleteAccount_ResetsCredentialsWhenCurrent()
+        {
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+            _objectUnderTest.UpdateCurrentAccount(_defaultUserAccount);
+
+            _objectUnderTest.DeleteAccount(_defaultUserAccount);
+
+            Assert.IsNull(_objectUnderTest.CurrentAccount);
+        }
+
+        [TestMethod]
+        public void TestAddAccount_CreatesCredentailsRootWhenMissing()
+        {
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(false);
+
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(fs => fs.Directory.CreateDirectory(It.IsAny<string>()));
+        }
+
+        [TestMethod]
+        public void TestAddAccount_SkipsCreatesCredentailsRootWhenExistant()
+        {
+            _fileSystemMock.Setup(fs => fs.Directory.Exists(It.IsAny<string>())).Returns(true);
+
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(fs => fs.Directory.CreateDirectory(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestAddAccount_SavesUserFile()
+        {
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            _fileSystemMock.Verify(
+                fs => fs.File.WriteAllText(It.IsAny<string>(), JsonConvert.SerializeObject(_defaultUserAccount)));
+        }
+
+        [TestMethod]
+        public void TestAddAccount_ThrowsCredentialsStoreExceptionForFileIOException()
+        {
+            _fileSystemMock.Setup(
+                fs => fs.File.WriteAllText(It.IsAny<string>(), It.IsAny<string>())).Throws<IOException>();
+
+            Assert.ThrowsException<CredentialsStoreException>(() => _objectUnderTest.AddAccount(_defaultUserAccount));
+        }
+
+        [TestMethod]
+        public void TestAddAccount_AddsAccount()
+        {
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            Assert.AreEqual(_defaultUserAccount, _objectUnderTest.GetAccount(_defaultUserAccount.AccountName));
+        }
+
+        [TestMethod]
+        public void TestGetAccount_ReturnsNullForNull()
+        {
+            IUserAccount result = _objectUnderTest.GetAccount(null);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void TestGetAccount_GetsNullForMissingAccount()
+        {
+            IUserAccount result = _objectUnderTest.GetAccount(DefaultAccountName);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void TestGetAccount_GetsAccount()
+        {
+            _objectUnderTest.AddAccount(_defaultUserAccount);
+
+            IUserAccount result = _objectUnderTest.GetAccount(_defaultUserAccount.AccountName);
+
+            Assert.AreEqual(_defaultUserAccount, result);
+        }
+
+        private static bool IsExpectedCredentialsJson(string s, string accountName, string projectId)
+        {
+            var credentials = JsonConvert.DeserializeObject<DefaultCredentials>(s);
+            return credentials.AccountName == accountName && credentials.ProjectId == projectId;
+        }
+    }
+}

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GoogleCloudExtensionUnitTests.csproj
@@ -230,6 +230,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Accounts\CredentialsStoreTests.cs" />
     <Compile Include="Accounts\WindowsCredentialsStoreTest.cs" />
     <Compile Include="AppEngineManagement\AppEngineManagementViewModelTests.cs" />
     <Compile Include="AssemblyInitialize.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Services/FileSystem/IODirectoryServiceTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Services/FileSystem/IODirectoryServiceTests.cs
@@ -15,6 +15,7 @@
 using GoogleCloudExtension.Services.FileSystem;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace GoogleCloudExtensionUnitTests.Services.FileSystem
@@ -23,7 +24,10 @@ namespace GoogleCloudExtensionUnitTests.Services.FileSystem
     [DeploymentItem(TestResourcesPath, TestResourcesPath)]
     public class IODirectoryServiceTests
     {
+        private const string TestResourcesParentPath = @"Services\FileSystem";
         private const string TestResourcesPath = @"Services\FileSystem\Resources";
+        private const string ExistingFilePath = @"Services\FileSystem\Resources\TestXmlFile.xml";
+        private const string TargetDirectoryPath = @"Services\FileSystem\Resources\TargetDirectory";
         private IODirectoryService _objectUnderTest;
 
         [TestInitialize]
@@ -47,9 +51,27 @@ namespace GoogleCloudExtensionUnitTests.Services.FileSystem
         [TestMethod]
         public void TestEnumerateDirectories()
         {
-            IEnumerable<string> results = _objectUnderTest.EnumerateDirectories(@"Services\FileSystem");
+            IEnumerable<string> results = _objectUnderTest.EnumerateDirectories(TestResourcesParentPath);
 
             CollectionAssert.AreEqual(new[] { TestResourcesPath }, results.ToList());
+        }
+
+        [TestMethod]
+        public void TestCreateDirectory()
+        {
+            DirectoryInfo result = _objectUnderTest.CreateDirectory(TargetDirectoryPath);
+
+            Assert.IsTrue(Directory.Exists(TargetDirectoryPath));
+            Assert.IsTrue(result.Exists);
+            StringAssert.EndsWith(result.FullName, TargetDirectoryPath);
+        }
+
+        [TestMethod]
+        public void TestEnumerateFiles()
+        {
+            IEnumerable<string> results = _objectUnderTest.EnumerateFiles(TestResourcesPath);
+
+            CollectionAssert.AreEqual(new[] { ExistingFilePath }, results.ToList());
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Services/FileSystem/IoFileServiceTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Services/FileSystem/IoFileServiceTests.cs
@@ -127,8 +127,19 @@ namespace GoogleCloudExtensionUnitTests.Services.FileSystem
             {
                 writer.Write("File Contents");
             }
+
             _objectUnderTest.Delete(TargetFilePath);
             Assert.IsFalse(File.Exists(TargetFilePath));
+        }
+
+        [TestMethod]
+        public void TestReadAllText()
+        {
+            string expectedResult = File.ReadAllText(TestXmlFilePath);
+
+            string result = _objectUnderTest.ReadAllText(TestXmlFilePath);
+
+            Assert.AreEqual(expectedResult, result);
         }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverErrorReporting/ErrorReportingDetailViewModelTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverErrorReporting/ErrorReportingDetailViewModelTests.cs
@@ -461,14 +461,6 @@ namespace GoogleCloudExtensionUnitTests.StackdriverErrorReporting
         }
 
         [TestMethod]
-        public void TestResetProjectId()
-        {
-            CredentialStoreMock.Raise(cs => cs.Reset += null, CredentialsStore.Default, null);
-
-            Assert.IsTrue(_objectUnderTest.IsAccountChanged);
-        }
-
-        [TestMethod]
         public void TestDisposeDisablesAutoReload()
         {
             _objectUnderTest.Dispose();
@@ -482,15 +474,6 @@ namespace GoogleCloudExtensionUnitTests.StackdriverErrorReporting
             _objectUnderTest.Dispose();
             CredentialStoreMock.Raise(
                 cs => cs.CurrentProjectIdChanged += null, CredentialsStore.Default, null);
-
-            Assert.IsFalse(_objectUnderTest.IsAccountChanged);
-        }
-
-        [TestMethod]
-        public void TestDisposeDisablesResetProjectId()
-        {
-            _objectUnderTest.Dispose();
-            CredentialStoreMock.Raise(cs => cs.Reset += null, CredentialsStore.Default, null);
 
             Assert.IsFalse(_objectUnderTest.IsAccountChanged);
         }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverLogsViewer/LogsViewerToolWindowTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/StackdriverLogsViewer/LogsViewerToolWindowTests.cs
@@ -50,17 +50,6 @@ namespace GoogleCloudExtensionUnitTests.StackdriverLogsViewer
         }
 
         [TestMethod]
-        public void TestProjectIdReset()
-        {
-            _objectUnderTest.Frame = _frameMock.Object;
-            ILogsViewerViewModel oldViewModel = _objectUnderTest.ViewModel;
-
-            CredentialStoreMock.Raise(cs => cs.Reset += null, CredentialsStore.Default, null);
-
-            Assert.AreNotEqual(oldViewModel, _objectUnderTest.ViewModel);
-        }
-
-        [TestMethod]
         public void TestCloseDisablesProjectIdChanged()
         {
             _objectUnderTest.Frame = _frameMock.Object;
@@ -69,18 +58,6 @@ namespace GoogleCloudExtensionUnitTests.StackdriverLogsViewer
             ((IVsWindowPane)_objectUnderTest).ClosePane();
             CredentialStoreMock.Raise(
                 cs => cs.CurrentProjectIdChanged += null, CredentialsStore.Default, null);
-
-            Assert.AreEqual(oldViewModel, _objectUnderTest.ViewModel);
-        }
-
-        [TestMethod]
-        public void TestCloseDisablesProjectIdReset()
-        {
-            _objectUnderTest.Frame = _frameMock.Object;
-            ILogsViewerViewModel oldViewModel = _objectUnderTest.ViewModel;
-
-            ((IVsWindowPane)_objectUnderTest).ClosePane();
-            CredentialStoreMock.Raise(cs => cs.Reset += null, CredentialsStore.Default, null);
 
             Assert.AreEqual(oldViewModel, _objectUnderTest.ViewModel);
         }

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/DataSourceFactoryTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/Utils/DataSourceFactoryTests.cs
@@ -19,7 +19,6 @@ using GoogleCloudExtension.Accounts;
 using GoogleCloudExtension.DataSources;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 
 namespace GoogleCloudExtensionUnitTests.Utils
 {
@@ -38,7 +37,7 @@ namespace GoogleCloudExtensionUnitTests.Utils
         {
             CredentialStoreMock.SetupGet(cs => cs.CurrentGoogleCredential).Returns(() => null);
 
-            ResourceManagerDataSource result = _objectUnderTest.CreateResourceManagerDataSource();
+            IResourceManagerDataSource result = _objectUnderTest.CreateResourceManagerDataSource();
 
             Assert.IsNull(result);
         }
@@ -66,7 +65,7 @@ namespace GoogleCloudExtensionUnitTests.Utils
             CredentialStoreMock.SetupGet(cs => cs.CurrentGoogleCredential)
                 .Returns(userAccount.GetGoogleCredential());
 
-            ResourceManagerDataSource result = _objectUnderTest.CreateResourceManagerDataSource();
+            IResourceManagerDataSource result = _objectUnderTest.CreateResourceManagerDataSource();
 
             var googleCredential = (GoogleCredential)result.Service.HttpClientInitializer;
             var userCredential = (UserCredential)googleCredential.UnderlyingCredential;


### PR DESCRIPTION
Make sure both `CurrentProjectIdChanged` and `CurrentAccountChanged` are called instead.
There were no cases in the code base where `Reset` was subscribed in a different way than at least one of those other events.
Add `CredentialsStoreTests`.

Fix #435 