### PR TITLE
Update licenses

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/GoogleCloudExtension.PowerShellUtils.Tests.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/GoogleCloudExtension.PowerShellUtils.Tests.csproj
@@ -47,7 +47,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+      <HintPath>..\packages\Microsoft.PowerShell.3.ReferenceAssemblies.1.0.0\lib\net4\System.Management.Automation.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -59,7 +59,10 @@
       <Link>Resources\InstallRemoteTool.ps1</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GoogleCloudExtension.PowerShellUtils\GoogleCloudExtension.PowerShellUtils.csproj">

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/app.config
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/app.config
@@ -15,6 +15,13 @@
     limitations under the License.
 -->
 
-<packages>
-  <package id="Microsoft.PowerShell.3.ReferenceAssemblies" version="1.0.0" targetFramework="net46" />
-</packages>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.PowerShell.3.ReferenceAssemblies" version="1.0.0" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.2.1" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.2.1" targetFramework="net461" />
-  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net461" />
 </packages>

--- a/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/GoogleCloudExtension.PowerShellUtils.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.PowerShellUtils/GoogleCloudExtension.PowerShellUtils.csproj
@@ -40,7 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+      <HintPath>..\packages\Microsoft.PowerShell.3.ReferenceAssemblies.1.0.0\lib\net4\System.Management.Automation.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -60,9 +60,7 @@
     <None Include="Key.snk" />
     <EmbeddedResource Include="Resources\InstallRemoteTool.ps1" />
     <EmbeddedResource Include="Resources\StartRemoteTool.ps1" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/GoogleCloudExtension.TemplateWizards.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension.TemplateWizards/GoogleCloudExtension.TemplateWizards.csproj
@@ -68,24 +68,7 @@
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6071\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.3.25407\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.7.27703\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.15.0.25415\lib\net45\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.11.0.15.0.25415\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.12.0.15.0.25415\lib\net45\Microsoft.VisualStudio.Shell.Immutable.12.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.15.0.25405\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6072\lib\net11\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
     </Reference>

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -816,21 +816,7 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.3.25407\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.7.27703\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.15.0.25415\lib\net45\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.11.0.15.0.25415\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.12.0.15.0.25415\lib\net45\Microsoft.VisualStudio.Shell.Immutable.12.0.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.15.0.25405\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6072\lib\net11\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
     </Reference>
@@ -895,7 +881,7 @@
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+      <HintPath>..\packages\Microsoft.PowerShell.3.ReferenceAssemblies.1.0.0\lib\net4\System.Management.Automation.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>

--- a/GoogleCloudExtension/GoogleCloudExtension/Licenses.txt
+++ b/GoogleCloudExtension/GoogleCloudExtension/Licenses.txt
@@ -1,4 +1,6 @@
-﻿BouncyCastle:
+﻿===============================================================================
+BouncyCastle (BouncyCastle.Crypto.dll)
+-------------------------------------------------------------------------------
 
 LICENSE
 Copyright (c) 2000 - 2015 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
@@ -9,13 +11,21 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-Google.Apis
-Google.Apis.Auth
-Google.Apis.CloudResourceManager.v1
-Google.Apis.Compute.v1
-Google.Apis.Core
-Google.Apis.Plus.v1
-Log4net
+===============================================================================
+Google.Apis (Google.Apis.dll)
+Google.Apis.Appengine.v1 (Google.Apis.Appengine.v1.dll)
+Google.Apis.Auth (Google.Apis.Auth.dll)
+Google.Apis.Clouderrorreporting.v1beta1 (Google.Apis.Clouderrorreporting.v1beta1.dll)
+Google.Apis.CloudResourceManager.v1 (Google.Apis.CloudResourceManager.v1.dll)
+Google.Apis.CloudSourceRepositories.v1 (Google.Apis.CloudSourceRepositories.v1.dll)
+Google.Apis.Compute.v1 (Google.Apis.Compute.v1.dll)
+Google.Apis.Container.v1 (Google.Apis.Container.v1.dll)
+Google.Apis.Core (Google.Apis.Core.dll)
+Google.Apis.Logging.v2 (Google.Apis.Logging.v2.dll)
+Google.Apis.Plus.v1 (Google.Apis.Plus.v1.dll)
+Google.Apis.ServiceManagement.v1 (Google.Apis.ServiceManagement.v1.dll)
+log4net (log4net.dll)
+-------------------------------------------------------------------------------
 
                               Apache License
                         Version 2.0, January 2004
@@ -192,7 +202,39 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
    incurred by, or claims asserted against, such Contributor by reason
    of your accepting any such warranty or additional liability.
 
-NewtonSoft.Json:
+===============================================================================
+Microsoft.PowerShell.3.ReferenceAssemblies (Microsoft.Management.Infrastructure.dll, System.Management.Automation.dll)
+-------------------------------------------------------------------------------
+
+The MIT License (MIT) 
+
+
+Copyright (c) 2015 Microsoft Corporation. 
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions: 
+
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+===============================================================================
+NewtonSoft.Json (NewtonSoft.Json.dll)
+-------------------------------------------------------------------------------
 
 The MIT License (MIT)
 
@@ -215,7 +257,61 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-ZLib.Portable.Signed:
+===============================================================================
+System.ValueTuple (System.ValueTuple.dll)
+-------------------------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===============================================================================
+YamlDotNet
+-------------------------------------------------------------------------------
+
+Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014 Antoine Aubry and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===============================================================================
+ZLib.Portable.Signed (Zlib.Portable.dll)
+-------------------------------------------------------------------------------
 
 Copyright (c) <''year''> <''copyright holders''>
 

--- a/GoogleCloudExtension/GoogleCloudExtension/packages.config
+++ b/GoogleCloudExtension/GoogleCloudExtension/packages.config
@@ -16,6 +16,7 @@
   <package id="Google.Apis.ServiceManagement.v1" version="1.33.1.1230" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Microsoft.Data.ConnectionUI" version="15.7.27703" targetFramework="net452" />
+  <package id="Microsoft.PowerShell.3.ReferenceAssemblies" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.7.27703" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.6.27740" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Data" version="15.7.27703" targetFramework="net452" />
@@ -47,7 +48,6 @@
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
   <package id="stdole" version="7.0.3303" targetFramework="net452" />
   <package id="StreamJsonRpc" version="1.3.23" targetFramework="net46" />
-  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net46" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net46" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
* Update packages to use properly licensed System.Management.Automation.dll.
* Remove assembly references that were importing Microsoft.VisualStudio.RemoteControl.dll.
* Update Licenses.txt with new distributed assemblies.

Fixes #1005 
