### PR TITLE
Use gcloud builds submit rather than gcloud container builds submit

### DIFF
--- a/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/CloudSdkVersions.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension.GCloud/Models/CloudSdkVersions.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
 
 namespace GoogleCloudExtension.GCloud.Models
 {
@@ -25,6 +27,7 @@ namespace GoogleCloudExtension.GCloud.Models
         /// The version of the Cloud SDK itself.
         /// </summary>
         [JsonProperty("Google Cloud SDK")]
-        public string SdkVersion { get; set; }
+        [JsonConverter(typeof(VersionConverter))]
+        public Version SdkVersion { get; set; }
     }
 }

--- a/GoogleCloudExtension/GoogleCloudExtension/GCloud/GCloudContext.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GCloud/GCloudContext.cs
@@ -53,10 +53,10 @@ namespace GoogleCloudExtension.GCloud
         /// </summary>
         public string ProjectId { get; }
 
-        protected readonly Dictionary<string, string> Environment = new Dictionary<string, string> {
+        protected readonly Dictionary<string, string> Environment = new Dictionary<string, string>
+        {
             [GCloudMetricsVariable] = GoogleCloudExtensionPackage.Instance.ApplicationName,
-            [GCloudMetricsVersionVariable] =
-                GoogleCloudExtensionPackage.Instance.ApplicationVersion
+            [GCloudMetricsVersionVariable] = GoogleCloudExtensionPackage.Instance.ApplicationVersion
         };
 
         private readonly Task<CloudSdkVersions> _versionsTask;

--- a/GoogleCloudExtension/GoogleCloudExtension/GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GCloud/GCloudWrapper.cs
@@ -42,7 +42,8 @@ namespace GoogleCloudExtension.GCloud
 
         // Mapping between the enum and the actual gcloud component.
         private static readonly Dictionary<GCloudComponent, string> s_componentNames =
-            new Dictionary<GCloudComponent, string> {
+            new Dictionary<GCloudComponent, string>
+            {
                 [GCloudComponent.Beta] = "beta",
                 [GCloudComponent.Kubectl] = "kubectl"
             };

--- a/GoogleCloudExtension/GoogleCloudExtension/GCloud/GCloudWrapper.cs
+++ b/GoogleCloudExtension/GoogleCloudExtension/GCloud/GCloudWrapper.cs
@@ -42,10 +42,9 @@ namespace GoogleCloudExtension.GCloud
 
         // Mapping between the enum and the actual gcloud component.
         private static readonly Dictionary<GCloudComponent, string> s_componentNames =
-            new Dictionary<GCloudComponent, string>
-            {
+            new Dictionary<GCloudComponent, string> {
                 [GCloudComponent.Beta] = "beta",
-                [GCloudComponent.Kubectl] = "kubectl",
+                [GCloudComponent.Kubectl] = "kubectl"
             };
 
         private readonly Lazy<IProcessService> _processService;
@@ -89,7 +88,7 @@ namespace GoogleCloudExtension.GCloud
         /// in <paramref name="outputPath"/>. If the <paramref name="sourcePath"/> does not refer to a supported CVS (currently git) then
         /// nothing will be done.
         /// </summary>
-        /// <param name="sourcePath">The directory for which to generate the source contenxt.</param>
+        /// <param name="sourcePath">The directory for which to generate the source context.</param>
         /// <param name="outputPath">Where to store the source context files.</param>
         /// <returns>The task to be completed when the operation finishes.</returns>
         public async Task GenerateSourceContextAsync(string sourcePath, string outputPath)
@@ -109,7 +108,7 @@ namespace GoogleCloudExtension.GCloud
             return components.Where(x => x.State.IsInstalled).Select(x => x.Id).ToList();
         }
 
-        private bool IsGCloudCliInstalled()
+        private static bool IsGCloudCliInstalled()
         {
             Debug.WriteLine("Validating GCloud installation.");
             string gcloudPath = PathUtils.GetCommandPathFromPATH("gcloud.cmd");
@@ -136,7 +135,7 @@ namespace GoogleCloudExtension.GCloud
             }
 
             CloudSdkVersions version = await GetJsonOutputAsync<CloudSdkVersions>("version");
-            return new Version(version.SdkVersion);
+            return version.SdkVersion;
         }
 
         private async Task<T> GetJsonOutputAsync<T>(string command)

--- a/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
+++ b/GoogleCloudExtension/GoogleCloudExtension/GoogleCloudExtension.csproj
@@ -44,6 +44,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>
@@ -54,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Accounts\CredentialsStore.cs" />

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GCloud/GCloudContextUnitTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GCloud/GCloudContextUnitTests.cs
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 using GoogleCloudExtension.GCloud;
+using GoogleCloudExtension.GCloud.Models;
 using GoogleCloudExtension.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace GoogleCloudExtensionUnitTests.GCloud
@@ -36,11 +39,34 @@ namespace GoogleCloudExtensionUnitTests.GCloud
         private GCloudContext _objectUnderTest;
         private Mock<IProcessService> _processServiceMock;
         private Action<string> _mockedOutputAction;
+        private TaskCompletionSource<CloudSdkVersions> _versionResultSource;
+
+        /// <summary>
+        /// A version of Google Cloud SDK that includes the gcloud builds commands.
+        /// </summary>
+        private static readonly CloudSdkVersions s_buildsEnabledSdkVersion =
+            new CloudSdkVersions { SdkVersion = new Version(GCloudContext.GCloudBuildsMinimumVersion) };
+
+        /// <summary>
+        /// A version of Google Cloud SDK from before the gcloud builds commands were added.
+        /// </summary>
+        private static readonly CloudSdkVersions s_buildsMissingSdkVersion =
+            new CloudSdkVersions { SdkVersion = new Version(GCloudWrapper.GCloudSdkMinimumVersion) };
+
+        /// <summary>
+        /// Used as dynamic data to test that container builder arguments do not change between versions.
+        /// </summary>
+        private static IEnumerable<object[]> SdkVersions => new[]
+        {
+            new object[] {s_buildsMissingSdkVersion},
+            new object[] {s_buildsEnabledSdkVersion}
+        };
 
         protected override void BeforeEach()
         {
             _processServiceMock = new Mock<IProcessService>();
-            SetupRunCommandResult(true);
+            _versionResultSource = new TaskCompletionSource<CloudSdkVersions>();
+            SetupGetJsonOutput("version", _versionResultSource.Task);
             PackageMock.Setup(p => p.ProcessService).Returns(_processServiceMock.Object);
             _objectUnderTest = new GCloudContext();
             _mockedOutputAction = Mock.Of<Action<string>>();
@@ -244,16 +270,29 @@ namespace GoogleCloudExtensionUnitTests.GCloud
         }
 
         [TestMethod]
-        public async Task TestBuildContainerAsync_RunsGcloudContainerBuildsSubmit()
+        public async Task TestBuildContainerAsync_ForOldVersionRuns_GcloudContainerBuildsSubmit()
         {
+            _versionResultSource.SetResult(s_buildsMissingSdkVersion);
             await _objectUnderTest.BuildContainerAsync(DefaultImageTag, DefaultContentsPath, _mockedOutputAction);
 
-            VerifyCommandArgsContain("container builds submit");
+            VerifyCommandArgsContain("gcloud container builds submit");
         }
 
         [TestMethod]
-        public async Task TestBuildContainerAsync_PassesGivenImageTag()
+        public async Task TestBuildContainerAsync_ForNewerVersions_RunsGcloudBuildsSubmit()
         {
+            _versionResultSource.SetResult(s_buildsEnabledSdkVersion);
+            await _objectUnderTest.BuildContainerAsync(DefaultImageTag, DefaultContentsPath, _mockedOutputAction);
+
+            VerifyCommandArgsContain("gcloud builds submit");
+            VerifyCommandArgs(s => !s.Contains("container"));
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(SdkVersions))]
+        public async Task TestBuildContainerAsync_PassesGivenImageTag(CloudSdkVersions version)
+        {
+            _versionResultSource.SetResult(version);
             const string expectedImageTag = "expected-image-tag";
             await _objectUnderTest.BuildContainerAsync(expectedImageTag, DefaultContentsPath, _mockedOutputAction);
 
@@ -261,8 +300,10 @@ namespace GoogleCloudExtensionUnitTests.GCloud
         }
 
         [TestMethod]
-        public async Task TestBuildContainerAsync_PassesGivenIContentPath()
+        [DynamicData(nameof(SdkVersions))]
+        public async Task TestBuildContainerAsync_PassesGivenIContentPath(CloudSdkVersions version)
         {
+            _versionResultSource.SetResult(version);
             const string expectedContentsPath = "expected-contents-path";
             await _objectUnderTest.BuildContainerAsync(DefaultImageTag, expectedContentsPath, _mockedOutputAction);
 
@@ -270,8 +311,10 @@ namespace GoogleCloudExtensionUnitTests.GCloud
         }
 
         [TestMethod]
-        public async Task TestBuildContainerAsync_PassesHandler()
+        [DynamicData(nameof(SdkVersions))]
+        public async Task TestBuildContainerAsync_PassesHandler(CloudSdkVersions version)
         {
+            _versionResultSource.SetResult(version);
             const string expectedOutputLine = "expected-output-line";
             SetupRunCommandInvokeHandler(expectedOutputLine);
 
@@ -280,11 +323,16 @@ namespace GoogleCloudExtensionUnitTests.GCloud
             Mock.Get(_mockedOutputAction).Verify(f => f(expectedOutputLine));
         }
 
+        private static IEnumerable<object[]> SdkVersionAndBooleans =>
+            SdkVersions.SelectMany(v => new[] { true, false }, (v, b) => new[] { v[0], b });
+
         [TestMethod]
-        [DataRow(true)]
-        [DataRow(false)]
-        public async Task TestBuildContainerAsync_ReturnsResultFromCommand(bool expectedResult)
+        [DynamicData(nameof(SdkVersionAndBooleans))]
+        public async Task TestBuildContainerAsync_ReturnsResultFromCommand(
+            CloudSdkVersions version,
+            bool expectedResult)
         {
+            _versionResultSource.SetResult(version);
             SetupRunCommandResult(expectedResult);
 
             bool result = await _objectUnderTest.BuildContainerAsync(
@@ -305,12 +353,14 @@ namespace GoogleCloudExtensionUnitTests.GCloud
                     It.IsAny<IDictionary<string, string>>()));
         }
 
-        private void VerifyCommandArgsContain(string expectedArg)
+        private void VerifyCommandArgsContain(string expectedArg) => VerifyCommandArgs(s => s.Contains(expectedArg));
+
+        private void VerifyCommandArgs(Expression<Func<string, bool>> predicateExpression)
         {
             _processServiceMock.Verify(
                 p => p.RunCommandAsync(
                     "cmd.exe",
-                    It.Is<string>(s => s.Contains(expectedArg)),
+                    It.Is(predicateExpression),
                     It.IsAny<EventHandler<OutputHandlerEventArgs>>(),
                     It.IsAny<string>(),
                     It.IsAny<IDictionary<string, string>>()));
@@ -327,6 +377,18 @@ namespace GoogleCloudExtensionUnitTests.GCloud
                         It.IsAny<string>(),
                         It.IsAny<IDictionary<string, string>>()))
                 .Returns(Task.FromResult(result));
+        }
+
+        private void SetupGetJsonOutput<T>(string command, Task<T> result)
+        {
+            _processServiceMock
+                .Setup(
+                    p => p.GetJsonOutputAsync<T>(
+                        It.IsAny<string>(),
+                        It.Is<string>(s => s.Contains(command)),
+                        null,
+                        It.IsAny<Dictionary<string, string>>()))
+                .Returns(result);
         }
 
         private void SetupGetJsonOutput<T>(T result)

--- a/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GCloud/GCloudContextUnitTests.cs
+++ b/GoogleCloudExtension/GoogleCloudExtensionUnitTests/GCloud/GCloudContextUnitTests.cs
@@ -270,7 +270,7 @@ namespace GoogleCloudExtensionUnitTests.GCloud
         }
 
         [TestMethod]
-        public async Task TestBuildContainerAsync_ForOldVersionRuns_GcloudContainerBuildsSubmit()
+        public async Task TestBuildContainerAsync_ForOldVersion_RunsGcloudContainerBuildsSubmit()
         {
             _versionResultSource.SetResult(s_buildsMissingSdkVersion);
             await _objectUnderTest.BuildContainerAsync(DefaultImageTag, DefaultContentsPath, _mockedOutputAction);
@@ -279,7 +279,7 @@ namespace GoogleCloudExtensionUnitTests.GCloud
         }
 
         [TestMethod]
-        public async Task TestBuildContainerAsync_ForNewerVersions_RunsGcloudBuildsSubmit()
+        public async Task TestBuildContainerAsync_ForNewerVersion_RunsGcloudBuildsSubmit()
         {
             _versionResultSource.SetResult(s_buildsEnabledSdkVersion);
             await _objectUnderTest.BuildContainerAsync(DefaultImageTag, DefaultContentsPath, _mockedOutputAction);


### PR DESCRIPTION
gcloud versions > 207.0.0 are expected to use gcloud builds submit rather than gcloud container builds submit.